### PR TITLE
Implement TX_PLAN_SECURITY_CANCELLATION validation rules

### DIFF
--- a/ocf_validator/ocfMachine.ts
+++ b/ocf_validator/ocfMachine.ts
@@ -971,6 +971,39 @@ export const ocfMachine: any = {
             ],
           },
         ],
+        TX_PLAN_SECURITY_CANCELLATION: [
+          {
+            guard: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => {
+              return validators.valid_tx_plan_security_cancellation(context, event, true);
+            },
+            target: 'capTable',
+            actions: [
+              assign({
+                report: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) =>
+                  [...context.report, validators.valid_tx_plan_security_cancellation(context, event, false)]
+              }),
+              assign({
+                planSecurityIssuances: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) =>
+                  context.planSecurityIssuances.filter((obj: any) => { return obj.security_id !== event.data.security_id; }
+                  ),
+              }),
+
+            ],
+          },
+          {
+            target: "validationError",
+            actions: [
+              assign({
+                report: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) =>
+                  [...context.report, validators.valid_tx_plan_security_cancellation(context, event, false)]
+              }),
+              assign({
+                result: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) =>
+                  `The validation of the OCF package for ${context.ocfPackageContent.manifest.issuer.legal_name} failed on ${event.data.id}: ${JSON.stringify(validators.valid_tx_plan_security_cancellation(context, event, false),null, 2)}`
+              }),
+            ],
+          },
+        ],
         INVALID_TX: [
           {
             target: "validationError",

--- a/ocf_validator/validators/plan_security/tx_plan_security_cancellation.ts
+++ b/ocf_validator/validators/plan_security/tx_plan_security_cancellation.ts
@@ -1,13 +1,72 @@
-const valid_tx_plan_security_acceptance = (context: any, event: any) => {
-  let valid = false;
-  valid = true;
-  // TBC: validation of tx_plan_security_acceptance
+import {OcfMachineContext} from '../../ocfMachine';
 
-  if (valid) {
-    return true;
-  } else {
-    return false;
+const valid_tx_plan_security_cancellation = (
+  context: OcfMachineContext,
+  event: any,
+  isGuard: Boolean = false
+) => {
+  let validity = false;
+  let report: any = {transaction_type: "TX_PLAN_SECURITY_CANCELLATION", transaction_id: event.data.id, transaction_date: event.data.date};
+
+  const {transactions} = context.ocfPackageContent;
+  // 1. Check that plan security issuance in incoming security_id reference by transaction exists in current state.
+  let incoming_planSecurityIssuance_validity = false;
+  context.planSecurityIssuances.forEach((ele: any) => {
+    if (ele.security_id === event.data.security_id) {
+      incoming_planSecurityIssuance_validity = true;
+      report.incoming_planSecurityIssuance_validity = true;
+    }
+  });
+
+  if (!incoming_planSecurityIssuance_validity) {
+    report.incoming_planSecurityIssuance_validity = false;
   }
+
+  // 2. Check to ensure that the date of transaction is the same day or after the date of the incoming plan security issuance.
+  let incoming_date_validity = false;
+  transactions.forEach((ele: any) => {
+    if (
+      ele.security_id === event.data.security_id &&
+      ele.object_type === 'TX_PLAN_SECURITY_ISSUANCE'
+    ) {
+      if (ele.date <= event.data.date) {
+        incoming_date_validity = true;
+        report.incoming_date_validity = true;
+      }
+    }
+  });
+  if (!incoming_date_validity) {
+    report.incoming_date_validity = false;
+  }
+
+  // 3. The security_id of the plan security issuance referred to in the security_id variable must not be the security_id related to any other transactions with the exception of a plan security acceptance transaction.
+  let only_transaction_validity = true;
+  transactions.map((ele: any) => {
+    if (
+      ele.security_id === event.data.security_id &&
+      ele.object_type !== 'TX_PLAN_SECURITY_ISSUANCE' &&
+      ele.object_type !== 'TX_PLAN_SECURITY_ACCEPTANCE' &&
+      !(ele.object_type === 'TX_PLAN_SECURITY_CANCELLATION' && ele.id === event.data.id)
+    ) {
+      only_transaction_validity = false;
+      report.only_transaction_validity = false;
+    }
+  });
+  if (only_transaction_validity) {
+    report.only_transaction_validity = true;
+  }
+
+  if (
+    incoming_planSecurityIssuance_validity &&
+    incoming_date_validity &&
+    only_transaction_validity
+  ) {
+    validity = true;
+  }
+
+  const result = isGuard ? validity : report;
+
+  return result;
 };
 
-export default valid_tx_plan_security_acceptance;
+export default valid_tx_plan_security_cancellation;


### PR DESCRIPTION
## Summary
- Replaces stub `TX_PLAN_SECURITY_CANCELLATION` validator with real validation logic
- Fixes copy-paste bug where file exported wrong function name (`valid_tx_plan_security_acceptance`)
- Validates plan security issuance exists in current state
- Validates date is on or after the issuance date
- Validates no other transactions exist for this security (except acceptance)
- Wires `TX_PLAN_SECURITY_CANCELLATION` into the XState machine
- On cancellation, removes the security from `planSecurityIssuances` context

## Stack
PR 4/4 — based on #134 (retraction)

## Test plan
- [x] All 166 existing tests pass
- [ ] Add test data for plan security cancellation scenarios (tracked in #65)

Closes #48