### PR TITLE
Implement TX_PLAN_SECURITY_ISSUANCE validation rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ node_modules/
 dist/
 
 .vscode/launch.json
+CLAUDE.md

--- a/ocf_validator/eod.ts
+++ b/ocf_validator/eod.ts
@@ -1,7 +1,7 @@
 import { OcfMachineContext } from "./ocfMachine";
 
 const RUN_EOD = (context: OcfMachineContext, event: any): any => {
-  let snapshot: any = {date: event.date, stockIssuances: [], convertibles: [], warrants: [], equityCompensation: []};
+  let snapshot: any = {date: event.date, stockIssuances: [], convertibles: [], warrants: [], equityCompensation: [], planSecurityIssuances: []};
 
   
   context.stockIssuances.forEach((issuance: any) => {
@@ -39,6 +39,16 @@ const RUN_EOD = (context: OcfMachineContext, event: any): any => {
       stakeholder: issuance.stakeholder_id,
       quantity: issuance.quantity,
       availableToExercise: issuance.availableToExercise,
+    });
+  });
+
+  context.planSecurityIssuances.forEach((issuance: any) => {
+    snapshot.planSecurityIssuances.push({
+      date: issuance.date,
+      custom_id: issuance.custom_id,
+      stakeholder: issuance.stakeholder_id,
+      stock_plan_id: issuance.stock_plan_id,
+      quantity: issuance.quantity,
     });
   });
 

--- a/ocf_validator/ocfMachine.ts
+++ b/ocf_validator/ocfMachine.ts
@@ -8,6 +8,7 @@ export type OcfMachineContext = {
   equityCompensation: any[];
   convertibleIssuances: any[];
   warrantIssuances: any[];
+  planSecurityIssuances: any[];
   ocfPackageContent: OcfPackageContent;
   report: any[];
   snapshots: any[],
@@ -29,6 +30,7 @@ export const ocfMachine: any = {
     equityCompensation: [],
     convertibleIssuances: [],
     warrantIssuances: [],
+    planSecurityIssuances: [],
     ocfPackageContent: {},
     report: [],
     snapshots: [],
@@ -873,6 +875,38 @@ export const ocfMachine: any = {
               assign({
                 result: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) =>
                   `The validation of the OCF package for ${context.ocfPackageContent.manifest.issuer.legal_name} failed on ${event.data.id}: ${JSON.stringify(validators.valid_tx_equity_compensation_exercise(context, event, false),null, 2)}`
+              }),
+            ],
+          },
+        ],
+        TX_PLAN_SECURITY_ISSUANCE: [
+          {
+            guard: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => {
+              return validators.valid_tx_plan_security_issuance(context, event, true);
+            },
+            actions: [
+              assign({
+                report: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) =>
+                  [...context.report, validators.valid_tx_plan_security_issuance(context, event, false)]
+
+              }),
+              assign({
+                planSecurityIssuances: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) =>
+                  [...context.planSecurityIssuances, event.data],
+              }),
+            ],
+            target: "capTable",
+          },
+          {
+            target: "validationError",
+            actions: [
+              assign({
+                report: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) =>
+                  [...context.report, validators.valid_tx_plan_security_issuance(context, event, false)]
+              }),
+              assign({
+                result: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) =>
+                  `The validation of the OCF package for ${context.ocfPackageContent.manifest.issuer.legal_name} failed on ${event.data.id}: ${JSON.stringify(validators.valid_tx_plan_security_issuance(context, event, false),null, 2)}`
               }),
             ],
           },

--- a/ocf_validator/validators/plan_security/tx_plan_security_issuance.ts
+++ b/ocf_validator/validators/plan_security/tx_plan_security_issuance.ts
@@ -1,13 +1,112 @@
-const valid_tx_plan_security_issuance = (context: any, event: any) => {
-  let valid = false;
-  valid = true;
-  // TBC: validation of tx_plan_security_issuance
+const valid_tx_plan_security_issuance = (context: any, event: any, isGuard: any) => {
+  let validity = false;
+  const { stakeholders, stockPlans, transactions } = context.ocfPackageContent;
+  let report: any = {transaction_type: "TX_PLAN_SECURITY_ISSUANCE", transaction_id: event.data.id, transaction_date: event.data.date};
 
-  if (valid) {
-    return true;
-  } else {
-    return false;
+  // 1. Check if the stakeholder referenced by the transaction exists in the stakeholder file.
+  let stakeholder_validity = false;
+  stakeholders.forEach((ele: any) => {
+    if (ele.id === event.data.stakeholder_id) {
+      stakeholder_validity = true;
+      report.stakeholder_validity = true
+    }
+  });
+  if (!stakeholder_validity) {
+    report.stakeholder_validity = false
   }
+
+  // 2. Check that the stock plan referenced by the transaction exists.
+  let stock_plan_validity = false;
+  const stockPlan = stockPlans.find((plan: any) => plan.id === event.data.stock_plan_id);
+  if (stockPlan) {
+    stock_plan_validity = true;
+    report.stock_plan_validity = true;
+  } else {
+    report.stock_plan_validity = false;
+  }
+
+  // 3. Check that the stock plan has a board approval date on or before the issuance date.
+  let stock_plan_approval_validity = false;
+  if (stockPlan && stockPlan.board_approval_date) {
+    if (stockPlan.board_approval_date <= event.data.date) {
+      stock_plan_approval_validity = true;
+      report.stock_plan_approval_validity = true;
+    } else {
+      report.stock_plan_approval_validity = false;
+    }
+  } else {
+    report.stock_plan_approval_validity = false;
+  }
+
+  // 4. Check that the stock plan has sufficient shares remaining in the pool.
+  //    Pool size is determined by `initial_shares_reserved` on the stock plan,
+  //    modified by TX_STOCK_PLAN_POOL_ADJUSTMENT events (which set a new absolute total)
+  //    and TX_STOCK_PLAN_RETURN_TO_POOL events (which add shares back).
+  //    Both TX_PLAN_SECURITY_ISSUANCE and TX_EQUITY_COMPENSATION_ISSUANCE draw from the pool.
+  let sufficient_shares_validity = false;
+  if (stockPlan) {
+    // Determine current pool size: start with initial_shares_reserved,
+    // then check for the most recent pool adjustment on or before the issuance date.
+    let currentPoolSize = parseFloat(stockPlan.initial_shares_reserved);
+
+    const poolAdjustments = transactions
+      .filter((tx: any) =>
+        tx.object_type === 'TX_STOCK_PLAN_POOL_ADJUSTMENT' &&
+        tx.stock_plan_id === event.data.stock_plan_id &&
+        tx.date <= event.data.date
+      )
+      .sort((a: any, b: any) => a.date.localeCompare(b.date));
+
+    if (poolAdjustments.length > 0) {
+      // The most recent adjustment sets the absolute pool size
+      currentPoolSize = parseFloat(poolAdjustments[poolAdjustments.length - 1].shares_reserved);
+    }
+
+    // Sum shares returned to pool on or before the issuance date
+    const sharesReturned = transactions
+      .filter((tx: any) =>
+        tx.object_type === 'TX_STOCK_PLAN_RETURN_TO_POOL' &&
+        tx.stock_plan_id === event.data.stock_plan_id &&
+        tx.date <= event.data.date
+      )
+      .reduce((sum: number, tx: any) => sum + parseFloat(tx.quantity), 0);
+
+    // Sum shares already issued from this plan (both plan security and equity compensation issuances)
+    // excluding the current transaction
+    const sharesIssued = transactions
+      .filter((tx: any) =>
+        (tx.object_type === 'TX_PLAN_SECURITY_ISSUANCE' || tx.object_type === 'TX_EQUITY_COMPENSATION_ISSUANCE') &&
+        tx.stock_plan_id === event.data.stock_plan_id &&
+        tx.date <= event.data.date &&
+        tx.id !== event.data.id
+      )
+      .reduce((sum: number, tx: any) => sum + parseFloat(tx.quantity), 0);
+
+    const availableShares = currentPoolSize - sharesIssued + sharesReturned;
+    const requestedShares = parseFloat(event.data.quantity);
+
+    if (availableShares >= requestedShares) {
+      sufficient_shares_validity = true;
+      report.sufficient_shares_validity = true;
+    } else {
+      report.sufficient_shares_validity = false;
+    }
+  } else {
+    report.sufficient_shares_validity = false;
+  }
+
+  if (
+    stakeholder_validity &&
+    stock_plan_validity &&
+    stock_plan_approval_validity &&
+    sufficient_shares_validity
+  ) {
+    validity = true;
+  }
+
+  const result = isGuard ? validity : report;
+
+  return result;
 };
 
 export default valid_tx_plan_security_issuance;


### PR DESCRIPTION
## Summary
- Replaces stub `TX_PLAN_SECURITY_ISSUANCE` validator with real validation logic
- Validates stakeholder exists, stock plan exists, board approval date is on or before issuance date
- Validates sufficient shares remain in plan pool, accounting for pool adjustments (`TX_STOCK_PLAN_POOL_ADJUSTMENT`), returns to pool (`TX_STOCK_PLAN_RETURN_TO_POOL`), and existing issuances from both plan security and equity compensation
- Adds `planSecurityIssuances` to XState machine context and EOD snapshots
- Adds `CLAUDE.md` to `.gitignore`

## Stack
This is PR 1/4. Subsequent PRs build on this branch:
1. **Issuance** (this PR)
2. Acceptance → `feat/plan-security-acceptance-validation`
3. Retraction → `feat/plan-security-retraction-validation`
4. Cancellation → `feat/plan-security-cancellation-validation`

## Test plan
- [x] All 166 existing tests pass
- [ ] Add test data for plan security issuance scenarios (tracked in #65)

Closes #45