### PR TITLE
Add stock plan test data to acme_holdings_limited sample

### DIFF
--- a/sample_ocf_folders/acme_holdings_limited/Manifest.ocf.json
+++ b/sample_ocf_folders/acme_holdings_limited/Manifest.ocf.json
@@ -11,7 +11,12 @@
   },
   "as_of": "2023-06-29",
   "generated_at": "2023-06-29T09:57:16.793Z",
-  "stock_plans_files": [],
+  "stock_plans_files": [
+    {
+      "filepath": "./StockPlans.ocf.json",
+      "md5": "placeholder"
+    }
+  ],
   "stock_legend_templates_files": [],
   "stock_classes_files": [
     {

--- a/sample_ocf_folders/acme_holdings_limited/StockPlans.ocf.json
+++ b/sample_ocf_folders/acme_holdings_limited/StockPlans.ocf.json
@@ -1,0 +1,23 @@
+{
+  "file_type": "OCF_STOCK_PLANS_FILE",
+  "items": [
+    {
+      "id": "stock_plan_01",
+      "object_type": "STOCK_PLAN",
+      "plan_name": "2019 Stock Option Plan",
+      "board_approval_date": "2019-01-01",
+      "initial_shares_reserved": "2000000",
+      "default_cancellation_behavior": "RETURN_TO_POOL",
+      "stock_class_ids": ["ordinaryB"]
+    },
+    {
+      "id": "stock_plan_02",
+      "object_type": "STOCK_PLAN",
+      "plan_name": "2023 Equity Incentive Plan",
+      "board_approval_date": "2023-01-01",
+      "initial_shares_reserved": "500000",
+      "default_cancellation_behavior": "RETURN_TO_POOL",
+      "stock_class_ids": ["ordinaryB"]
+    }
+  ]
+}

--- a/sample_ocf_folders/acme_holdings_limited/Transactions.ocf.json
+++ b/sample_ocf_folders/acme_holdings_limited/Transactions.ocf.json
@@ -468,6 +468,103 @@
       "security_id": "equity_compensation_issuance_01",
       "resulting_security_ids": ["share_issuance_04"],
       "quantity": "350"
+    },
+    {
+      "id": "spa_01",
+      "object_type": "TX_STOCK_PLAN_POOL_ADJUSTMENT",
+      "date": "2022-06-01",
+      "stock_plan_id": "stock_plan_01",
+      "board_approval_date": "2022-06-01",
+      "shares_reserved": "2500000",
+      "comments": ["Increased plan 1 pool from 2,000,000 to 2,500,000"]
+    },
+    {
+      "id": "spa_02",
+      "object_type": "TX_STOCK_PLAN_POOL_ADJUSTMENT",
+      "date": "2023-06-01",
+      "stock_plan_id": "stock_plan_02",
+      "board_approval_date": "2023-06-01",
+      "shares_reserved": "400000",
+      "comments": ["Decreased plan 2 pool from 500,000 to 400,000"]
+    },
+    {
+      "id": "psi_01",
+      "object_type": "TX_PLAN_SECURITY_ISSUANCE",
+      "date": "2023-03-01",
+      "security_id": "plan_security_01",
+      "custom_id": "PS-1",
+      "stakeholder_id": "janeCTO",
+      "security_law_exemptions": [],
+      "stock_plan_id": "stock_plan_02",
+      "stock_class_id": "ordinaryB",
+      "quantity": "100000",
+      "compensation_type": "RSU",
+      "option_grant_type": "NSO",
+      "expiration_date": null,
+      "termination_exercise_windows": []
+    },
+    {
+      "id": "psa_01",
+      "object_type": "TX_PLAN_SECURITY_ACCEPTANCE",
+      "date": "2023-03-15",
+      "security_id": "plan_security_01"
+    },
+    {
+      "id": "psi_02",
+      "object_type": "TX_PLAN_SECURITY_ISSUANCE",
+      "date": "2023-04-01",
+      "security_id": "plan_security_02",
+      "custom_id": "PS-2",
+      "stakeholder_id": "emilyEmployee",
+      "security_law_exemptions": [],
+      "stock_plan_id": "stock_plan_02",
+      "stock_class_id": "ordinaryB",
+      "quantity": "50000",
+      "compensation_type": "RSU",
+      "option_grant_type": "NSO",
+      "expiration_date": null,
+      "termination_exercise_windows": []
+    },
+    {
+      "id": "psc_01",
+      "object_type": "TX_PLAN_SECURITY_CANCELLATION",
+      "date": "2023-06-01",
+      "security_id": "plan_security_02",
+      "balance_security_id": "",
+      "reason_text": "Employee departed before vesting",
+      "quantity": "50000"
+    },
+    {
+      "id": "sprtp_01",
+      "object_type": "TX_STOCK_PLAN_RETURN_TO_POOL",
+      "date": "2023-06-01",
+      "security_id": "plan_security_02",
+      "stock_plan_id": "stock_plan_02",
+      "reason_text": "Cancelled RSUs returned to 2023 plan pool",
+      "quantity": "50000"
+    },
+    {
+      "id": "psi_03",
+      "object_type": "TX_PLAN_SECURITY_ISSUANCE",
+      "date": "2023-07-01",
+      "security_id": "plan_security_03",
+      "custom_id": "PS-3",
+      "stakeholder_id": "emilyEmployee",
+      "security_law_exemptions": [],
+      "stock_plan_id": "stock_plan_02",
+      "stock_class_id": "ordinaryB",
+      "quantity": "30000",
+      "compensation_type": "RSU",
+      "option_grant_type": "NSO",
+      "expiration_date": null,
+      "termination_exercise_windows": []
+    },
+    {
+      "id": "psr_01",
+      "object_type": "TX_PLAN_SECURITY_RETRACTION",
+      "date": "2023-07-02",
+      "security_id": "plan_security_03",
+      "reason_text": "Grant issued in error"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds two stock plans to the acme_holdings_limited sample dataset (2019 Stock Option Plan, 2023 Equity Incentive Plan)
- Adds pool adjustments (plan 1 increased to 2.5M shares, plan 2 decreased to 400K)
- Adds plan security lifecycle transactions: issuances, acceptance, cancellation, retraction
- Adds return-to-pool event after cancellation
- Updates manifest to reference new StockPlans.ocf.json
- Fixes the existing gap where equity compensation issuances reference `stock_plan_01` but no stock plan object existed

## Stack
PR 1/6 — base of the stack. Merge this first.

## Test plan
- [x] All existing tests still pass
- Sample data can be validated by loading with `readOcfPackage`

Closes #65