### PR TITLE
Implement TX_PLAN_SECURITY_ACCEPTANCE validation rules

### DIFF
--- a/ocf_validator/ocfMachine.ts
+++ b/ocf_validator/ocfMachine.ts
@@ -911,6 +911,33 @@ export const ocfMachine: any = {
             ],
           },
         ],
+        TX_PLAN_SECURITY_ACCEPTANCE: [
+          {
+            guard: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => {
+              return validators.valid_tx_plan_security_acceptance(context, event, true);
+            },
+            target: 'capTable',
+            actions: [
+              assign({
+                report: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) =>
+                  [...context.report, validators.valid_tx_plan_security_acceptance(context, event, false)]
+              }),
+            ],
+          },
+          {
+            target: "validationError",
+            actions: [
+              assign({
+                report: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) =>
+                  [...context.report, validators.valid_tx_plan_security_acceptance(context, event, false)]
+              }),
+              assign({
+                result: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) =>
+                  `The validation of the OCF package for ${context.ocfPackageContent.manifest.issuer.legal_name} failed on ${event.data.id}: ${JSON.stringify(validators.valid_tx_plan_security_acceptance(context, event, false),null, 2)}`
+              }),
+            ],
+          },
+        ],
         INVALID_TX: [
           {
             target: "validationError",

--- a/ocf_validator/validators/plan_security/tx_plan_security_acceptance.ts
+++ b/ocf_validator/validators/plan_security/tx_plan_security_acceptance.ts
@@ -1,13 +1,72 @@
-const valid_tx_plan_security_acceptance = (context: any, event: any) => {
-  let valid = false;
-  valid = true;
-  // TBC: validation of tx_plan_security_acceptance
+const valid_tx_plan_security_acceptance = (context: any, event: any, isGuard: Boolean) => {
+  const {transactions} = context.ocfPackageContent;
 
-  if (valid) {
-    return true;
-  } else {
-    return false;
+  let validity = false;
+  let report: any = {transaction_type: "TX_PLAN_SECURITY_ACCEPTANCE", transaction_id: event.data.id, transaction_date: event.data.date};
+
+  // Check that plan security issuance in incoming security_id referenced by transaction exists in current state.
+  let incoming_planSecurityIssuance_validity = false;
+  context.planSecurityIssuances.forEach((ele: any) => {
+    if (
+      ele.security_id === event.data.security_id &&
+      ele.object_type === 'TX_PLAN_SECURITY_ISSUANCE'
+    ) {
+      incoming_planSecurityIssuance_validity = true;
+      report.incoming_planSecurityIssuance_validity = true;
+    }
+  });
+  if (!incoming_planSecurityIssuance_validity) {
+    report.incoming_planSecurityIssuance_validity = false;
   }
+
+  // Check to ensure that the date of transaction is the same day or after the date of the incoming plan security issuance.
+  let incoming_date_validity = false;
+  transactions.forEach((ele: any) => {
+    if (
+      ele.security_id === event.data.security_id &&
+      ele.object_type === 'TX_PLAN_SECURITY_ISSUANCE'
+    ) {
+      if (ele.date <= event.data.date) {
+        incoming_date_validity = true;
+        report.incoming_date_validity = true;
+      }
+    }
+  });
+  if (!incoming_date_validity) {
+    report.incoming_date_validity = false;
+  }
+
+  // Check that plan security issuance in incoming security_id does not have a plan security retraction transaction associated with it.
+  let no_plan_security_retraction_validity = false;
+  let plan_security_retraction_exists = false;
+  transactions.forEach((ele: any) => {
+    if (
+      ele.security_id === event.data.security_id &&
+      ele.object_type === 'TX_PLAN_SECURITY_RETRACTION'
+    ) {
+      plan_security_retraction_exists = true;
+    }
+  });
+
+  if (!plan_security_retraction_exists) {
+    no_plan_security_retraction_validity = true;
+    report.no_plan_security_retraction_validity = true;
+  }
+  if (!no_plan_security_retraction_validity) {
+    report.no_plan_security_retraction_validity = false;
+  }
+
+  if (
+    incoming_planSecurityIssuance_validity &&
+    incoming_date_validity &&
+    no_plan_security_retraction_validity
+  ) {
+    validity = true;
+  }
+
+  const result = isGuard ? validity : report;
+
+  return result;
 };
 
 export default valid_tx_plan_security_acceptance;


### PR DESCRIPTION
## Summary
- Replaces stub `TX_PLAN_SECURITY_ACCEPTANCE` validator with real validation logic
- Validates plan security issuance exists in current state
- Validates date is on or after the issuance date
- Validates no prior retraction exists for this security
- Wires `TX_PLAN_SECURITY_ACCEPTANCE` into the XState machine

## Stack
PR 2/4 — based on #132 (issuance)

## Test plan
- [x] All 166 existing tests pass
- [ ] Add test data for plan security acceptance scenarios (tracked in #65)

Closes #47