### PR TITLE
Refactor `vesting_schedule_generator` and `iso_nso_calculator` into modular services for improved maintainability and scalability

### DIFF
--- a/iso_nso_calculator/index.ts
+++ b/iso_nso_calculator/index.ts
@@ -1,8 +1,5 @@
-import { OcfPackageContent, readOcfPackage, TX_Equity_Compensation_Issuance, Valuation } from "../read_ocf_package";
-import { generateSchedule, VestingSchedule } from "../vesting_schedule_generator";
-
-// Hardcoding the $100K annual ISO limit
-const ANNUAL_CAPACITY = 100000
+import { TX_Equity_Compensation_Exercise, TX_Equity_Compensation_Issuance, TX_Vesting_Start, Valuation, VestingTerms } from "../read_ocf_package";
+import { VestingSchedule, VestingScheduleService } from "../vesting_schedule_generator";
 
 // Define the interface for the data supplied to the calculator
 interface Installment extends VestingSchedule {
@@ -12,6 +9,150 @@ interface Installment extends VestingSchedule {
   FMV: number; // for now we assume that the FMV is the exercise price if there is no valuation.id.  Better approaches to be discussed.
   Grant_Type: 'NSO' | 'ISO' | 'INTL';
 }
+
+// Define the interface for the results of the ISO/NSO test
+export interface ISONSOTestResult extends Pick<Installment, 'Year' | 'Date' | 'GrantId' | 'Event Type' | 'Became Exercisable' | 'FMV'> {
+  StartingCapacity: number,
+  ISOShares: number
+  NSOShares: number
+  CapacityUtilized: number;
+  CapacityRemaining: number;
+}
+
+export class ISONSOCalculatorService {
+  private issuances: TX_Equity_Compensation_Issuance[]
+  private installments: Installment[]
+  private sortedInstallments: Installment[]
+  private ANNUAL_CAPACITY = 100000
+  private remainingCapacity: number
+  private results: ISONSOTestResult[]
+
+  constructor(
+    private stakeholderId: string,
+    private transactions: (TX_Equity_Compensation_Issuance | TX_Vesting_Start | TX_Equity_Compensation_Exercise)[],
+    private vestingTerms: VestingTerms[],
+    private valuations: Valuation[]
+  ){
+    this.issuances = this.transactions.filter((tx): tx is TX_Equity_Compensation_Issuance => tx.object_type === 'TX_EQUITY_COMPENSATION_ISSUANCE' && tx.stakeholder_id === this.stakeholderId)
+    this.installments = this.createInstallments()
+    this.sortedInstallments = this.sortInstallments()
+    this.remainingCapacity = this.ANNUAL_CAPACITY
+    this.results = this.calculate()
+  }
+
+  private createInstallments() {
+    
+    // create a vesting schedule for each issuance
+    const allInstallments = this.issuances.reduce((acc, issuance) => {
+
+      const schedule = new VestingScheduleService(
+        this.vestingTerms,
+        this.transactions,
+        issuance.security_id
+      ).getVestingDetails_WithExerices()
+
+      const installments = schedule.reduce((acc, entry) => {
+
+        // ignore exercise events within the vesting schedule
+        if (entry["Event Type"] === 'Exercise') return acc
+
+        const date = new Date(entry.Date)
+        acc.push({
+          ...entry,
+            GrantId: issuance.id,
+            Grant_Date: issuance.date,
+            Year: date.getFullYear(),
+            FMV: this.getFMV(issuance),
+            Grant_Type: issuance.option_grant_type
+        })
+        return acc
+
+      }, [] as Installment[])
+
+      acc.push(...installments)
+      return acc
+    }, [] as Installment[])
+
+    return allInstallments
+  }
+
+  private sortInstallments() {
+    const sortedInstallments = this.installments.sort((a: { Grant_Date: string, Date: string}, b: { Grant_Date: string, Date:string }) => {
+      if (a.Grant_Date === b.Grant_Date) {
+        return a.Date.localeCompare(b.Date)
+      }
+      return a.Grant_Date.localeCompare(b.Grant_Date)
+    })
+
+    return sortedInstallments
+  }
+
+  // For now we'll assume that the FMV on the grant date is equal to the exercise price if there is no valuation_id
+  // Alternative approaches to be discussed
+  private getFMV(issuance: TX_Equity_Compensation_Issuance) {
+    const valuation = this.valuations?.find(valuation => valuation.id === issuance.valuation_id)
+    const FMV = valuation?.price_per_share.amount ?? issuance.exercise_price.amount
+    return parseFloat(FMV)
+  }
+
+  private calculate() {
+    let currentYear = this.sortedInstallments[0].Year // Initialize the current year to the year of the first installment
+
+    const result = this.sortedInstallments.reduce((acc, current) => {
+      // if the year changes, reset the remaining capacity to 100,000
+      if (current.Year !== currentYear) {
+        this.remainingCapacity = this.ANNUAL_CAPACITY
+      }
+
+      const startingCapacity = this.remainingCapacity
+
+      // Determine how many shares are in included in this iteration of the test
+      // options that are not eligible to be ISOs have already been removed in createInstallments
+      const ISOEligibleShares = current["Became Exercisable"]
+      
+      // Determine how many shares can be ISOs based on the remainingCapacity
+      const MaxISOShares = Math.floor(this.remainingCapacity / current.FMV)
+
+      // Determine how many shares are ISOs
+      const ISOShares = Math.min(MaxISOShares, ISOEligibleShares);
+
+      // Determine how many shares are NSOs
+      const NSOShares = current["Became Exercisable"] - ISOShares
+
+      // Determine how much capacity was utilized
+      const utilizedCapacity = ISOShares * current.FMV
+
+      // Update remaining capacity after usage
+      this.remainingCapacity -= utilizedCapacity;
+
+      acc.push({
+        Year: current.Year,
+        Date: current.Date,
+        GrantId: current.GrantId,
+        "Event Type": current["Event Type"],
+        "Became Exercisable": current["Event Quantity"],
+        FMV: current.FMV,
+        StartingCapacity: startingCapacity,
+        ISOShares: ISOShares,
+        NSOShares: NSOShares,
+        CapacityUtilized: utilizedCapacity,
+        CapacityRemaining: this.remainingCapacity,
+      });
+
+      return acc
+    }, [] as ISONSOTestResult[])
+
+    return result
+  }
+
+  get Results() {
+    return this.results
+  }
+}
+
+/**
+// Hardcoding the $100K annual ISO limit
+const ANNUAL_CAPACITY = 100000
 
 // creates vesting installments for all of a stockholder's equity issuances
 const createInstallments = (packagePath: string, issuance: TX_Equity_Compensation_Issuance, FMV: number): Installment[] => {
@@ -149,3 +290,4 @@ export const isoNsoCalculator = (packagePath: string, stakeholderId: string): IS
 
   return result;
 };
+ */

--- a/read_ocf_package/index.ts
+++ b/read_ocf_package/index.ts
@@ -2,7 +2,7 @@ import * as fs from "fs";
 import * as path from "path";
 
 // ideally we'll eventually import these from OCF
-interface VestingConditions_VestingScheduleRelative {
+export interface VestingConditions_VestingScheduleRelative {
   id: string;
   description: string;
   portion: {
@@ -37,7 +37,7 @@ interface VestingConditions_VestingScheduleRelative {
   } // this isn't part of the schema yet
 }
 
-interface VestingTerms {
+export interface VestingTerms {
   id: string;
   comments: string[];
   object_type: 'VESTING_TERMS';
@@ -114,11 +114,22 @@ export interface TX_Equity_Compensation_Issuance {
   valuation_id: string // this isn't part of the schema yet
 }
 
+export interface TX_Equity_Compensation_Exercise {
+  id: string;
+  comments: string[];
+  object_type: "TX_EQUITY_COMPENSATION_EXERCISE";
+  date: string;
+  security_id: string;
+  consideration_text: string;
+  resulting_security_ids: string[];
+  quantity: string
+}
+
 export interface OcfPackageContent {
   manifest: any;
   stakeholders: any;
   stockClasses: any;
-  transactions: Array<TX_Equity_Compensation_Issuance | TX_Vesting_Start>;
+  transactions: Array<TX_Equity_Compensation_Issuance | TX_Vesting_Start | TX_Equity_Compensation_Exercise>;
   stockLegends: any;
   stockPlans: any;
   vestingTerms: VestingTerms[];

--- a/testing_scripts/iso_nso_test.ts
+++ b/testing_scripts/iso_nso_test.ts
@@ -1,11 +1,19 @@
-import { isoNsoCalculator } from "./iso_nso_calculator";
+import { ISONSOCalculatorService } from "../iso_nso_calculator"
+import { OcfPackageContent, readOcfPackage } from "../read_ocf_package";
 
 const packagePath  = './sample_ocf_folders/acme_holdings_limited'
 const stakeholderId = 'emilyEmployee'
+const ocfPackage: OcfPackageContent = readOcfPackage(packagePath);
+const { vestingTerms, transactions, valuations } = ocfPackage;
 
 try {
     
-    const results = isoNsoCalculator(packagePath, stakeholderId)
+    const results = new ISONSOCalculatorService(
+        stakeholderId,
+        transactions,
+        vestingTerms,
+        valuations
+    ).Results
 
     const years: number[] = []
     results.map((result) => {

--- a/testing_scripts/vesting_schedule.ts
+++ b/testing_scripts/vesting_schedule.ts
@@ -1,0 +1,36 @@
+import { VestingScheduleService } from "../vesting_schedule_generator"
+import { OcfPackageContent, readOcfPackage } from "../read_ocf_package";
+
+const packagePath  = './sample_ocf_folders/acme_holdings_limited'
+const securityId = 'equity_compensation_issuance_01'
+const ocfPackage: OcfPackageContent = readOcfPackage(packagePath);
+const { vestingTerms, transactions } = ocfPackage;
+
+try {
+    
+    const schedules = new VestingScheduleService(vestingTerms, transactions, securityId).getVestingDetails()
+
+    const years: number[] = []
+    schedules.map((result) => {
+        const year = new Date(result.Date).getFullYear()
+        if (!years.includes(year)) {
+            years.push(year)
+        }
+    })
+
+    years.sort((a,b) => a - b)
+
+    years.forEach(year => {
+        const resultsByYear = schedules.filter(schedule => {
+            const vestingYear = new Date(schedule.Date).getFullYear()
+            return vestingYear === year
+        })
+        console.table(resultsByYear)
+    })
+    
+} catch (error) {
+    if (error instanceof Error) {
+        console.error("Error message:", error.message)
+    }
+    console.error("Unknown error:", error)
+}

--- a/testing_scripts/vesting_schedule_with_exercises.ts
+++ b/testing_scripts/vesting_schedule_with_exercises.ts
@@ -1,11 +1,14 @@
-import { generateSchedule } from "./vesting_schedule_generator"
+import { VestingScheduleService } from "../vesting_schedule_generator"
+import { OcfPackageContent, readOcfPackage } from "../read_ocf_package";
 
 const packagePath  = './sample_ocf_folders/acme_holdings_limited'
-const equityCompensationIssuanceSecurityId = 'equity_compensation_issuance_03'
+const securityId = 'equity_compensation_issuance_01'
+const ocfPackage: OcfPackageContent = readOcfPackage(packagePath);
+const { vestingTerms, transactions } = ocfPackage;
 
 try {
     
-    const schedules = generateSchedule(packagePath, equityCompensationIssuanceSecurityId )
+    const schedules = new VestingScheduleService(vestingTerms, transactions, securityId).getVestingDetails_WithExerices()
 
     const years: number[] = []
     schedules.map((result) => {
@@ -15,6 +18,8 @@ try {
         }
     })
 
+    years.sort((a,b) => a - b)
+
     years.forEach(year => {
         const resultsByYear = schedules.filter(schedule => {
             const vestingYear = new Date(schedule.Date).getFullYear()
@@ -22,7 +27,7 @@ try {
         })
         console.table(resultsByYear)
     })
-    // console.table(schedules)
+    
 } catch (error) {
     if (error instanceof Error) {
         console.error("Error message:", error.message)

--- a/vesting_schedule_generator/exercise_transactions.ts
+++ b/vesting_schedule_generator/exercise_transactions.ts
@@ -1,0 +1,113 @@
+import { VestingSchedule } from ".";
+import { TX_Equity_Compensation_Exercise } from "../read_ocf_package";
+
+export class ExerciseTransactionsService {
+    private cumulativeExercised = 0;
+    private availableToExercise = 0;
+
+    constructor(
+        private exerciseTransactions: TX_Equity_Compensation_Exercise[],
+        private vestingSchedule: VestingSchedule[],
+        private quantity: string,
+        private EARLY_EXERCISABLE: boolean
+    ){
+        this.sortTransactions()
+        this.sortVestingSchedule()
+    }
+
+    private sortTransactions() {
+        this.exerciseTransactions.sort((a: { date: string }, b: { date: string }) => a.date.localeCompare(b.date) )
+    }
+
+    private sortVestingSchedule() {
+        this.vestingSchedule.sort((a: { Date: string }, b: { Date: string}) => a.Date.localeCompare(b.Date))
+    }
+
+    private getLastInstallmentBeforeExercise(dateString: string) {
+        const tx_date = new Date(dateString)
+
+        // binary search
+        let left = 0
+        let right = this.vestingSchedule.length - 1
+        let result = {
+            lastInstallmentBeforeExercise: {} as VestingSchedule,
+            index: 0
+        }
+
+        while (left <= right) {
+            let mid = Math.floor((left + right) / 2)
+            const midDate = new Date(this.vestingSchedule[mid].Date)
+            
+            if (midDate <= tx_date) {
+                result = {
+                    lastInstallmentBeforeExercise: this.vestingSchedule[mid],
+                    index: mid
+                }
+                left = mid + 1
+            } else {
+                right = mid - 1
+            }
+        }
+
+        return result
+    }
+
+    private processExerciseTx(tx: TX_Equity_Compensation_Exercise, installment: VestingSchedule, index: number) {
+        
+        const quantityExercised = parseFloat(tx.quantity)
+        this.cumulativeExercised += quantityExercised
+
+        const event: VestingSchedule = {
+            Date: tx.date,
+            "Event Type": 'Exercise',
+            'Event Quantity': quantityExercised,
+            'Remaining Unvested': installment["Remaining Unvested"],
+            'Cumulative Vested': installment["Cumulative Vested"],
+            'Became Exercisable': 0,
+            "Cumulative Exercised": this.cumulativeExercised,
+            "Available to Exercise": 0
+        }
+
+        this.vestingSchedule.splice(index + 1, 0, event)
+    }
+
+    private populateAvailableToExercise() {
+        const populatedSchedule = this.vestingSchedule.map((installment) => {
+            
+            if (installment["Event Type"] !== 'Exercise') {
+                this.availableToExercise += installment["Became Exercisable"]
+                return {
+                    ...installment,
+                    'Available to Exercise': this.availableToExercise
+                }
+            } else {
+                this.availableToExercise -= installment["Event Quantity"]
+                return {
+                    ...installment,
+                    'Available to Exercise': this.availableToExercise
+                }
+            }
+ 
+        })
+
+        this.vestingSchedule = populatedSchedule
+    }
+
+    public handleExerciseTransactions() {
+    
+        this.exerciseTransactions.forEach((tx) => {
+            const result = this.getLastInstallmentBeforeExercise(tx.date)
+
+            if (!result) {
+                throw new Error('Invalid exercise prior to the Start event')
+            }
+
+            const {lastInstallmentBeforeExercise, index} = result
+
+            this.processExerciseTx(tx, lastInstallmentBeforeExercise, index)
+            
+        })
+        this.populateAvailableToExercise()
+        return this.vestingSchedule
+    }
+}

--- a/vesting_schedule_generator/index.ts
+++ b/vesting_schedule_generator/index.ts
@@ -1,5 +1,13 @@
-import { OcfPackageContent, readOcfPackage } from "../read_ocf_package";
-import type { TX_Vesting_Start, TX_Equity_Compensation_Issuance } from "../read_ocf_package"
+import type {
+  TX_Vesting_Start,
+  TX_Equity_Compensation_Issuance,
+  TX_Equity_Compensation_Exercise,
+  VestingTerms,
+  Valuation,
+ } from "../read_ocf_package"
+import { ExerciseTransactionsService } from "./exercise_transactions";
+import { VestingCalculatorService } from "./vesting_calculator";
+import { VestingInitializationService } from "./vesting_initialization";
 
 export interface VestingSchedule {
   Date: string;
@@ -12,236 +20,292 @@ export interface VestingSchedule {
   "Available to Exercise": number;
 };
 
+export class VestingScheduleService {
+  private initializationService: VestingInitializationService;
+  private calculationService: VestingCalculatorService;
+  private exerciseTransactionsService: ExerciseTransactionsService;
+  private vestingDetails: VestingSchedule[];
+  private vestingDetailsWithExercises: VestingSchedule[];
 
-export const generateSchedule = (packagePath: string, equityCompensationIssuanceSecurityId: string): VestingSchedule[] => {
-  const vestingSchedule: VestingSchedule[] = [];
+  constructor (
+    private vestingTerms: VestingTerms[],
+    private transactions: (TX_Equity_Compensation_Issuance | TX_Vesting_Start | TX_Equity_Compensation_Exercise)[],
+    private securityId: string,
+  ) {
+    
+    // initialize vesting data
+    this.initializationService = new VestingInitializationService(this.transactions, this.vestingTerms, this.securityId)
+    const { issuance, vestingStartTx, issuanceVestingTerms } = this.initializationService.setUpVestingData()
 
-  const ocfPackage: OcfPackageContent = readOcfPackage(packagePath);
-  const vestingTerms = ocfPackage.vestingTerms;
-  const transactions = ocfPackage.transactions;
-  const equityCompensationIssuance = transactions.find((transaction) => transaction.security_id === equityCompensationIssuanceSecurityId) as TX_Equity_Compensation_Issuance | undefined;
+    // calculate vesting schedule
+    this.calculationService = new VestingCalculatorService(
+      vestingStartTx,
+      issuanceVestingTerms,
+      parseFloat(issuance.quantity),
+      issuance.early_exercisable
+    )
+    this.vestingDetails = this.calculationService.generate(),
 
-  if (!equityCompensationIssuance) {
-    throw new Error(`Equity compensation issuance with security id ${equityCompensationIssuanceSecurityId} not found`);
+    // add exercise details to vesting schedule
+    this.exerciseTransactionsService = new ExerciseTransactionsService(
+      transactions.filter((tx): tx is TX_Equity_Compensation_Exercise => tx.object_type === 'TX_EQUITY_COMPENSATION_EXERCISE' && tx.security_id === securityId),
+      this.vestingDetails,
+      issuance.quantity,
+      issuance.early_exercisable,
+    )
+    this.vestingDetailsWithExercises = this.exerciseTransactionsService.handleExerciseTransactions()
+
   }
 
-  const vestingStartTransaction = transactions.find((transaction: any) => transaction.object_type === "TX_VESTING_START" && transaction.security_id === equityCompensationIssuance.security_id) as TX_Vesting_Start | undefined;
-
-  if (!vestingStartTransaction) {
-    throw new Error(`For this generator, the transaction must have a TX_VESTING_START object.`)
+  public getVestingDetails() {
+    return this.vestingDetails
   }
-  const equityCompensationVestingTerms = vestingTerms.find((vestingTerm: any) => vestingTerm.id === equityCompensationIssuance.vesting_terms_id);
-
-  if (!equityCompensationVestingTerms) {
-    throw new Error(`Vesting terms for security.id ${equityCompensationIssuanceSecurityId} not found`)
-  }
-  let transactionDate: Date = new Date(vestingStartTransaction.date);
-  let vestingConditionId: string = vestingStartTransaction.vesting_condition_id;
-
-  let equityCompensationQuantity: number = parseFloat(equityCompensationIssuance.quantity);
-  let unvested: number = equityCompensationQuantity;
-  let vested: number = 0;
-
-  const EARLY_EXERCISABLE = equityCompensationIssuance.early_exercisable
-  let availableToExercise: number = equityCompensationQuantity * +EARLY_EXERCISABLE
-
-  let currentVestingCondition = equityCompensationVestingTerms.vesting_conditions.find((vestingCondition: any) => vestingCondition.id === vestingConditionId);
-
-  if (!currentVestingCondition) {
-    throw new Error(`Vesting conditions for security.id ${equityCompensationIssuanceSecurityId} not found`)
-  }
-  if (currentVestingCondition.trigger.type !== "VESTING_START_DATE") {
-    throw new Error(`For this generator, the first condition must have a VESTING_START_DATE trigger.`);
+  
+  public getVestingDetails_WithExerices() {
+    return this.vestingDetailsWithExercises
   }
 
-  let amountVested: number = (equityCompensationQuantity * parseFloat(currentVestingCondition.portion.numerator)) / parseFloat(currentVestingCondition.portion.denominator);
+  public getVestingStatus(checkDateString: string) {
 
-  vested += amountVested;
-  unvested -= amountVested;
-
-  // designate entire option as exercisable at the "Start" event if the option is early exercisable
-  const becameExercisable = availableToExercise
-
-  vestingSchedule.push({
-    Date: transactionDate.toISOString().split("T")[0],
-    "Event Type": "Start",
-    "Event Quantity": amountVested,
-    "Remaining Unvested": unvested,
-    "Cumulative Vested": vested,
-    "Became Exercisable": becameExercisable,
-    "Cumulative Exercised": 0,
-    "Available to Exercise": availableToExercise,
-  });
-
-  vestingConditionId = currentVestingCondition.next_condition_ids[0];
-  currentVestingCondition = equityCompensationVestingTerms.vesting_conditions.find((vestingCondition: any) => vestingCondition.id === vestingConditionId);
-  if (!currentVestingCondition || currentVestingCondition.trigger.type !== "VESTING_SCHEDULE_RELATIVE") {
-    throw new Error(`This generator can only calculate for VESTING_SCHEDULE_RELATIVE triggers.`);
+    const status = this.vestingDetails.find((schedule) => Date.parse(schedule.Date) >= Date.parse(checkDateString))
+    return status
   }
 
-  for (let i = 0; i < currentVestingCondition.trigger.period.occurrences; i++) {
-    transactionDate = new Date(transactionDate.setMonth(transactionDate.getMonth() + currentVestingCondition.trigger.period.length));
-    let cumulativePercent: number;
-    let lastCumulativePercent: number;
-    let remainder: number;
-    const denominator = parseFloat(currentVestingCondition.portion.denominator)
-    switch (equityCompensationVestingTerms.allocation_type) {
-      case "CUMULATIVE_ROUNDING":
-        cumulativePercent = (i + 1) / denominator;
-        if (i === 0) {
-          amountVested = Math.ceil(cumulativePercent * equityCompensationQuantity);
-        } else {
-          lastCumulativePercent = i / denominator;
-          amountVested = Math.ceil(cumulativePercent * equityCompensationQuantity) - Math.ceil(lastCumulativePercent * equityCompensationQuantity);
-        }
-        break;
-      case "CUMULATIVE_ROUND_DOWN":
-        cumulativePercent = (i + 1) / denominator;
-        if (i === 0) {
-          amountVested = Math.floor(cumulativePercent * equityCompensationQuantity);
-        } else {
-          lastCumulativePercent = i / denominator;
-          amountVested = Math.floor(cumulativePercent * equityCompensationQuantity) - Math.floor(lastCumulativePercent * equityCompensationQuantity);
-        }
-        break;
-      case "FRONT_LOADED":
-        remainder = equityCompensationQuantity % denominator;
-        if (i < remainder) {
-          amountVested = Math.ceil(equityCompensationQuantity / denominator);
-        } else {
-          amountVested = Math.floor(equityCompensationQuantity / denominator);
-        }
-        break;
-      case "BACK_LOADED":
-        remainder = equityCompensationQuantity % denominator;
-        if (i < remainder) {
-          amountVested = Math.floor(equityCompensationQuantity / denominator);
-        } else {
-          amountVested = Math.ceil(equityCompensationQuantity / denominator);
-        }
-        break;
-      case "FRONT_LOADED_TO_SINGLE_TRANCHE":
-        remainder = equityCompensationQuantity % denominator;
-        if (i === 0) {
-          amountVested = Math.floor(equityCompensationQuantity / denominator) + remainder;
-        } else {
-          amountVested = Math.floor(equityCompensationQuantity / denominator);
-        }
-        break;
-      case "BACK_LOADED_TO_SINGLE_TRANCHE":
-        remainder = equityCompensationQuantity % denominator;
-        if (i === denominator - 1) {
-          amountVested = Math.floor(equityCompensationQuantity / denominator) + remainder;
-        } else {
-          amountVested = Math.floor(equityCompensationQuantity / denominator);
-        }
-        break;
-      default: // allocation_type set to FRACTIONAL
-        amountVested = (equityCompensationQuantity * parseFloat(currentVestingCondition.portion.numerator)) / parseFloat(currentVestingCondition.portion.denominator);
-    }
-
-    vested += amountVested;
-    unvested -= amountVested;
-
-    // increment availableToExercise only if the option is not early exercisable
-    const becameExercisable = amountVested * +!EARLY_EXERCISABLE
-    availableToExercise += becameExercisable  
-
-    vestingSchedule.push({
-      Date: transactionDate.toISOString().split("T")[0],
-      "Event Type": "Vesting",
-      "Event Quantity": amountVested,
-      "Remaining Unvested": unvested,
-      "Cumulative Vested": vested,
-      "Became Exercisable": becameExercisable,
-      "Cumulative Exercised": 0,
-      "Available to Exercise": availableToExercise,
-    });
+  public getVestingStatus_WithExercises(checkDateString: string) {
+    const status = this.vestingDetailsWithExercises.find((schedule) => Date.parse(schedule.Date) >= Date.parse(checkDateString))
+    return status
   }
+}
 
-  if (currentVestingCondition.cliff_condition) {
-    const cliffLength = currentVestingCondition.cliff_condition.period.length
+// export const generateSchedule = (packagePath: string, equityCompensationIssuanceSecurityId: string): VestingSchedule[] => {
+//   const vestingSchedule: VestingSchedule[] = [];
 
-    for (let i = 1; i <= cliffLength; i++) {
+//   const ocfPackage: OcfPackageContent = readOcfPackage(packagePath);
+//   const vestingTerms = ocfPackage.vestingTerms;
+//   const transactions = ocfPackage.transactions;
+//   const equityCompensationIssuance = transactions.find((transaction) => transaction.security_id === equityCompensationIssuanceSecurityId) as TX_Equity_Compensation_Issuance | undefined;
 
-      // remove all installments prior to the vesting cliff
-      // we start at 1 because 0 is the "Start" event
-      if (i < cliffLength) {
-        vestingSchedule.splice(1, 1);
-      }
+//   if (!equityCompensationIssuance) {
+//     throw new Error(`Equity compensation issuance with security id ${equityCompensationIssuanceSecurityId} not found`);
+//   }
 
-      // convert the cliff installment into a "Cliff" event
-      if (i === cliffLength) {
-        vestingSchedule[1]["Event Type"] = "Cliff";
-        vestingSchedule[1]["Event Quantity"] = vestingSchedule[1]["Cumulative Vested"];
+//   const vestingStartTransaction = transactions.find((transaction: any) => transaction.object_type === "TX_VESTING_START" && transaction.security_id === equityCompensationIssuance.security_id) as TX_Vesting_Start | undefined;
 
-        // increment available to exercise only if the option is not early exercisable
-        vestingSchedule[1]["Became Exercisable"] = EARLY_EXERCISABLE ? 0 : vestingSchedule[1]["Available to Exercise"]
-      }
-    }
-  }
+//   if (!vestingStartTransaction) {
+//     throw new Error(`For this generator, the transaction must have a TX_VESTING_START object.`)
+//   }
+//   const equityCompensationVestingTerms = vestingTerms.find((vestingTerm: any) => vestingTerm.id === equityCompensationIssuance.vesting_terms_id);
 
-  const exerciseTranscations = transactions.filter((transaction: any) => transaction.object_type === "TX_EQUITY_COMPENSATION_EXERCISE" && transaction.security_id === equityCompensationIssuance.security_id);
+//   if (!equityCompensationVestingTerms) {
+//     throw new Error(`Vesting terms for security.id ${equityCompensationIssuanceSecurityId} not found`)
+//   }
+//   let transactionDate: Date = new Date(vestingStartTransaction.date);
+//   let vestingConditionId: string = vestingStartTransaction.vesting_condition_id;
 
-  const sortedExerciseTransactions = exerciseTranscations.sort((a: { date: string; object_type: string }, b: { date: string; object_type: string }) => a.date.localeCompare(b.date));
+//   let equityCompensationQuantity: number = parseFloat(equityCompensationIssuance.quantity);
+//   let unvested: number = equityCompensationQuantity;
+//   let vested: number = 0;
 
-  let cumulativeExercised = 0;
+//   const EARLY_EXERCISABLE = equityCompensationIssuance.early_exercisable
+//   let availableToExercise: number = equityCompensationQuantity * +EARLY_EXERCISABLE
 
-  sortedExerciseTransactions.forEach((transaction: any, index: any) => {
-    if (Date.parse(vestingSchedule[vestingSchedule.length - 1].Date) > Date.parse(transaction.date)) {
-      for (let i = 0; i < vestingSchedule.length - 1; i++) {
-        if (
-          Date.parse(vestingSchedule[i + 1].Date) <=
-            Date.parse(transaction.date) &&
-          index === 0
-        ) {
-          vestingSchedule[i]["Cumulative Exercised"] = cumulativeExercised;
-          vestingSchedule[i]['Available to Exercise'] = availableToExercise;
+//   let currentVestingCondition = equityCompensationVestingTerms.vesting_conditions.find((vestingCondition: any) => vestingCondition.id === vestingConditionId);
+
+//   if (!currentVestingCondition) {
+//     throw new Error(`Vesting conditions for security.id ${equityCompensationIssuanceSecurityId} not found`)
+//   }
+//   if (currentVestingCondition.trigger.type !== "VESTING_START_DATE") {
+//     throw new Error(`For this generator, the first condition must have a VESTING_START_DATE trigger.`);
+//   }
+
+//   let amountVested: number = (equityCompensationQuantity * parseFloat(currentVestingCondition.portion.numerator)) / parseFloat(currentVestingCondition.portion.denominator);
+
+//   vested += amountVested;
+//   unvested -= amountVested;
+
+//   // designate entire option as exercisable at the "Start" event if the option is early exercisable
+//   const becameExercisable = availableToExercise
+
+//   vestingSchedule.push({
+//     Date: transactionDate.toISOString().split("T")[0],
+//     "Event Type": "Start",
+//     "Event Quantity": amountVested,
+//     "Remaining Unvested": unvested,
+//     "Cumulative Vested": vested,
+//     "Became Exercisable": becameExercisable,
+//     "Cumulative Exercised": 0,
+//     "Available to Exercise": availableToExercise,
+//   });
+
+//   vestingConditionId = currentVestingCondition.next_condition_ids[0];
+//   currentVestingCondition = equityCompensationVestingTerms.vesting_conditions.find((vestingCondition: any) => vestingCondition.id === vestingConditionId);
+//   if (!currentVestingCondition || currentVestingCondition.trigger.type !== "VESTING_SCHEDULE_RELATIVE") {
+//     throw new Error(`This generator can only calculate for VESTING_SCHEDULE_RELATIVE triggers.`);
+//   }
+
+//   for (let i = 0; i < currentVestingCondition.trigger.period.occurrences; i++) {
+//     transactionDate = new Date(transactionDate.setMonth(transactionDate.getMonth() + currentVestingCondition.trigger.period.length));
+//     let cumulativePercent: number;
+//     let lastCumulativePercent: number;
+//     let remainder: number;
+//     const denominator = parseFloat(currentVestingCondition.portion.denominator)
+//     switch (equityCompensationVestingTerms.allocation_type) {
+//       case "CUMULATIVE_ROUNDING":
+//         cumulativePercent = (i + 1) / denominator;
+//         if (i === 0) {
+//           amountVested = Math.ceil(cumulativePercent * equityCompensationQuantity);
+//         } else {
+//           lastCumulativePercent = i / denominator;
+//           amountVested = Math.ceil(cumulativePercent * equityCompensationQuantity) - Math.ceil(lastCumulativePercent * equityCompensationQuantity);
+//         }
+//         break;
+//       case "CUMULATIVE_ROUND_DOWN":
+//         cumulativePercent = (i + 1) / denominator;
+//         if (i === 0) {
+//           amountVested = Math.floor(cumulativePercent * equityCompensationQuantity);
+//         } else {
+//           lastCumulativePercent = i / denominator;
+//           amountVested = Math.floor(cumulativePercent * equityCompensationQuantity) - Math.floor(lastCumulativePercent * equityCompensationQuantity);
+//         }
+//         break;
+//       case "FRONT_LOADED":
+//         remainder = equityCompensationQuantity % denominator;
+//         if (i < remainder) {
+//           amountVested = Math.ceil(equityCompensationQuantity / denominator);
+//         } else {
+//           amountVested = Math.floor(equityCompensationQuantity / denominator);
+//         }
+//         break;
+//       case "BACK_LOADED":
+//         remainder = equityCompensationQuantity % denominator;
+//         if (i < remainder) {
+//           amountVested = Math.floor(equityCompensationQuantity / denominator);
+//         } else {
+//           amountVested = Math.ceil(equityCompensationQuantity / denominator);
+//         }
+//         break;
+//       case "FRONT_LOADED_TO_SINGLE_TRANCHE":
+//         remainder = equityCompensationQuantity % denominator;
+//         if (i === 0) {
+//           amountVested = Math.floor(equityCompensationQuantity / denominator) + remainder;
+//         } else {
+//           amountVested = Math.floor(equityCompensationQuantity / denominator);
+//         }
+//         break;
+//       case "BACK_LOADED_TO_SINGLE_TRANCHE":
+//         remainder = equityCompensationQuantity % denominator;
+//         if (i === denominator - 1) {
+//           amountVested = Math.floor(equityCompensationQuantity / denominator) + remainder;
+//         } else {
+//           amountVested = Math.floor(equityCompensationQuantity / denominator);
+//         }
+//         break;
+//       default: // allocation_type set to FRACTIONAL
+//         amountVested = (equityCompensationQuantity * parseFloat(currentVestingCondition.portion.numerator)) / parseFloat(currentVestingCondition.portion.denominator);
+//     }
+
+//     vested += amountVested;
+//     unvested -= amountVested;
+
+//     // increment availableToExercise only if the option is not early exercisable
+//     const becameExercisable = amountVested * +!EARLY_EXERCISABLE
+//     availableToExercise += becameExercisable  
+
+//     vestingSchedule.push({
+//       Date: transactionDate.toISOString().split("T")[0],
+//       "Event Type": "Vesting",
+//       "Event Quantity": amountVested,
+//       "Remaining Unvested": unvested,
+//       "Cumulative Vested": vested,
+//       "Became Exercisable": becameExercisable,
+//       "Cumulative Exercised": 0,
+//       "Available to Exercise": availableToExercise,
+//     });
+//   }
+
+//   if (currentVestingCondition.cliff_condition) {
+//     const cliffLength = currentVestingCondition.cliff_condition.period.length
+
+//     for (let i = 1; i <= cliffLength; i++) {
+
+//       // remove all installments prior to the vesting cliff
+//       // we start at 1 because 0 is the "Start" event
+//       if (i < cliffLength) {
+//         vestingSchedule.splice(1, 1);
+//       }
+
+//       // convert the cliff installment into a "Cliff" event
+//       if (i === cliffLength) {
+//         vestingSchedule[1]["Event Type"] = "Cliff";
+//         vestingSchedule[1]["Event Quantity"] = vestingSchedule[1]["Cumulative Vested"];
+
+//         // increment available to exercise only if the option is not early exercisable
+//         vestingSchedule[1]["Became Exercisable"] = EARLY_EXERCISABLE ? 0 : vestingSchedule[1]["Available to Exercise"]
+//       }
+//     }
+//   }
+
+//   const exerciseTranscations = transactions.filter((transaction: any) => transaction.object_type === "TX_EQUITY_COMPENSATION_EXERCISE" && transaction.security_id === equityCompensationIssuance.security_id);
+
+//   const sortedExerciseTransactions = exerciseTranscations.sort((a: { date: string; object_type: string }, b: { date: string; object_type: string }) => a.date.localeCompare(b.date));
+
+//   let cumulativeExercised = 0;
+
+//   sortedExerciseTransactions.forEach((transaction: any, index: any) => {
+//     if (Date.parse(vestingSchedule[vestingSchedule.length - 1].Date) > Date.parse(transaction.date)) {
+//       for (let i = 0; i < vestingSchedule.length - 1; i++) {
+//         if (
+//           Date.parse(vestingSchedule[i + 1].Date) <=
+//             Date.parse(transaction.date) &&
+//           index === 0
+//         ) {
+//           vestingSchedule[i]["Cumulative Exercised"] = cumulativeExercised;
+//           vestingSchedule[i]['Available to Exercise'] = availableToExercise;
           
-        } else 
-        if (Date.parse(vestingSchedule[i].Date) <= Date.parse(transaction.date) && Date.parse(vestingSchedule[i + 1].Date) > Date.parse(transaction.date) && vestingSchedule[i]["Event Type"] !== "Exercise") {
-          vestingSchedule[i]["Available to Exercise"] = vestingSchedule[i]["Cumulative Vested"] - cumulativeExercised;
-          const amountExercised = parseFloat(transaction.quantity);
-          cumulativeExercised += amountExercised;
-          availableToExercise -= amountExercised
+//         } else 
+//         if (Date.parse(vestingSchedule[i].Date) <= Date.parse(transaction.date) && Date.parse(vestingSchedule[i + 1].Date) > Date.parse(transaction.date) && vestingSchedule[i]["Event Type"] !== "Exercise") {
+//           vestingSchedule[i]["Available to Exercise"] = vestingSchedule[i]["Cumulative Vested"] - cumulativeExercised;
+//           const amountExercised = parseFloat(transaction.quantity);
+//           cumulativeExercised += amountExercised;
+//           availableToExercise -= amountExercised
           
-          vestingSchedule.splice(i + 1, 0, {
-            Date: transaction.date,
-            "Event Type": "Exercise",
-            "Event Quantity": parseFloat(transaction.quantity),
-            "Remaining Unvested": vestingSchedule[i]["Remaining Unvested"],
-            "Cumulative Vested": vestingSchedule[i]["Cumulative Vested"],
-            "Became Exercisable": 0,
-            "Cumulative Exercised": cumulativeExercised,
-            "Available to Exercise": availableToExercise,
-          });
-          i++;
-        } else if (
-          Date.parse(vestingSchedule[i].Date) >
-            Date.parse(transaction.date) &&
-            vestingSchedule[i]['Event Type'] !== 'Exercise'
-        ) {
-          vestingSchedule[i]["Cumulative Exercised"] = cumulativeExercised,
-          vestingSchedule[i]['Available to Exercise'] = availableToExercise;
-        }
-      }
-      vestingSchedule[vestingSchedule.length - 1]["Cumulative Exercised"] = cumulativeExercised;
+//           vestingSchedule.splice(i + 1, 0, {
+//             Date: transaction.date,
+//             "Event Type": "Exercise",
+//             "Event Quantity": parseFloat(transaction.quantity),
+//             "Remaining Unvested": vestingSchedule[i]["Remaining Unvested"],
+//             "Cumulative Vested": vestingSchedule[i]["Cumulative Vested"],
+//             "Became Exercisable": 0,
+//             "Cumulative Exercised": cumulativeExercised,
+//             "Available to Exercise": availableToExercise,
+//           });
+//           i++;
+//         } else if (
+//           Date.parse(vestingSchedule[i].Date) >
+//             Date.parse(transaction.date) &&
+//             vestingSchedule[i]['Event Type'] !== 'Exercise'
+//         ) {
+//           vestingSchedule[i]["Cumulative Exercised"] = cumulativeExercised,
+//           vestingSchedule[i]['Available to Exercise'] = availableToExercise;
+//         }
+//       }
+//       vestingSchedule[vestingSchedule.length - 1]["Cumulative Exercised"] = cumulativeExercised;
 
-      vestingSchedule[vestingSchedule.length - 1]["Available to Exercise"] = availableToExercise;
-    } else {
-      cumulativeExercised += parseFloat(transaction.quantity);
-      vestingSchedule.push({
-        Date: transaction.date,
-        "Event Type": "Exercise",
-        "Event Quantity": parseFloat(transaction.quantity),
-        "Remaining Unvested": 0,
-        "Cumulative Vested": vestingSchedule[vestingSchedule.length - 1]["Cumulative Vested"],
-        "Became Exercisable": 0,
-        "Cumulative Exercised": cumulativeExercised,
-        "Available to Exercise": availableToExercise,
-      });
-    }
-  });
+//       vestingSchedule[vestingSchedule.length - 1]["Available to Exercise"] = availableToExercise;
+//     } else {
+//       cumulativeExercised += parseFloat(transaction.quantity);
+//       vestingSchedule.push({
+//         Date: transaction.date,
+//         "Event Type": "Exercise",
+//         "Event Quantity": parseFloat(transaction.quantity),
+//         "Remaining Unvested": 0,
+//         "Cumulative Vested": vestingSchedule[vestingSchedule.length - 1]["Cumulative Vested"],
+//         "Became Exercisable": 0,
+//         "Cumulative Exercised": cumulativeExercised,
+//         "Available to Exercise": availableToExercise,
+//       });
+//     }
+//   });
 
-  return vestingSchedule;
-};
+//   return vestingSchedule;
+// };

--- a/vesting_schedule_generator/vesting_calculator.ts
+++ b/vesting_schedule_generator/vesting_calculator.ts
@@ -1,0 +1,258 @@
+import { VestingSchedule } from ".";
+import { TX_Vesting_Start, VestingConditions_VestingScheduleRelative, VestingTerms } from "../read_ocf_package";
+
+export class VestingCalculatorService {
+    private vestingMode!: (
+        installment: number,
+        denominator: string,
+        numerator?: string
+    ) => number;
+    private unvested: number;
+    private vested = 0;
+    private transactionDate!: Date;
+    private vestingConditionId!: string;
+    private currentVestingCondition!: VestingConditions_VestingScheduleRelative;
+    private vestingSchedule: VestingSchedule[] = [];
+    private hasBeenGenerated: boolean = false;
+
+    constructor(
+      private vestingStartTx: TX_Vesting_Start,
+      private issuanceVestingTerms: VestingTerms,
+      private quantity: number,
+      private EARLY_EXERCISABLE: boolean,
+    ){
+      this.determineVestingMode(),
+      this.unvested = this.quantity
+    }
+
+    private determineVestingMode() {
+        
+        switch (this.issuanceVestingTerms.allocation_type) {
+            case "CUMULATIVE_ROUNDING":
+                this.vestingMode = (installment: number, denominator: string) => {
+                    const cumulativePercent = (installment + 1) / parseFloat(denominator)
+                    if (installment === 0) {
+                        return Math.ceil(cumulativePercent * this.quantity)
+                    }
+                    const lastCumulativePercent = installment / parseFloat(denominator)
+                    return Math.ceil(cumulativePercent * this.quantity) - Math.floor(lastCumulativePercent * this.quantity)
+                }
+                break;
+            case "CUMULATIVE_ROUND_DOWN":
+                this.vestingMode = (installment: number, denominator: string) => {
+                    const cumulativePercent = (installment + 1) / parseFloat(denominator)
+                    if (installment === 0) {
+                        return Math.ceil(cumulativePercent * this.quantity)
+                    }
+                    const lastCumulativePercent = installment / parseFloat(denominator)
+                    return Math.ceil(cumulativePercent * this.quantity) - Math.floor(lastCumulativePercent * this.quantity)
+                }  
+              break;
+            case "FRONT_LOADED":
+              this.vestingMode = (installment: number, denominator: string) => {
+                const remainder = this.quantity % parseFloat(denominator)
+                if (installment < remainder) {
+                  return Math.ceil(this.quantity / parseFloat(denominator))
+                }
+                return Math.floor(this.quantity / parseFloat(denominator))
+              }
+              break;
+            case 'BACK_LOADED':
+              this.vestingMode = (installment: number, denominator: string) => {
+                const remainder = this.quantity % parseFloat(denominator)
+                if (installment < remainder) {
+                  return Math.floor(this.quantity / parseFloat(denominator))
+                }
+                return Math.ceil(this.quantity / parseFloat(denominator))
+              }
+              break;
+            case 'FRONT_LOADED_TO_SINGLE_TRANCHE':
+              this.vestingMode = (installment: number, denominator: string) => {
+                const remainder = this.quantity % parseFloat(denominator)
+                if (installment < remainder) {
+                  return Math.floor(this.quantity / parseFloat(denominator)) + remainder
+                }
+                return Math.floor(this.quantity / parseFloat(denominator))
+              }
+              break;
+            case 'BACK_LOADED_TO_SINGLE_TRANCHE':
+              this.vestingMode = (installment: number, denominator: string) => {
+                const remainder = this.quantity % parseFloat(denominator)
+                if (installment < remainder) {
+                  return Math.floor(this.quantity / parseFloat(denominator)) + remainder
+                }
+                return Math.floor(this.quantity / parseFloat(denominator))
+              }
+              break;
+            default:
+              this.vestingMode = (installment, denominator, numerator = '0') => (this.quantity * parseFloat(numerator)) / parseFloat(denominator)
+              break
+          }
+    }
+
+    private handleVestingStartTx() {
+      // initialize the first transaction date and the vestingConditionId to the vesting start date
+      this.transactionDate = new Date(this.vestingStartTx.date);
+      this.vestingConditionId = this.vestingStartTx.vesting_condition_id;
+
+      // throw error if no vesting conditions for the provided security id or if the first condition does not have a Vesting_Start_Date trigger
+      const currentVestingCondition = this.issuanceVestingTerms.vesting_conditions.find((vc) => vc.id === this.vestingConditionId)
+      if (!currentVestingCondition) {
+        throw new Error(`Vesting conditions for vesting start id ${this.vestingStartTx.id} not found`)
+      } else if (currentVestingCondition.trigger.type !== "VESTING_START_DATE") {
+        throw new Error(`For this generator, the first condition must have a VESTING_START_DATE trigger.`)
+      }
+      this.currentVestingCondition = currentVestingCondition
+      
+      const amountVested = (this.quantity * parseFloat(this.currentVestingCondition.portion.numerator)) / parseFloat(this.currentVestingCondition.portion.denominator)
+      this.vested += amountVested
+      this.unvested -+ amountVested
+
+      // designate the entire option as becoming exercisable as of the "Start" event if the option is early exercisable
+      const becameExercisable = this.quantity * +this.EARLY_EXERCISABLE
+
+      const event: VestingSchedule = {
+        Date: this.transactionDate.toISOString().split("T")[0],
+        "Event Type": "Start",
+        "Event Quantity": amountVested,
+        "Remaining Unvested": this.unvested,
+        "Cumulative Vested": this.vested,
+        "Became Exercisable": becameExercisable,
+        'Cumulative Exercised': 0,
+        'Available to Exercise': 0 // placeholder to be populated via the exercise service
+      }
+
+      this.vestingSchedule.push(event)
+      return this
+    }
+
+    private handleCliffCondition(cliffLength: number) {
+      // we start at 1 because 0 is the "Start" event
+      for (let i = 1; i <= cliffLength; i++) {
+  
+        // remove all installments prior to the cliff
+        if (i < cliffLength) {
+          this.vestingSchedule.splice(1, 1);
+        }
+  
+        // convert the cliff installment into a "Cliff" event
+        if (i === cliffLength) {
+          this.vestingSchedule[1]["Event Type"] = "Cliff";
+          this.vestingSchedule[1]["Event Quantity"] = this.vestingSchedule[1]["Cumulative Vested"];
+  
+          // increment available to excercise only if the option is not early exercisable
+          this.vestingSchedule[1]["Became Exercisable"] = this.EARLY_EXERCISABLE ? 0 : this.vestingSchedule[1]["Cumulative Vested"]
+        }
+      }
+    }
+
+    private incrementTransactionDate() {
+    
+      const newDate = new Date(this.transactionDate)
+      const {type, length} = this.currentVestingCondition.trigger.period
+      
+      if (type === "MONTHS") {
+        const currentMonth = newDate.getMonth()
+        newDate.setMonth(currentMonth + length)
+  
+        // Adjust the day of the month after incrementing the month
+        // const day_of_month = this.currentVestingCondition.trigger.period.day_of_month
+        // switch (day_of_month) {
+        //   case "29_OR_LAST_DAY_OF_MONTH":
+        //   case "30_OR_LAST_DAY_OF_MONTH":
+        //   case "31_OR_LAST_DAY_OF_MONTH":
+        //     this.setDayToLastDayOfMonth(newDate);
+        //     break;
+        //   case 'VESTING_START_DAY_OR_LAST_DAY_OF_MONTH':
+        //     this.setDayToVestingStartOrLast(newDate);
+        //     break;
+        //   default:
+        //     newDate.setDate(parseInt(day_of_month));
+        //     break;
+        // }
+  
+      } else if (type === 'DAYS') {
+        newDate.setDate(newDate.getDate() + length)
+      }
+      
+      this.transactionDate = newDate
+  
+    }
+  
+    private setDayToLastDayOfMonth(date: Date) {
+      const nextMonth = new Date(date.getFullYear(), date.getMonth() + 1, 0)
+      date.setDate(nextMonth.getDate())
+    }
+  
+    private setDayToVestingStartOrLast(date: Date) {
+      const vestingDay = this.transactionDate.getDate();
+      const lastDayOfNewMonth = new Date(date.getFullYear(), date.getMonth() + 1, 0).getDate()
+  
+      if (vestingDay > lastDayOfNewMonth) {
+        date.setDate(lastDayOfNewMonth)
+      } else {
+        date.setDate(vestingDay)
+      }
+    }
+  
+    private handleNextVestingCondition() {
+  
+      // initialize the currentVestingCondition
+      // throw error if the trigger is not VESTING_SCHEDULE_RELATIVE
+      this.vestingConditionId = this.currentVestingCondition?.next_condition_ids[0];
+      const currentVestingCondition = this.issuanceVestingTerms.vesting_conditions.find((vc) => vc.id === this.vestingConditionId)
+  
+      if (!currentVestingCondition || currentVestingCondition.trigger.type !== "VESTING_SCHEDULE_RELATIVE") {
+        throw new Error(`This generator can only calculate for VESTING_SCHEDULE_RELATIVE triggers.`);
+      }
+      this.currentVestingCondition = currentVestingCondition
+  
+      // create array of vesting events
+      const occurrencesCount = currentVestingCondition.trigger.period.occurrences
+      const { denominator, numerator } = currentVestingCondition.portion
+  
+      const events = Array.from({ length: occurrencesCount }, (_, index) => {
+        this.incrementTransactionDate()
+        const amountVested = this.vestingMode(index, denominator, numerator)
+        this.vested += amountVested
+        this.unvested -= amountVested
+  
+        // increment becomeExercisable only if the option is not early exercisable
+        const becameExercisable = amountVested * +!this.EARLY_EXERCISABLE
+  
+        const event: VestingSchedule = {
+          Date: this.transactionDate.toISOString().split("T")[0],
+          "Event Type": "Vesting",
+          "Event Quantity": amountVested,
+          "Remaining Unvested": this.unvested,
+          'Cumulative Vested': this.vested,
+          "Became Exercisable": becameExercisable,
+          'Cumulative Exercised': 0,
+          'Available to Exercise': 0 // placeholder to be populated via the exercise service
+        }
+  
+        return event
+      })
+  
+      // add vesting events to vestingSchedule
+      this.vestingSchedule.push(...events)
+  
+      // handle the cliff condition
+      if (currentVestingCondition.cliff_condition) {
+        const cliffLength = currentVestingCondition.cliff_condition.period.length
+        this.handleCliffCondition(cliffLength)
+      }
+    }
+
+    generate() {
+      
+      if (this.hasBeenGenerated) return this.vestingSchedule
+      
+      this
+      .handleVestingStartTx()
+      .handleNextVestingCondition()
+
+      return this.vestingSchedule
+
+    }
+}

--- a/vesting_schedule_generator/vesting_initialization.ts
+++ b/vesting_schedule_generator/vesting_initialization.ts
@@ -1,0 +1,45 @@
+import { TX_Equity_Compensation_Exercise, TX_Equity_Compensation_Issuance, TX_Vesting_Start, VestingTerms } from "../read_ocf_package";
+
+export class VestingInitializationService {
+    constructor (
+        private transactions: (TX_Equity_Compensation_Issuance | TX_Vesting_Start | TX_Equity_Compensation_Exercise)[],
+        private vestingTerms: VestingTerms[],
+        private securityId: string
+    ){}
+
+    public setUpVestingData(): {
+        issuance: TX_Equity_Compensation_Issuance,
+        vestingStartTx: TX_Vesting_Start,
+        issuanceVestingTerms: VestingTerms
+    } {
+        const issuance = this.findIssuance();
+        const vestingStartTx = this.findVestingStartTx();
+        const issuanceVestingTerms = this.findIssuanceVestingTerms(issuance);
+        
+        return { issuance, vestingStartTx, issuanceVestingTerms }
+    }
+
+    private findIssuance() {
+        const issuance = this.transactions.find((tx): tx is TX_Equity_Compensation_Issuance => tx.security_id === this.securityId);
+        if (!issuance) {
+            throw new Error(`Equity compensation issuance with security id ${this.securityId} not found`) 
+        }
+        return issuance
+    }
+
+    private findVestingStartTx() {
+        const vestingStartTx = this.transactions.find((tx): tx is TX_Vesting_Start => tx.object_type === 'TX_VESTING_START' && tx.security_id === this.securityId)
+        if (!vestingStartTx) {
+            throw new Error(`For this generator, the transaction must have a TX_VESTING_START object.`)
+        }
+        return vestingStartTx
+    }
+
+    private findIssuanceVestingTerms(issuance: TX_Equity_Compensation_Issuance) {
+        const issuanceVestingTerms = this.vestingTerms.find((vt) => vt.id === issuance.vesting_terms_id)
+        if (!issuanceVestingTerms) {
+            throw new Error(`Vesting terms for security.id ${this.securityId} not found`)
+        }
+        return issuanceVestingTerms
+    }
+}

--- a/vesting_status_check/index.ts
+++ b/vesting_status_check/index.ts
@@ -1,30 +1,35 @@
 import { OcfPackageContent, readOcfPackage } from "../read_ocf_package";
-import { VestingSchedule, generateSchedule } from "../vesting_schedule_generator";
+import { VestingScheduleService } from "../vesting_schedule_generator";
 
-export const vestingStatusCheck = (packagePath: string, equityCompensationIssuanceSecurityId: string, checkDate: string) => {
+export const vestingStatusCheck = (packagePath: string, securityId: string, checkDateString: string) => {
   
   const ocfPackage: OcfPackageContent = readOcfPackage(packagePath);
-  const vestingSchedule: VestingSchedule[] = generateSchedule(packagePath, equityCompensationIssuanceSecurityId);
-  let amountVested = 0;
-  let amountUnvested = 0;
-  let amountAvailable = 0;
-  let amountExercised = 0;
+  const { vestingTerms, transactions } = ocfPackage
+  const vestingSchedule = new VestingScheduleService(vestingTerms, transactions, securityId).generate()
 
-  for (let i = 0; i < vestingSchedule.length; i++) {
-    if (Date.parse(vestingSchedule[i].Date) <= Date.parse(checkDate) && Date.parse(vestingSchedule[i + 1].Date) > Date.parse(checkDate)) {
-      amountVested = vestingSchedule[i]["Cumulative Vested"];
-      amountUnvested = vestingSchedule[i]["Remaining Unvested"];
-      amountAvailable = vestingSchedule[i]["Available to Exercise"];
-      amountExercised = vestingSchedule[i]["Cumulative Exercised"];
-    }
-  }
+  const status = vestingSchedule.find((schedule) => Date.parse(schedule.Date) >= Date.parse(checkDateString))
+  return status
 
-  const status = {
-    "Analysis Date: ": checkDate,
-    "Amount Unvested: ": amountUnvested,
-    "Amount Vested to Date: ": amountVested,
-    "Amount Exercised to Date: ": amountExercised,
-    "Amount Available to Exercise: ": amountAvailable,
-  };
-  return status;
+  // let amountVested = 0;
+  // let amountUnvested = 0;
+  // let amountAvailable = 0;
+  // let amountExercised = 0;
+
+  // for (let i = 0; i < vestingSchedule.length; i++) {
+  //   if (Date.parse(vestingSchedule[i].Date) <= Date.parse(checkDate) && Date.parse(vestingSchedule[i + 1].Date) > Date.parse(checkDate)) {
+  //     amountVested = vestingSchedule[i]["Cumulative Vested"];
+  //     amountUnvested = vestingSchedule[i]["Remaining Unvested"];
+  //     amountAvailable = vestingSchedule[i]["Available to Exercise"];
+  //     amountExercised = vestingSchedule[i]["Cumulative Exercised"];
+  //   }
+  // }
+
+  // const status = {
+  //   "Analysis Date: ": checkDate,
+  //   "Amount Unvested: ": amountUnvested,
+  //   "Amount Vested to Date: ": amountVested,
+  //   "Amount Exercised to Date: ": amountExercised,
+  //   "Amount Available to Exercise: ": amountAvailable,
+  // };
+  // return status;
 };


### PR DESCRIPTION
Implements #95 

**Decomposition of `vesting schedule generator`**. Split the original function into multiple services:
  - **vesting_initialization**. Locates the applicable equity compensation issuance transaction, vesting start transaction, and vesting terms, and throws errors if these are not found.
  - **vesting_calculator.** Determines the vesting formula based on the allocation_type. Builds the vesting schedule and applies the `cliff_condition`. Tracks vesting and exercisability.
  - **exercise_transactions**. Inserts exercise transactions into the vesting schedule, and populates cumulative exercised data.

`VestingScheduleService` orchestrates the various services.

The `iso_nso_calculator` has also been refactored into a modular service, with the `VestingScheduleService` utilized as a dependency.

The functionality can be tested in the command line with `ts-node` and the various scripts in the `testing_scripts` repository.