### PR TITLE
Add canonical vesting compiler and structural validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,18 +34,37 @@ const snapshot = ocfSnapshot(ocfPackageFolderDir, ocfSnapshotDate);
 
 ## Compile Vesting
 
-This tool compiles a canonical [`VestingScheduleTemplate`](https://github.com/Open-Cap-Table-Coalition/OCF-Composed-Schemas/tree/main/canonical/vesting) plus a `VestingSchedule` and a total share count into the OCF projection layer: an array of `{ date, amount }` vesting events. Supports time-based vesting with optional cliff under `CUMULATIVE_ROUND_DOWN` allocation (no event-based logic, milestones, or acceleration).
+This tool compiles a canonical [`VestingScheduleTemplate`](https://github.com/Open-Cap-Table-Coalition/OCF-Composed-Schemas/tree/main/canonical/vesting) plus per-grant runtime data into the OCF projection layer: an array of `{ date, amount }` vesting events. Supports both DATE-anchored (time-based) and EVENT-anchored (named-event triggered) statements, with optional cliff and optional partial-payout fractions on event firings, under `CUMULATIVE_ROUND_DOWN` allocation.
 
 ```ts
-const events = compileVesting(template, schedule, totalShares);
-const events = compileVesting(template, schedule, totalShares, grantDate);
+const events = compileVesting(template, totalShares, runtime);
 ```
 
-**Grant date (optional fourth argument).** When `grantDate` is provided, any events whose computed date falls before it are held back and emitted as a single aggregated event on `grantDate` itself — an implicit cliff at the grant date. This models the common case of vesting backdated to a hire date earlier than the actual grant approval. When omitted, the schedule runs unconstrained from `start_date`.
+Where `runtime` is:
 
-**Structural validator.** The same package exports `validateVestingScheduleTemplate(t)` and `validateVestingSchedule(s)` (plus assert-wrapper variants), which return `{ valid, errors[] }` for a canonical spec object. `compileVesting` calls these internally; downstream consumers (such as the OCF validator) can call them directly to produce their own structured reports.
+```ts
+interface VestingRuntime {
+  startDate?: OCFDate;        // anchor for DATE-anchored statements
+  eventFirings?: Array<{      // anchors for EVENT-anchored statements
+    event_id: string;
+    date: OCFDate;
+    realized_fraction?: Fraction;  // partial-payout scaling, defaults to 1
+  }>;
+  grantDate?: OCFDate;        // optional implicit cliff at the grant date
+}
+```
 
-**Day-of-month assumption.** The canonical spec does not currently carry a day-of-month policy. This compiler assumes OCF's `VESTING_START_DAY_OR_LAST_DAY_OF_MONTH` semantics: each event preserves the `start_date`'s day-of-month and clamps to the last day in shorter months (Jan 31 → Feb 28 → Mar 31 → …). Other OCF `VestingDayOfMonth` values (fixed numeric days, `*_OR_LAST_DAY_OF_MONTH` variants) are not supported. Revisit if/when the canonical spec adds a `day_of_month` field.
+These three fields correspond to the canonical-transaction inputs: `startDate` from `TX_CANONICAL_VESTING_START`, `eventFirings` from zero or more `TX_CANONICAL_VESTING_EVENT` transactions, and `grantDate` from `TX_CANONICAL_EQUITY_COMPENSATION_ISSUANCE.date`.
+
+**DATE vs EVENT statements.** Each `VestingStatement` carries a `vesting_base` discriminator. DATE statements chain by `order` from `runtime.startDate`. EVENT statements anchor at the firing date of the matching `event_id` (multiple statements may share an `event_id`; one firing fans out to all of them). Output events are sorted chronologically with `statement.order` as the tie-break.
+
+**Partial firings.** An EVENT firing may carry `realized_fraction`, which scales the matching statement's contribution multiplicatively (e.g., a 50%/grant statement firing at `realized_fraction: 3/10` vests 15% of the grant). EVENT statements whose `event_id` never fires are silently skipped — the grant ends with that portion unvested.
+
+**Grant date.** When `runtime.grantDate` is provided, any events whose computed date falls before it are held back and emitted as a single aggregated event on `grantDate` itself — an implicit cliff at the grant date. This models the common case of vesting backdated to a hire date earlier than the actual grant approval. Applies uniformly to DATE and EVENT events.
+
+**Structural validator.** The same package exports `validateVestingScheduleTemplate(t)` and `validateVestingRuntime(runtime, template)` (plus assert-wrapper variants), which return `{ valid, errors[] }` for canonical inputs. `compileVesting` calls these internally; downstream consumers (such as the OCF validator) can call them directly to produce their own structured reports.
+
+**Day-of-month assumption.** The canonical spec does not currently carry a day-of-month policy. This compiler assumes OCF's `VESTING_START_DAY_OR_LAST_DAY_OF_MONTH` semantics: each event preserves the anchor date's day-of-month and clamps to the last day in shorter months (Jan 31 → Feb 28 → Mar 31 → …). Other OCF `VestingDayOfMonth` values (fixed numeric days, `*_OR_LAST_DAY_OF_MONTH` variants) are not supported. Revisit if/when the canonical spec adds a `day_of_month` field.
 
 ## How to use the toolset
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Date: 01 April 2026
 
 A growing toolset to help validate and utilize Open Cap Table Format datasets.
 
-Currently, the toolset includes 3 tools:
+Currently, the toolset includes 4 tools:
 
 ## Read OCF Package
 
@@ -32,6 +32,21 @@ This tool allows the user to see the outstanding captable of a OCF package on a 
 const snapshot = ocfSnapshot(ocfPackageFolderDir, ocfSnapshotDate);
 ```
 
+## Compile Vesting
+
+This tool compiles a canonical [`VestingScheduleTemplate`](https://github.com/Open-Cap-Table-Coalition/OCF-Composed-Schemas/tree/main/canonical/vesting) plus a `VestingSchedule` and a total share count into the OCF projection layer: an array of `{ date, amount }` vesting events. Supports time-based vesting with optional cliff under `CUMULATIVE_ROUND_DOWN` allocation (no event-based logic, milestones, or acceleration).
+
+```ts
+const events = compileVesting(template, schedule, totalShares);
+const events = compileVesting(template, schedule, totalShares, grantDate);
+```
+
+**Grant date (optional fourth argument).** When `grantDate` is provided, any events whose computed date falls before it are held back and emitted as a single aggregated event on `grantDate` itself — an implicit cliff at the grant date. This models the common case of vesting backdated to a hire date earlier than the actual grant approval. When omitted, the schedule runs unconstrained from `start_date`.
+
+**Structural validator.** The same package exports `validateVestingScheduleTemplate(t)` and `validateVestingSchedule(s)` (plus assert-wrapper variants), which return `{ valid, errors[] }` for a canonical spec object. `compileVesting` calls these internally; downstream consumers (such as the OCF validator) can call them directly to produce their own structured reports.
+
+**Day-of-month assumption.** The canonical spec does not currently carry a day-of-month policy. This compiler assumes OCF's `VESTING_START_DAY_OR_LAST_DAY_OF_MONTH` semantics: each event preserves the `start_date`'s day-of-month and clamps to the last day in shorter months (Jan 31 → Feb 28 → Mar 31 → …). Other OCF `VestingDayOfMonth` values (fixed numeric days, `*_OR_LAST_DAY_OF_MONTH` variants) are not supported. Revisit if/when the canonical spec adds a `day_of_month` field.
+
 ## How to use the toolset
 
 ### (before publication to NPM)
@@ -39,5 +54,5 @@ const snapshot = ocfSnapshot(ocfPackageFolderDir, ocfSnapshotDate);
 Download this repository and run `npm i; npm run build; npm link;`
 
 In the project that you want to use ocf-tools, run `npm link ocf-tools` and add
-`const { readOcfPackage, ocfValidator, ocfSnapshot } = require("ocf-tools");`
+`const { readOcfPackage, ocfValidator, ocfSnapshot, compileVesting } = require("ocf-tools");`
 to the top of the file you want to use the ocf-tools in.

--- a/index.ts
+++ b/index.ts
@@ -1,9 +1,11 @@
 import { readOcfPackage } from "./read_ocf_package";
 import { ocfValidator } from "./ocf_validator";
 import { ocfSnapshot } from "./ocf_snapshot";
+import { compileVesting } from "./vesting_compiler";
 
 module.exports = {
   readOcfPackage,
   ocfValidator,
   ocfSnapshot,
+  compileVesting,
 };

--- a/ocf_validator/validators/vesting/ts_vesting_event.ts
+++ b/ocf_validator/validators/vesting/ts_vesting_event.ts
@@ -1,3 +1,12 @@
+// TODO: Once OcfPackageContent carries canonical VestingScheduleTemplate (see
+// PR2: migrate-to-canonical-vesting), fill this in by:
+//   1. Looking up the grant by event.data.security_id in context.equityCompensation
+//   2. Looking up the referenced template in context.vestingScheduleTemplates
+//   3. Validating the template structurally via validateVestingScheduleTemplate
+//      from ../../../vesting_compiler (or its assert variant)
+//   4. Calling compileVesting(template, schedule, totalShares, grantDate) and
+//      asserting the recorded event matches an entry in the compiled stream
+// Build the report in the established pattern: named *_validity boolean per check.
 const valid_tx_vesting_event = (context: any, event: any) => {
   let valid = false;
   valid = true;

--- a/ocf_validator/validators/vesting/ts_vesting_start.ts
+++ b/ocf_validator/validators/vesting/ts_vesting_start.ts
@@ -1,3 +1,9 @@
+// TODO: Once OcfPackageContent carries canonical VestingScheduleTemplate (see
+// PR2: migrate-to-canonical-vesting), this transaction type is likely redundant
+// — VestingSchedule.start_date carries the start anchor directly, and there is
+// no condition_id to reference under the canonical model. Either delete this
+// validator + the transaction type, or trim it to a minimal "references a
+// known grant" check.
 const valid_tx_vesting_start = (context: any, event: any) => {
   let valid = false;
   valid = true;

--- a/types/canonical/vesting/index.ts
+++ b/types/canonical/vesting/index.ts
@@ -1,0 +1,1 @@
+export * from "./types";

--- a/types/canonical/vesting/types.ts
+++ b/types/canonical/vesting/types.ts
@@ -1,0 +1,44 @@
+// Port of canonical vesting types from OCF-Composed-Schemas:
+// https://github.com/Open-Cap-Table-Coalition/OCF-Composed-Schemas/blob/main/canonical/vesting/types.ts
+//
+// Divergence from OCF: the canonical spec does NOT carry a day_of_month field
+// equivalent to OCF's VestingDayOfMonth enum. The compileVesting function
+// assumes VESTING_START_DAY_OR_LAST_DAY_OF_MONTH semantics — see
+// /vesting_compiler/dates.ts for the implementation. Revisit if the canonical
+// spec is extended.
+
+// ─── OCF types we $ref ───────────────────────────────────────
+// From types/Date.schema.json: ISO 8601 YYYY-MM-DD
+export type OCFDate = string;
+
+// From enums/PeriodType.schema.json
+export type PeriodType = "DAYS" | "MONTHS" | "YEARS";
+
+export interface VestingSchedule {
+  template_id: string; // refs a VestingScheduleTemplate
+  start_date: OCFDate;
+}
+
+export interface VestingScheduleTemplate {
+  id: string;
+  statements: VestingStatement[]; // chained implicitly by order
+}
+
+export interface VestingStatement {
+  order: number; // 1-based sequence position
+  occurrences: number; // integer >= 1; number of vesting events in segment
+  period: number; // integer >= 0; length of one installment, in period_type units
+  period_type: PeriodType;
+  cliff?: Cliff;
+  percentage: Fraction; // share of total grant this vesting statement covers
+}
+
+export interface Fraction {
+  numerator: number; // integer
+  denominator: number; // integer >= 1
+}
+
+export interface Cliff {
+  occurrence: number; // 1-indexed installment at which the cliff applies (must be <= containing statement's occurrences)
+  percentage: Fraction; // share of the statement that vests at cliff
+}

--- a/types/canonical/vesting/types.ts
+++ b/types/canonical/vesting/types.ts
@@ -14,23 +14,38 @@ export type OCFDate = string;
 // From enums/PeriodType.schema.json
 export type PeriodType = "DAYS" | "MONTHS" | "YEARS";
 
-export interface VestingSchedule {
-  template_id: string; // refs a VestingScheduleTemplate
-  start_date: OCFDate;
-}
-
 export interface VestingScheduleTemplate {
   id: string;
-  statements: VestingStatement[]; // chained implicitly by order
+  statements: VestingStatement[]; // chained implicitly by order (DATE statements only)
 }
 
 export interface VestingStatement {
   order: number; // 1-based sequence position
+  vesting_base: VestingBase; // anchor: per-grant date (DATE) or named event (EVENT)
   occurrences: number; // integer >= 1; number of vesting events in segment
   period: number; // integer >= 0; length of one installment, in period_type units
   period_type: PeriodType;
   cliff?: Cliff;
   percentage: Fraction; // share of total grant this vesting statement covers
+}
+
+// Discriminated union for how a VestingStatement's schedule is anchored.
+// DATE-anchored statements take their start from a per-grant date supplied
+// out-of-band (in OCF-Tools, via VestingRuntime.startDate). EVENT-anchored
+// statements anchor to the firing date of a named event (in OCF-Tools, via
+// VestingRuntime.eventFirings). The event's definition (what it means, how
+// it's achieved) is not modeled here; the consumer maintains that out-of-band.
+// Multiple statements may reference the same event_id — a single firing fans
+// out to all matching statements.
+export type VestingBase = VestingBaseDate | VestingBaseEvent;
+
+export interface VestingBaseDate {
+  type: "DATE";
+}
+
+export interface VestingBaseEvent {
+  type: "EVENT";
+  event_id: string;
 }
 
 export interface Fraction {

--- a/types/index.ts
+++ b/types/index.ts
@@ -134,7 +134,7 @@ export interface VestingTerms {
   vesting_conditions: VestingCondition[];
 }
 
-export interface vestingObject {
+export interface Vesting {
   date: string;
   amount: string;
 }
@@ -215,7 +215,7 @@ export interface TX_Equity_Compensation_Issuance {
   };
   early_exercisable?: boolean;
   vesting_terms_id?: string;
-  vestings?: vestingObject[];
+  vestings?: Vesting[];
   expiration_date: string | null;
   termination_exercise_windows: {
     reason:

--- a/vesting_compiler/__tests__/allocate.test.ts
+++ b/vesting_compiler/__tests__/allocate.test.ts
@@ -1,0 +1,91 @@
+import { allocate, floorSharesAt } from "../allocate";
+import type { Allocation_Type } from "../../types";
+
+describe("floorSharesAt", () => {
+  it("floor(100000 × 3/10) = 30000", () => {
+    expect(floorSharesAt(100_000, { numerator: 3, denominator: 10 })).toBe(
+      30_000,
+    );
+  });
+
+  it("floor(100 × 1/3) = 33", () => {
+    expect(floorSharesAt(100, { numerator: 1, denominator: 3 })).toBe(33);
+  });
+
+  it("floor(100000 × 1/1) = 100000", () => {
+    expect(floorSharesAt(100_000, { numerator: 1, denominator: 1 })).toBe(
+      100_000,
+    );
+  });
+
+  it("floor of zero is zero", () => {
+    expect(floorSharesAt(100_000, { numerator: 0, denominator: 1 })).toBe(0);
+  });
+});
+
+describe("allocate", () => {
+  describe("CUMULATIVE_ROUND_DOWN", () => {
+    it("returns floor(totalShares × cumulative) − vestedSoFar", () => {
+      expect(
+        allocate(
+          "CUMULATIVE_ROUND_DOWN",
+          100_000,
+          { numerator: 1, denominator: 4 },
+          0,
+        ),
+      ).toBe(25_000);
+    });
+
+    it("subtracts what's already been emitted (telescoping)", () => {
+      // 100,000 × 13/48 = 27083 floored. Already emitted 25,000.
+      expect(
+        allocate(
+          "CUMULATIVE_ROUND_DOWN",
+          100_000,
+          { numerator: 13, denominator: 48 },
+          25_000,
+        ),
+      ).toBe(2_083);
+    });
+
+    it("emits totalShares − vestedSoFar when cumulative reaches 1/1", () => {
+      expect(
+        allocate(
+          "CUMULATIVE_ROUND_DOWN",
+          1_000,
+          { numerator: 1, denominator: 1 },
+          979,
+        ),
+      ).toBe(21);
+    });
+
+    it("emits 0 when the floor hasn't advanced (drift case)", () => {
+      // 1 × 1/48 = 0.02… → floor = 0. No emission.
+      expect(
+        allocate(
+          "CUMULATIVE_ROUND_DOWN",
+          1,
+          { numerator: 1, denominator: 48 },
+          0,
+        ),
+      ).toBe(0);
+    });
+  });
+
+  describe("unimplemented modes", () => {
+    const modes: Exclude<Allocation_Type, "CUMULATIVE_ROUND_DOWN">[] = [
+      "CUMULATIVE_ROUNDING",
+      "FRONT_LOADED",
+      "BACK_LOADED",
+      "FRONT_LOADED_TO_SINGLE_TRANCHE",
+      "BACK_LOADED_TO_SINGLE_TRANCHE",
+      "FRACTIONAL",
+    ];
+
+    it.each(modes)("throws on %s", (mode) => {
+      expect(() =>
+        allocate(mode, 100, { numerator: 1, denominator: 4 }, 0),
+      ).toThrow(/not yet implemented/);
+    });
+  });
+});

--- a/vesting_compiler/__tests__/compile.test.ts
+++ b/vesting_compiler/__tests__/compile.test.ts
@@ -1,16 +1,11 @@
-import { compileVesting } from "../compile";
-import type {
-  VestingSchedule,
-  VestingScheduleTemplate,
-} from "../../types/canonical/vesting";
+import { compileVesting, type VestingRuntime } from "../compile";
+import type { VestingScheduleTemplate } from "../../types/canonical/vesting";
 
 const sumAmounts = (events: { amount: string }[]): number =>
   events.reduce((acc, e) => acc + Number(e.amount), 0);
 
-const schedule: VestingSchedule = {
-  template_id: "t1",
-  start_date: "2025-01-01",
-};
+const DATE_BASE = { type: "DATE" as const };
+const startJan2025: VestingRuntime = { startDate: "2025-01-01" };
 
 describe("compileVesting — standard 4yr/1mo with 25% cliff", () => {
   const template: VestingScheduleTemplate = {
@@ -18,6 +13,7 @@ describe("compileVesting — standard 4yr/1mo with 25% cliff", () => {
     statements: [
       {
         order: 1,
+        vesting_base: DATE_BASE,
         occurrences: 48,
         period: 1,
         period_type: "MONTHS",
@@ -28,32 +24,32 @@ describe("compileVesting — standard 4yr/1mo with 25% cliff", () => {
   };
 
   it("emits 37 events: 1 cliff + 36 post-cliff", () => {
-    const events = compileVesting(template, schedule, 100_000);
+    const events = compileVesting(template, 100_000, startJan2025);
     expect(events).toHaveLength(37);
   });
 
   it("first event is the cliff at month 12 vesting 25000", () => {
-    const events = compileVesting(template, schedule, 100_000);
+    const events = compileVesting(template, 100_000, startJan2025);
     expect(events[0]).toEqual({ date: "2026-01-01", amount: "25000" });
   });
 
   it("last event lands at start + 48 months", () => {
-    const events = compileVesting(template, schedule, 100_000);
+    const events = compileVesting(template, 100_000, startJan2025);
     expect(events[events.length - 1].date).toBe("2029-01-01");
   });
 
   it("sum equals totalShares exactly", () => {
-    const events = compileVesting(template, schedule, 100_000);
+    const events = compileVesting(template, 100_000, startJan2025);
     expect(sumAmounts(events)).toBe(100_000);
   });
 
   it("absorbs rounding drift with an awkward share count", () => {
-    const events = compileVesting(template, schedule, 100);
+    const events = compileVesting(template, 100, startJan2025);
     expect(sumAmounts(events)).toBe(100);
   });
 
   it("emits exactly one share at the final event when totalShares = 1", () => {
-    const events = compileVesting(template, schedule, 1);
+    const events = compileVesting(template, 1, startJan2025);
     expect(events).toHaveLength(1);
     expect(events[0]).toEqual({ date: "2029-01-01", amount: "1" });
   });
@@ -65,6 +61,7 @@ describe("compileVesting — non-standard 30% cliff", () => {
     statements: [
       {
         order: 1,
+        vesting_base: DATE_BASE,
         occurrences: 48,
         period: 1,
         period_type: "MONTHS",
@@ -78,12 +75,12 @@ describe("compileVesting — non-standard 30% cliff", () => {
   };
 
   it("cliff event vests 30000 (30% of 100000)", () => {
-    const events = compileVesting(template, schedule, 100_000);
+    const events = compileVesting(template, 100_000, startJan2025);
     expect(events[0]).toEqual({ date: "2026-01-01", amount: "30000" });
   });
 
   it("emits 37 events with sum equal to totalShares", () => {
-    const events = compileVesting(template, schedule, 100_000);
+    const events = compileVesting(template, 100_000, startJan2025);
     expect(events).toHaveLength(37);
     expect(sumAmounts(events)).toBe(100_000);
   });
@@ -95,6 +92,7 @@ describe("compileVesting — bespoke 5/15/40/40 chained over 4 years", () => {
     statements: [
       {
         order: 1,
+        vesting_base: DATE_BASE,
         occurrences: 1,
         period: 12,
         period_type: "MONTHS",
@@ -102,6 +100,7 @@ describe("compileVesting — bespoke 5/15/40/40 chained over 4 years", () => {
       },
       {
         order: 2,
+        vesting_base: DATE_BASE,
         occurrences: 1,
         period: 12,
         period_type: "MONTHS",
@@ -109,6 +108,7 @@ describe("compileVesting — bespoke 5/15/40/40 chained over 4 years", () => {
       },
       {
         order: 3,
+        vesting_base: DATE_BASE,
         occurrences: 1,
         period: 12,
         period_type: "MONTHS",
@@ -116,6 +116,7 @@ describe("compileVesting — bespoke 5/15/40/40 chained over 4 years", () => {
       },
       {
         order: 4,
+        vesting_base: DATE_BASE,
         occurrences: 1,
         period: 12,
         period_type: "MONTHS",
@@ -124,8 +125,10 @@ describe("compileVesting — bespoke 5/15/40/40 chained over 4 years", () => {
     ],
   };
 
+  // Regression for DATE statement chaining via dateCursor: each statement
+  // anchors at the previous statement's end (not at runtime.startDate).
   it("emits 4 yearly events with chained dates and 5/15/40/40 split", () => {
-    const events = compileVesting(template, schedule, 100_000);
+    const events = compileVesting(template, 100_000, startJan2025);
     expect(events).toEqual([
       { date: "2026-01-01", amount: "5000" },
       { date: "2027-01-01", amount: "15000" },
@@ -135,13 +138,14 @@ describe("compileVesting — bespoke 5/15/40/40 chained over 4 years", () => {
   });
 });
 
-describe("compileVesting — additional cases", () => {
+describe("compileVesting — additional DATE-anchored cases", () => {
   it("plain 4-year monthly with no cliff emits 48 events summing to totalShares", () => {
     const template: VestingScheduleTemplate = {
       id: "t1",
       statements: [
         {
           order: 1,
+          vesting_base: DATE_BASE,
           occurrences: 48,
           period: 1,
           period_type: "MONTHS",
@@ -149,7 +153,7 @@ describe("compileVesting — additional cases", () => {
         },
       ],
     };
-    const events = compileVesting(template, schedule, 100_000);
+    const events = compileVesting(template, 100_000, startJan2025);
     expect(events).toHaveLength(48);
     expect(sumAmounts(events)).toBe(100_000);
     expect(events[0].date).toBe("2025-02-01");
@@ -162,6 +166,7 @@ describe("compileVesting — additional cases", () => {
       statements: [
         {
           order: 1,
+          vesting_base: DATE_BASE,
           occurrences: 12,
           period: 1,
           period_type: "MONTHS",
@@ -173,7 +178,7 @@ describe("compileVesting — additional cases", () => {
         },
       ],
     };
-    const events = compileVesting(template, schedule, 100_000);
+    const events = compileVesting(template, 100_000, startJan2025);
     expect(events).toEqual([{ date: "2026-01-01", amount: "100000" }]);
   });
 
@@ -183,6 +188,7 @@ describe("compileVesting — additional cases", () => {
       statements: [
         {
           order: 1,
+          vesting_base: DATE_BASE,
           occurrences: 4,
           period: 7,
           period_type: "DAYS",
@@ -190,7 +196,7 @@ describe("compileVesting — additional cases", () => {
         },
       ],
     };
-    const events = compileVesting(template, schedule, 400);
+    const events = compileVesting(template, 400, startJan2025);
     expect(events.map((e) => e.date)).toEqual([
       "2025-01-08",
       "2025-01-15",
@@ -206,6 +212,7 @@ describe("compileVesting — additional cases", () => {
       statements: [
         {
           order: 1,
+          vesting_base: DATE_BASE,
           occurrences: 6,
           period: 1,
           period_type: "MONTHS",
@@ -213,11 +220,7 @@ describe("compileVesting — additional cases", () => {
         },
       ],
     };
-    const events = compileVesting(
-      template,
-      { template_id: "t1", start_date: "2025-01-31" },
-      600,
-    );
+    const events = compileVesting(template, 600, { startDate: "2025-01-31" });
     expect(events.map((e) => e.date)).toEqual([
       "2025-02-28",
       "2025-03-31",
@@ -234,6 +237,7 @@ describe("compileVesting — additional cases", () => {
       statements: [
         {
           order: 1,
+          vesting_base: DATE_BASE,
           occurrences: 1,
           period: 12,
           period_type: "MONTHS",
@@ -241,6 +245,7 @@ describe("compileVesting — additional cases", () => {
         },
         {
           order: 2,
+          vesting_base: DATE_BASE,
           occurrences: 1,
           period: 12,
           period_type: "MONTHS",
@@ -252,8 +257,8 @@ describe("compileVesting — additional cases", () => {
       id: "t1",
       statements: [ordered.statements[1], ordered.statements[0]],
     };
-    expect(compileVesting(ordered, schedule, 100)).toEqual(
-      compileVesting(reversed, schedule, 100),
+    expect(compileVesting(ordered, 100, startJan2025)).toEqual(
+      compileVesting(reversed, 100, startJan2025),
     );
   });
 
@@ -263,6 +268,7 @@ describe("compileVesting — additional cases", () => {
       statements: [
         {
           order: 1,
+          vesting_base: DATE_BASE,
           occurrences: 1,
           period: 12,
           period_type: "MONTHS",
@@ -270,6 +276,7 @@ describe("compileVesting — additional cases", () => {
         },
         {
           order: 2,
+          vesting_base: DATE_BASE,
           occurrences: 1,
           period: 12,
           period_type: "MONTHS",
@@ -277,7 +284,7 @@ describe("compileVesting — additional cases", () => {
         },
       ],
     };
-    const events = compileVesting(template, schedule, 100);
+    const events = compileVesting(template, 100, startJan2025);
     expect(events).toEqual([{ date: "2027-01-01", amount: "100" }]);
   });
 
@@ -287,6 +294,7 @@ describe("compileVesting — additional cases", () => {
       statements: [
         {
           order: 1,
+          vesting_base: DATE_BASE,
           occurrences: 1,
           period: 12,
           period_type: "MONTHS",
@@ -294,17 +302,18 @@ describe("compileVesting — additional cases", () => {
         },
       ],
     };
-    expect(() => compileVesting(template, schedule, -1)).toThrow();
-    expect(() => compileVesting(template, schedule, 1.5)).toThrow();
+    expect(() => compileVesting(template, -1, startJan2025)).toThrow();
+    expect(() => compileVesting(template, 1.5, startJan2025)).toThrow();
   });
 });
 
-describe("compileVesting — grant_date handling", () => {
+describe("compileVesting — grant_date handling (DATE-anchored)", () => {
   const monthlyNoCliff: VestingScheduleTemplate = {
     id: "t1",
     statements: [
       {
         order: 1,
+        vesting_base: DATE_BASE,
         occurrences: 48,
         period: 1,
         period_type: "MONTHS",
@@ -318,6 +327,7 @@ describe("compileVesting — grant_date handling", () => {
     statements: [
       {
         order: 1,
+        vesting_base: DATE_BASE,
         occurrences: 48,
         period: 1,
         period_type: "MONTHS",
@@ -328,7 +338,10 @@ describe("compileVesting — grant_date handling", () => {
   };
 
   it("grant_date before vesting_start has no effect", () => {
-    const events = compileVesting(monthlyNoCliff, schedule, 4800, "2023-06-01");
+    const events = compileVesting(monthlyNoCliff, 4800, {
+      startDate: "2025-01-01",
+      grantDate: "2023-06-01",
+    });
     expect(events).toHaveLength(48);
     expect(events[0].date).toBe("2025-02-01");
     expect(sumAmounts(events)).toBe(4800);
@@ -336,7 +349,10 @@ describe("compileVesting — grant_date handling", () => {
 
   it("grant_date equal to a scheduled event date merges held amount into that event", () => {
     // schedule.start_date = 2025-01-01 monthly; grant_date = 2025-04-01 (= event #3)
-    const events = compileVesting(monthlyNoCliff, schedule, 4800, "2025-04-01");
+    const events = compileVesting(monthlyNoCliff, 4800, {
+      startDate: "2025-01-01",
+      grantDate: "2025-04-01",
+    });
     // events #1 (Feb) and #2 (Mar) held; event #3 emits own 100 + held 200 = 300
     expect(events).toHaveLength(46);
     expect(events[0]).toEqual({ date: "2025-04-01", amount: "300" });
@@ -346,7 +362,10 @@ describe("compileVesting — grant_date handling", () => {
 
   it("grant_date between scheduled events emits an off-rhythm event on grant_date", () => {
     // grant_date = 2025-03-15 falls between events #2 (Mar 1) and #3 (Apr 1)
-    const events = compileVesting(monthlyNoCliff, schedule, 4800, "2025-03-15");
+    const events = compileVesting(monthlyNoCliff, 4800, {
+      startDate: "2025-01-01",
+      grantDate: "2025-03-15",
+    });
     // events #1 (Feb) and #2 (Mar) held = 200; emit on grant_date itself
     // then event #3 (Apr) emits normally
     expect(events).toHaveLength(47);
@@ -357,15 +376,10 @@ describe("compileVesting — grant_date handling", () => {
   });
 
   it("grant_date after explicit cliff absorbs cliff + intervening months", () => {
-    // vesting_start = 2023-01-01; cliff at month 12 = 2024-01-01 vesting 25%
-    // grant_date = 2024-06-01 — after the cliff
-    const earlierStart = { template_id: "t1", start_date: "2023-01-01" };
-    const events = compileVesting(
-      monthlyWithCliff,
-      earlierStart,
-      4800,
-      "2024-06-01",
-    );
+    const events = compileVesting(monthlyWithCliff, 4800, {
+      startDate: "2023-01-01",
+      grantDate: "2024-06-01",
+    });
     // cliff at 2024-01-01 vests 1200 — held
     // months 13-16 (2024-02..05) each vest 100 — held, total 400
     // month 17 (2024-06-01) == grant_date: emit own 100 + held 1600 = 1700
@@ -375,25 +389,18 @@ describe("compileVesting — grant_date handling", () => {
   });
 
   it("grant_date after the entire schedule emits the full grant on grant_date", () => {
-    const earlyStart = { template_id: "t1", start_date: "2020-01-01" };
-    const events = compileVesting(
-      monthlyNoCliff,
-      earlyStart,
-      4800,
-      "2030-01-01",
-    );
+    const events = compileVesting(monthlyNoCliff, 4800, {
+      startDate: "2020-01-01",
+      grantDate: "2030-01-01",
+    });
     expect(events).toEqual([{ date: "2030-01-01", amount: "4800" }]);
   });
 
   it("grant_date on the rhythm with a cliff exactly at grant_date", () => {
-    // vesting_start = 2025-01-01; cliff at month 12 = 2026-01-01 vesting 25%
-    // grant_date = 2026-01-01 — exactly on the cliff date
-    const events = compileVesting(
-      monthlyWithCliff,
-      schedule,
-      100_000,
-      "2026-01-01",
-    );
+    const events = compileVesting(monthlyWithCliff, 100_000, {
+      startDate: "2025-01-01",
+      grantDate: "2026-01-01",
+    });
     // cliff date == grant_date — pending stays 0, cliff event emits normally
     expect(events).toHaveLength(37);
     expect(events[0]).toEqual({ date: "2026-01-01", amount: "25000" });
@@ -401,23 +408,263 @@ describe("compileVesting — grant_date handling", () => {
   });
 
   it("preserves the held-back-pre-cliff filter under grant_date", () => {
-    // Pre-cliff months have share=0/1; they should still be skipped at amount===0,
-    // never entering the pre-grant accumulator.
-    const events = compileVesting(
-      monthlyWithCliff,
-      schedule,
-      100_000,
-      "2026-06-01",
-    );
-    // Pre-cliff months 1..11 contribute nothing.
-    // Cliff month 12 (2026-01-01) vests 25000, held by grant_date.
-    // Months 13..17 each vest ~1/48 * 100000 floor-rounded.
-    // Month 18 (2026-06-01) == grant_date — merges held into this event.
+    const events = compileVesting(monthlyWithCliff, 100_000, {
+      startDate: "2025-01-01",
+      grantDate: "2026-06-01",
+    });
     const sum = sumAmounts(events);
     expect(sum).toBe(100_000);
-    // No event should land before 2026-06-01
     for (const e of events) {
       expect(e.date >= "2026-06-01").toBe(true);
     }
+  });
+});
+
+describe("compileVesting — EVENT-anchored statements", () => {
+  it("single-event instantaneous vest of full grant", () => {
+    const template: VestingScheduleTemplate = {
+      id: "t1",
+      statements: [
+        {
+          order: 1,
+          vesting_base: { type: "EVENT", event_id: "ipo" },
+          occurrences: 1,
+          period: 0,
+          period_type: "MONTHS",
+          percentage: { numerator: 1, denominator: 1 },
+        },
+      ],
+    };
+    const events = compileVesting(template, 100_000, {
+      eventFirings: [{ event_id: "ipo", date: "2026-04-01" }],
+    });
+    expect(events).toEqual([{ date: "2026-04-01", amount: "100000" }]);
+  });
+
+  it("partial firing with realized_fraction scales the vested amount", () => {
+    const template: VestingScheduleTemplate = {
+      id: "t1",
+      statements: [
+        {
+          order: 1,
+          vesting_base: { type: "EVENT", event_id: "milestone" },
+          occurrences: 1,
+          period: 0,
+          period_type: "MONTHS",
+          percentage: { numerator: 1, denominator: 1 },
+        },
+      ],
+    };
+    const events = compileVesting(template, 100_000, {
+      eventFirings: [
+        {
+          event_id: "milestone",
+          date: "2026-04-01",
+          realized_fraction: { numerator: 3, denominator: 10 },
+        },
+      ],
+    });
+    expect(events).toEqual([{ date: "2026-04-01", amount: "30000" }]);
+  });
+
+  it("post-event monthly schedule (occurrences > 1) vests from firing date", () => {
+    const template: VestingScheduleTemplate = {
+      id: "t1",
+      statements: [
+        {
+          order: 1,
+          vesting_base: { type: "EVENT", event_id: "ipo" },
+          occurrences: 12,
+          period: 1,
+          period_type: "MONTHS",
+          percentage: { numerator: 1, denominator: 1 },
+        },
+      ],
+    };
+    const events = compileVesting(template, 1200, {
+      eventFirings: [{ event_id: "ipo", date: "2026-04-01" }],
+    });
+    expect(events).toHaveLength(12);
+    expect(events[0].date).toBe("2026-05-01");
+    expect(events[events.length - 1].date).toBe("2027-04-01");
+    expect(sumAmounts(events)).toBe(1200);
+  });
+
+  it("two statements referencing the same event_id both fire on a single firing", () => {
+    const template: VestingScheduleTemplate = {
+      id: "t1",
+      statements: [
+        {
+          order: 1,
+          vesting_base: { type: "EVENT", event_id: "ipo" },
+          occurrences: 1,
+          period: 0,
+          period_type: "MONTHS",
+          percentage: { numerator: 1, denominator: 4 },
+        },
+        {
+          order: 2,
+          vesting_base: { type: "EVENT", event_id: "ipo" },
+          occurrences: 1,
+          period: 0,
+          period_type: "MONTHS",
+          percentage: { numerator: 3, denominator: 4 },
+        },
+      ],
+    };
+    const events = compileVesting(template, 100_000, {
+      eventFirings: [{ event_id: "ipo", date: "2026-04-01" }],
+    });
+    // Two events both on 2026-04-01; tie-break by statement.order.
+    expect(events).toEqual([
+      { date: "2026-04-01", amount: "25000" },
+      { date: "2026-04-01", amount: "75000" },
+    ]);
+  });
+
+  it("EVENT statement with no matching firing is silently skipped", () => {
+    const template: VestingScheduleTemplate = {
+      id: "t1",
+      statements: [
+        {
+          order: 1,
+          vesting_base: { type: "EVENT", event_id: "ipo" },
+          occurrences: 1,
+          period: 0,
+          period_type: "MONTHS",
+          percentage: { numerator: 1, denominator: 1 },
+        },
+      ],
+    };
+    const events = compileVesting(template, 100_000, { eventFirings: [] });
+    expect(events).toEqual([]);
+  });
+
+  it("all EVENT statements unfired emits zero events with no error", () => {
+    const template: VestingScheduleTemplate = {
+      id: "t1",
+      statements: [
+        {
+          order: 1,
+          vesting_base: { type: "EVENT", event_id: "ipo" },
+          occurrences: 1,
+          period: 0,
+          period_type: "MONTHS",
+          percentage: { numerator: 1, denominator: 2 },
+        },
+        {
+          order: 2,
+          vesting_base: { type: "EVENT", event_id: "acquisition" },
+          occurrences: 1,
+          period: 0,
+          period_type: "MONTHS",
+          percentage: { numerator: 1, denominator: 2 },
+        },
+      ],
+    };
+    const events = compileVesting(template, 100_000, {});
+    expect(events).toEqual([]);
+  });
+});
+
+describe("compileVesting — hybrid DATE + EVENT templates", () => {
+  it("DATE statement chains through; EVENT statement adds a chronological event", () => {
+    // 90% on a 4yr/1mo schedule starting 2025-01-01; 10% bonus on "ipo" event.
+    const template: VestingScheduleTemplate = {
+      id: "t1",
+      statements: [
+        {
+          order: 1,
+          vesting_base: DATE_BASE,
+          occurrences: 48,
+          period: 1,
+          period_type: "MONTHS",
+          cliff: { occurrence: 12, percentage: { numerator: 1, denominator: 4 } },
+          percentage: { numerator: 9, denominator: 10 },
+        },
+        {
+          order: 2,
+          vesting_base: { type: "EVENT", event_id: "ipo" },
+          occurrences: 1,
+          period: 0,
+          period_type: "MONTHS",
+          percentage: { numerator: 1, denominator: 10 },
+        },
+      ],
+    };
+    const events = compileVesting(template, 100_000, {
+      startDate: "2025-01-01",
+      eventFirings: [{ event_id: "ipo", date: "2027-06-15" }],
+    });
+    expect(sumAmounts(events)).toBe(100_000);
+    // Cliff fires at 2026-01-01 (90% × 25% = 22500)
+    expect(events[0]).toEqual({ date: "2026-01-01", amount: "22500" });
+    // The IPO bonus appears chronologically interleaved with the monthly events.
+    const ipoEvent = events.find((e) => e.date === "2027-06-15");
+    expect(ipoEvent).toBeDefined();
+    expect(ipoEvent!.amount).toBe("10000");
+    // Output is in chronological order.
+    for (let i = 1; i < events.length; i++) {
+      expect(events[i].date >= events[i - 1].date).toBe(true);
+    }
+  });
+
+  it("EVENT firing before grant_date is aggregated onto grant_date", () => {
+    const template: VestingScheduleTemplate = {
+      id: "t1",
+      statements: [
+        {
+          order: 1,
+          vesting_base: { type: "EVENT", event_id: "early" },
+          occurrences: 1,
+          period: 0,
+          period_type: "MONTHS",
+          percentage: { numerator: 1, denominator: 2 },
+        },
+        {
+          order: 2,
+          vesting_base: { type: "EVENT", event_id: "late" },
+          occurrences: 1,
+          period: 0,
+          period_type: "MONTHS",
+          percentage: { numerator: 1, denominator: 2 },
+        },
+      ],
+    };
+    const events = compileVesting(template, 100_000, {
+      eventFirings: [
+        { event_id: "early", date: "2025-03-01" },
+        { event_id: "late", date: "2025-09-01" },
+      ],
+      grantDate: "2025-06-01",
+    });
+    // "early" fires 2025-03-01 (before grant) → 50000 held → emitted on grant_date
+    // "late" fires 2025-09-01 (after grant) → emitted normally
+    expect(events).toEqual([
+      { date: "2025-06-01", amount: "50000" },
+      { date: "2025-09-01", amount: "50000" },
+    ]);
+  });
+
+  it("EVENT firing on grant_date emits normally without held-back aggregation", () => {
+    const template: VestingScheduleTemplate = {
+      id: "t1",
+      statements: [
+        {
+          order: 1,
+          vesting_base: { type: "EVENT", event_id: "ipo" },
+          occurrences: 1,
+          period: 0,
+          period_type: "MONTHS",
+          percentage: { numerator: 1, denominator: 1 },
+        },
+      ],
+    };
+    const events = compileVesting(template, 100_000, {
+      eventFirings: [{ event_id: "ipo", date: "2026-04-01" }],
+      grantDate: "2026-04-01",
+    });
+    // Date == grantDate, but pending was 0, so this just emits normally.
+    expect(events).toEqual([{ date: "2026-04-01", amount: "100000" }]);
   });
 });

--- a/vesting_compiler/__tests__/compile.test.ts
+++ b/vesting_compiler/__tests__/compile.test.ts
@@ -1,0 +1,423 @@
+import { compileVesting } from "../compile";
+import type {
+  VestingSchedule,
+  VestingScheduleTemplate,
+} from "../../types/canonical/vesting";
+
+const sumAmounts = (events: { amount: string }[]): number =>
+  events.reduce((acc, e) => acc + Number(e.amount), 0);
+
+const schedule: VestingSchedule = {
+  template_id: "t1",
+  start_date: "2025-01-01",
+};
+
+describe("compileVesting — standard 4yr/1mo with 25% cliff", () => {
+  const template: VestingScheduleTemplate = {
+    id: "t1",
+    statements: [
+      {
+        order: 1,
+        occurrences: 48,
+        period: 1,
+        period_type: "MONTHS",
+        cliff: { occurrence: 12, percentage: { numerator: 1, denominator: 4 } },
+        percentage: { numerator: 1, denominator: 1 },
+      },
+    ],
+  };
+
+  it("emits 37 events: 1 cliff + 36 post-cliff", () => {
+    const events = compileVesting(template, schedule, 100_000);
+    expect(events).toHaveLength(37);
+  });
+
+  it("first event is the cliff at month 12 vesting 25000", () => {
+    const events = compileVesting(template, schedule, 100_000);
+    expect(events[0]).toEqual({ date: "2026-01-01", amount: "25000" });
+  });
+
+  it("last event lands at start + 48 months", () => {
+    const events = compileVesting(template, schedule, 100_000);
+    expect(events[events.length - 1].date).toBe("2029-01-01");
+  });
+
+  it("sum equals totalShares exactly", () => {
+    const events = compileVesting(template, schedule, 100_000);
+    expect(sumAmounts(events)).toBe(100_000);
+  });
+
+  it("absorbs rounding drift with an awkward share count", () => {
+    const events = compileVesting(template, schedule, 100);
+    expect(sumAmounts(events)).toBe(100);
+  });
+
+  it("emits exactly one share at the final event when totalShares = 1", () => {
+    const events = compileVesting(template, schedule, 1);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({ date: "2029-01-01", amount: "1" });
+  });
+});
+
+describe("compileVesting — non-standard 30% cliff", () => {
+  const template: VestingScheduleTemplate = {
+    id: "t1",
+    statements: [
+      {
+        order: 1,
+        occurrences: 48,
+        period: 1,
+        period_type: "MONTHS",
+        cliff: {
+          occurrence: 12,
+          percentage: { numerator: 3, denominator: 10 },
+        },
+        percentage: { numerator: 1, denominator: 1 },
+      },
+    ],
+  };
+
+  it("cliff event vests 30000 (30% of 100000)", () => {
+    const events = compileVesting(template, schedule, 100_000);
+    expect(events[0]).toEqual({ date: "2026-01-01", amount: "30000" });
+  });
+
+  it("emits 37 events with sum equal to totalShares", () => {
+    const events = compileVesting(template, schedule, 100_000);
+    expect(events).toHaveLength(37);
+    expect(sumAmounts(events)).toBe(100_000);
+  });
+});
+
+describe("compileVesting — bespoke 5/15/40/40 chained over 4 years", () => {
+  const template: VestingScheduleTemplate = {
+    id: "t1",
+    statements: [
+      {
+        order: 1,
+        occurrences: 1,
+        period: 12,
+        period_type: "MONTHS",
+        percentage: { numerator: 1, denominator: 20 },
+      },
+      {
+        order: 2,
+        occurrences: 1,
+        period: 12,
+        period_type: "MONTHS",
+        percentage: { numerator: 3, denominator: 20 },
+      },
+      {
+        order: 3,
+        occurrences: 1,
+        period: 12,
+        period_type: "MONTHS",
+        percentage: { numerator: 2, denominator: 5 },
+      },
+      {
+        order: 4,
+        occurrences: 1,
+        period: 12,
+        period_type: "MONTHS",
+        percentage: { numerator: 2, denominator: 5 },
+      },
+    ],
+  };
+
+  it("emits 4 yearly events with chained dates and 5/15/40/40 split", () => {
+    const events = compileVesting(template, schedule, 100_000);
+    expect(events).toEqual([
+      { date: "2026-01-01", amount: "5000" },
+      { date: "2027-01-01", amount: "15000" },
+      { date: "2028-01-01", amount: "40000" },
+      { date: "2029-01-01", amount: "40000" },
+    ]);
+  });
+});
+
+describe("compileVesting — additional cases", () => {
+  it("plain 4-year monthly with no cliff emits 48 events summing to totalShares", () => {
+    const template: VestingScheduleTemplate = {
+      id: "t1",
+      statements: [
+        {
+          order: 1,
+          occurrences: 48,
+          period: 1,
+          period_type: "MONTHS",
+          percentage: { numerator: 1, denominator: 1 },
+        },
+      ],
+    };
+    const events = compileVesting(template, schedule, 100_000);
+    expect(events).toHaveLength(48);
+    expect(sumAmounts(events)).toBe(100_000);
+    expect(events[0].date).toBe("2025-02-01");
+    expect(events[events.length - 1].date).toBe("2029-01-01");
+  });
+
+  it("cliff at last occurrence (K == N) emits a single event", () => {
+    const template: VestingScheduleTemplate = {
+      id: "t1",
+      statements: [
+        {
+          order: 1,
+          occurrences: 12,
+          period: 1,
+          period_type: "MONTHS",
+          cliff: {
+            occurrence: 12,
+            percentage: { numerator: 1, denominator: 1 },
+          },
+          percentage: { numerator: 1, denominator: 1 },
+        },
+      ],
+    };
+    const events = compileVesting(template, schedule, 100_000);
+    expect(events).toEqual([{ date: "2026-01-01", amount: "100000" }]);
+  });
+
+  it("DAYS schedule produces correct ISO dates", () => {
+    const template: VestingScheduleTemplate = {
+      id: "t1",
+      statements: [
+        {
+          order: 1,
+          occurrences: 4,
+          period: 7,
+          period_type: "DAYS",
+          percentage: { numerator: 1, denominator: 1 },
+        },
+      ],
+    };
+    const events = compileVesting(template, schedule, 400);
+    expect(events.map((e) => e.date)).toEqual([
+      "2025-01-08",
+      "2025-01-15",
+      "2025-01-22",
+      "2025-01-29",
+    ]);
+    expect(sumAmounts(events)).toBe(400);
+  });
+
+  it("preserves seed day across short months for an end-of-month start", () => {
+    const template: VestingScheduleTemplate = {
+      id: "t1",
+      statements: [
+        {
+          order: 1,
+          occurrences: 6,
+          period: 1,
+          period_type: "MONTHS",
+          percentage: { numerator: 1, denominator: 1 },
+        },
+      ],
+    };
+    const events = compileVesting(
+      template,
+      { template_id: "t1", start_date: "2025-01-31" },
+      600,
+    );
+    expect(events.map((e) => e.date)).toEqual([
+      "2025-02-28",
+      "2025-03-31",
+      "2025-04-30",
+      "2025-05-31",
+      "2025-06-30",
+      "2025-07-31",
+    ]);
+  });
+
+  it("sorts statements by order before processing", () => {
+    const ordered: VestingScheduleTemplate = {
+      id: "t1",
+      statements: [
+        {
+          order: 1,
+          occurrences: 1,
+          period: 12,
+          period_type: "MONTHS",
+          percentage: { numerator: 1, denominator: 2 },
+        },
+        {
+          order: 2,
+          occurrences: 1,
+          period: 12,
+          period_type: "MONTHS",
+          percentage: { numerator: 1, denominator: 2 },
+        },
+      ],
+    };
+    const reversed: VestingScheduleTemplate = {
+      id: "t1",
+      statements: [ordered.statements[1], ordered.statements[0]],
+    };
+    expect(compileVesting(ordered, schedule, 100)).toEqual(
+      compileVesting(reversed, schedule, 100),
+    );
+  });
+
+  it("zero-percent statement emits no events but advances the cursor", () => {
+    const template: VestingScheduleTemplate = {
+      id: "t1",
+      statements: [
+        {
+          order: 1,
+          occurrences: 1,
+          period: 12,
+          period_type: "MONTHS",
+          percentage: { numerator: 0, denominator: 1 },
+        },
+        {
+          order: 2,
+          occurrences: 1,
+          period: 12,
+          period_type: "MONTHS",
+          percentage: { numerator: 1, denominator: 1 },
+        },
+      ],
+    };
+    const events = compileVesting(template, schedule, 100);
+    expect(events).toEqual([{ date: "2027-01-01", amount: "100" }]);
+  });
+
+  it("throws when totalShares is not a non-negative integer", () => {
+    const template: VestingScheduleTemplate = {
+      id: "t1",
+      statements: [
+        {
+          order: 1,
+          occurrences: 1,
+          period: 12,
+          period_type: "MONTHS",
+          percentage: { numerator: 1, denominator: 1 },
+        },
+      ],
+    };
+    expect(() => compileVesting(template, schedule, -1)).toThrow();
+    expect(() => compileVesting(template, schedule, 1.5)).toThrow();
+  });
+});
+
+describe("compileVesting — grant_date handling", () => {
+  const monthlyNoCliff: VestingScheduleTemplate = {
+    id: "t1",
+    statements: [
+      {
+        order: 1,
+        occurrences: 48,
+        period: 1,
+        period_type: "MONTHS",
+        percentage: { numerator: 1, denominator: 1 },
+      },
+    ],
+  };
+
+  const monthlyWithCliff: VestingScheduleTemplate = {
+    id: "t1",
+    statements: [
+      {
+        order: 1,
+        occurrences: 48,
+        period: 1,
+        period_type: "MONTHS",
+        cliff: { occurrence: 12, percentage: { numerator: 1, denominator: 4 } },
+        percentage: { numerator: 1, denominator: 1 },
+      },
+    ],
+  };
+
+  it("grant_date before vesting_start has no effect", () => {
+    const events = compileVesting(monthlyNoCliff, schedule, 4800, "2023-06-01");
+    expect(events).toHaveLength(48);
+    expect(events[0].date).toBe("2025-02-01");
+    expect(sumAmounts(events)).toBe(4800);
+  });
+
+  it("grant_date equal to a scheduled event date merges held amount into that event", () => {
+    // schedule.start_date = 2025-01-01 monthly; grant_date = 2025-04-01 (= event #3)
+    const events = compileVesting(monthlyNoCliff, schedule, 4800, "2025-04-01");
+    // events #1 (Feb) and #2 (Mar) held; event #3 emits own 100 + held 200 = 300
+    expect(events).toHaveLength(46);
+    expect(events[0]).toEqual({ date: "2025-04-01", amount: "300" });
+    expect(events[1]).toEqual({ date: "2025-05-01", amount: "100" });
+    expect(sumAmounts(events)).toBe(4800);
+  });
+
+  it("grant_date between scheduled events emits an off-rhythm event on grant_date", () => {
+    // grant_date = 2025-03-15 falls between events #2 (Mar 1) and #3 (Apr 1)
+    const events = compileVesting(monthlyNoCliff, schedule, 4800, "2025-03-15");
+    // events #1 (Feb) and #2 (Mar) held = 200; emit on grant_date itself
+    // then event #3 (Apr) emits normally
+    expect(events).toHaveLength(47);
+    expect(events[0]).toEqual({ date: "2025-03-15", amount: "200" });
+    expect(events[1]).toEqual({ date: "2025-04-01", amount: "100" });
+    expect(events[events.length - 1].date).toBe("2029-01-01");
+    expect(sumAmounts(events)).toBe(4800);
+  });
+
+  it("grant_date after explicit cliff absorbs cliff + intervening months", () => {
+    // vesting_start = 2023-01-01; cliff at month 12 = 2024-01-01 vesting 25%
+    // grant_date = 2024-06-01 — after the cliff
+    const earlierStart = { template_id: "t1", start_date: "2023-01-01" };
+    const events = compileVesting(
+      monthlyWithCliff,
+      earlierStart,
+      4800,
+      "2024-06-01",
+    );
+    // cliff at 2024-01-01 vests 1200 — held
+    // months 13-16 (2024-02..05) each vest 100 — held, total 400
+    // month 17 (2024-06-01) == grant_date: emit own 100 + held 1600 = 1700
+    expect(events[0]).toEqual({ date: "2024-06-01", amount: "1700" });
+    expect(events[1]).toEqual({ date: "2024-07-01", amount: "100" });
+    expect(sumAmounts(events)).toBe(4800);
+  });
+
+  it("grant_date after the entire schedule emits the full grant on grant_date", () => {
+    const earlyStart = { template_id: "t1", start_date: "2020-01-01" };
+    const events = compileVesting(
+      monthlyNoCliff,
+      earlyStart,
+      4800,
+      "2030-01-01",
+    );
+    expect(events).toEqual([{ date: "2030-01-01", amount: "4800" }]);
+  });
+
+  it("grant_date on the rhythm with a cliff exactly at grant_date", () => {
+    // vesting_start = 2025-01-01; cliff at month 12 = 2026-01-01 vesting 25%
+    // grant_date = 2026-01-01 — exactly on the cliff date
+    const events = compileVesting(
+      monthlyWithCliff,
+      schedule,
+      100_000,
+      "2026-01-01",
+    );
+    // cliff date == grant_date — pending stays 0, cliff event emits normally
+    expect(events).toHaveLength(37);
+    expect(events[0]).toEqual({ date: "2026-01-01", amount: "25000" });
+    expect(sumAmounts(events)).toBe(100_000);
+  });
+
+  it("preserves the held-back-pre-cliff filter under grant_date", () => {
+    // Pre-cliff months have share=0/1; they should still be skipped at amount===0,
+    // never entering the pre-grant accumulator.
+    const events = compileVesting(
+      monthlyWithCliff,
+      schedule,
+      100_000,
+      "2026-06-01",
+    );
+    // Pre-cliff months 1..11 contribute nothing.
+    // Cliff month 12 (2026-01-01) vests 25000, held by grant_date.
+    // Months 13..17 each vest ~1/48 * 100000 floor-rounded.
+    // Month 18 (2026-06-01) == grant_date — merges held into this event.
+    const sum = sumAmounts(events);
+    expect(sum).toBe(100_000);
+    // No event should land before 2026-06-01
+    for (const e of events) {
+      expect(e.date >= "2026-06-01").toBe(true);
+    }
+  });
+});

--- a/vesting_compiler/__tests__/dates.test.ts
+++ b/vesting_compiler/__tests__/dates.test.ts
@@ -1,0 +1,59 @@
+import { addPeriod } from "../dates";
+
+describe("addPeriod", () => {
+  describe("MONTHS", () => {
+    it("adds whole months on a mid-month date", () => {
+      expect(addPeriod("2025-01-01", 12, "MONTHS")).toBe("2026-01-01");
+    });
+
+    it("clamps Jan 31 + 1 month to Feb 28 in a non-leap year", () => {
+      expect(addPeriod("2025-01-31", 1, "MONTHS")).toBe("2025-02-28");
+    });
+
+    it("clamps Jan 31 + 1 month to Feb 29 in a leap year", () => {
+      expect(addPeriod("2024-01-31", 1, "MONTHS")).toBe("2024-02-29");
+    });
+
+    it("preserves the seed day across short months when computed from root start", () => {
+      const start = "2025-01-31";
+      expect(addPeriod(start, 1, "MONTHS")).toBe("2025-02-28");
+      expect(addPeriod(start, 2, "MONTHS")).toBe("2025-03-31");
+      expect(addPeriod(start, 3, "MONTHS")).toBe("2025-04-30");
+      expect(addPeriod(start, 4, "MONTHS")).toBe("2025-05-31");
+      expect(addPeriod(start, 5, "MONTHS")).toBe("2025-06-30");
+      expect(addPeriod(start, 6, "MONTHS")).toBe("2025-07-31");
+    });
+
+    it("crosses year boundaries correctly", () => {
+      expect(addPeriod("2025-11-15", 3, "MONTHS")).toBe("2026-02-15");
+    });
+  });
+
+  describe("YEARS", () => {
+    it("adds whole years", () => {
+      expect(addPeriod("2025-01-01", 4, "YEARS")).toBe("2029-01-01");
+    });
+
+    it("clamps Feb 29 + 1 year to Feb 28", () => {
+      expect(addPeriod("2024-02-29", 1, "YEARS")).toBe("2025-02-28");
+    });
+  });
+
+  describe("DAYS", () => {
+    it("adds 365 days across a non-leap year", () => {
+      expect(addPeriod("2025-01-01", 365, "DAYS")).toBe("2026-01-01");
+    });
+
+    it("adds 366 days across a leap year", () => {
+      expect(addPeriod("2024-01-01", 366, "DAYS")).toBe("2025-01-01");
+    });
+
+    it("adds 7 days", () => {
+      expect(addPeriod("2025-03-01", 7, "DAYS")).toBe("2025-03-08");
+    });
+  });
+
+  it("rejects malformed ISO input", () => {
+    expect(() => addPeriod("2025/01/01", 1, "MONTHS")).toThrow();
+  });
+});

--- a/vesting_compiler/__tests__/fractions.test.ts
+++ b/vesting_compiler/__tests__/fractions.test.ts
@@ -1,0 +1,66 @@
+import { fracAdd, fracMul, fracReduce, fracSub } from "../fractions";
+
+describe("fracReduce", () => {
+  it("reduces 50/100 to 1/2", () => {
+    expect(fracReduce({ numerator: 50, denominator: 100 })).toEqual({
+      numerator: 1,
+      denominator: 2,
+    });
+  });
+
+  it("leaves an already-reduced fraction alone", () => {
+    expect(fracReduce({ numerator: 3, denominator: 7 })).toEqual({
+      numerator: 3,
+      denominator: 7,
+    });
+  });
+
+  it("reduces zero numerator to 0/1", () => {
+    expect(fracReduce({ numerator: 0, denominator: 48 })).toEqual({
+      numerator: 0,
+      denominator: 1,
+    });
+  });
+});
+
+describe("fracAdd", () => {
+  it("adds 1/4 + 1/48 = 13/48", () => {
+    expect(fracAdd({ numerator: 1, denominator: 4 }, { numerator: 1, denominator: 48 })).toEqual({
+      numerator: 13,
+      denominator: 48,
+    });
+  });
+
+  it("adds two halves to one", () => {
+    expect(fracAdd({ numerator: 1, denominator: 2 }, { numerator: 1, denominator: 2 })).toEqual({
+      numerator: 1,
+      denominator: 1,
+    });
+  });
+});
+
+describe("fracSub", () => {
+  it("computes 1 - 1/4 = 3/4", () => {
+    expect(fracSub({ numerator: 1, denominator: 1 }, { numerator: 1, denominator: 4 })).toEqual({
+      numerator: 3,
+      denominator: 4,
+    });
+  });
+});
+
+describe("fracMul", () => {
+  it("multiplies 3/10 by 1/1", () => {
+    expect(fracMul({ numerator: 3, denominator: 10 }, { numerator: 1, denominator: 1 })).toEqual({
+      numerator: 3,
+      denominator: 10,
+    });
+  });
+
+  it("multiplies 3/4 by 1/36 = 1/48", () => {
+    expect(fracMul({ numerator: 3, denominator: 4 }, { numerator: 1, denominator: 36 })).toEqual({
+      numerator: 1,
+      denominator: 48,
+    });
+  });
+});
+

--- a/vesting_compiler/__tests__/validate.test.ts
+++ b/vesting_compiler/__tests__/validate.test.ts
@@ -1,0 +1,384 @@
+import {
+  assertValidVestingSchedule,
+  assertValidVestingScheduleTemplate,
+  validateVestingSchedule,
+  validateVestingScheduleTemplate,
+} from "../validate";
+import type {
+  VestingSchedule,
+  VestingScheduleTemplate,
+  VestingStatement,
+} from "../../types/canonical/vesting";
+
+const goodStatement: VestingStatement = {
+  order: 1,
+  occurrences: 48,
+  period: 1,
+  period_type: "MONTHS",
+  cliff: { occurrence: 12, percentage: { numerator: 1, denominator: 4 } },
+  percentage: { numerator: 1, denominator: 1 },
+};
+
+const goodTemplate: VestingScheduleTemplate = {
+  id: "t1",
+  statements: [goodStatement],
+};
+
+const goodSchedule: VestingSchedule = {
+  template_id: "t1",
+  start_date: "2025-01-01",
+};
+
+describe("validateVestingScheduleTemplate", () => {
+  it("accepts a well-formed template", () => {
+    const result = validateVestingScheduleTemplate(goodTemplate);
+    expect(result).toEqual({ valid: true, errors: [] });
+  });
+
+  describe("id", () => {
+    it("rejects empty string", () => {
+      const result = validateVestingScheduleTemplate({ ...goodTemplate, id: "" });
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContainEqual({
+        path: "id",
+        message: "must be a non-empty string",
+      });
+    });
+
+    it("rejects non-string", () => {
+      const result = validateVestingScheduleTemplate({
+        ...goodTemplate,
+        id: 123 as unknown as string,
+      });
+      expect(result.valid).toBe(false);
+    });
+  });
+
+  describe("statements array", () => {
+    it("rejects empty array", () => {
+      const result = validateVestingScheduleTemplate({
+        ...goodTemplate,
+        statements: [],
+      });
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContainEqual({
+        path: "statements",
+        message: "must be a non-empty array",
+      });
+    });
+
+    it("rejects non-array", () => {
+      const result = validateVestingScheduleTemplate({
+        ...goodTemplate,
+        statements: "nope" as unknown as VestingStatement[],
+      });
+      expect(result.valid).toBe(false);
+    });
+
+    it("rejects duplicate orders", () => {
+      const result = validateVestingScheduleTemplate({
+        id: "t1",
+        statements: [
+          { ...goodStatement, order: 1 },
+          { ...goodStatement, order: 1 },
+        ],
+      });
+      expect(result.valid).toBe(false);
+      expect(result.errors).toContainEqual({
+        path: "statements",
+        message: "duplicate order 1 at indices [0, 1]",
+      });
+    });
+
+    it("accepts non-sequential but unique orders", () => {
+      const result = validateVestingScheduleTemplate({
+        id: "t1",
+        statements: [
+          { ...goodStatement, order: 5 },
+          { ...goodStatement, order: 2 },
+        ],
+      });
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  describe("statement.order", () => {
+    it("rejects 0", () => {
+      const result = validateVestingScheduleTemplate({
+        id: "t1",
+        statements: [{ ...goodStatement, order: 0 }],
+      });
+      expect(result.errors).toContainEqual({
+        path: "statements[0].order",
+        message: "must be an integer >= 1",
+      });
+    });
+
+    it("rejects non-integer", () => {
+      const result = validateVestingScheduleTemplate({
+        id: "t1",
+        statements: [{ ...goodStatement, order: 1.5 }],
+      });
+      expect(result.valid).toBe(false);
+    });
+  });
+
+  describe("statement.occurrences", () => {
+    it("rejects 0", () => {
+      const result = validateVestingScheduleTemplate({
+        id: "t1",
+        statements: [{ ...goodStatement, occurrences: 0 }],
+      });
+      expect(result.errors).toContainEqual({
+        path: "statements[0].occurrences",
+        message: "must be an integer >= 1",
+      });
+    });
+
+    it("rejects non-integer", () => {
+      const result = validateVestingScheduleTemplate({
+        id: "t1",
+        statements: [{ ...goodStatement, occurrences: 1.5 }],
+      });
+      expect(result.valid).toBe(false);
+    });
+  });
+
+  describe("statement.period", () => {
+    it("accepts 0", () => {
+      const result = validateVestingScheduleTemplate({
+        id: "t1",
+        statements: [{ ...goodStatement, cliff: undefined, period: 0 }],
+      });
+      expect(result.valid).toBe(true);
+    });
+
+    it("rejects negative", () => {
+      const result = validateVestingScheduleTemplate({
+        id: "t1",
+        statements: [{ ...goodStatement, period: -1 }],
+      });
+      expect(result.errors).toContainEqual({
+        path: "statements[0].period",
+        message: "must be an integer >= 0",
+      });
+    });
+
+    it("rejects non-integer", () => {
+      const result = validateVestingScheduleTemplate({
+        id: "t1",
+        statements: [{ ...goodStatement, period: 1.5 }],
+      });
+      expect(result.valid).toBe(false);
+    });
+  });
+
+  describe("statement.period_type", () => {
+    it("rejects invalid enum value", () => {
+      const result = validateVestingScheduleTemplate({
+        id: "t1",
+        statements: [
+          {
+            ...goodStatement,
+            period_type: "WEEKS" as unknown as VestingStatement["period_type"],
+          },
+        ],
+      });
+      expect(result.errors).toContainEqual({
+        path: "statements[0].period_type",
+        message: "must be one of DAYS, MONTHS, YEARS",
+      });
+    });
+
+    it.each(["DAYS", "MONTHS", "YEARS"] as const)("accepts %s", (pt) => {
+      const result = validateVestingScheduleTemplate({
+        id: "t1",
+        statements: [{ ...goodStatement, cliff: undefined, period_type: pt }],
+      });
+      expect(result.valid).toBe(true);
+    });
+  });
+
+  describe("statement.percentage", () => {
+    it("rejects non-integer numerator", () => {
+      const result = validateVestingScheduleTemplate({
+        id: "t1",
+        statements: [
+          { ...goodStatement, percentage: { numerator: 1.5, denominator: 2 } },
+        ],
+      });
+      expect(result.errors).toContainEqual({
+        path: "statements[0].percentage.numerator",
+        message: "must be an integer",
+      });
+    });
+
+    it("rejects denominator 0", () => {
+      const result = validateVestingScheduleTemplate({
+        id: "t1",
+        statements: [
+          { ...goodStatement, percentage: { numerator: 1, denominator: 0 } },
+        ],
+      });
+      expect(result.errors).toContainEqual({
+        path: "statements[0].percentage.denominator",
+        message: "must be an integer >= 1",
+      });
+    });
+
+    it("rejects negative denominator", () => {
+      const result = validateVestingScheduleTemplate({
+        id: "t1",
+        statements: [
+          { ...goodStatement, percentage: { numerator: 1, denominator: -2 } },
+        ],
+      });
+      expect(result.valid).toBe(false);
+    });
+  });
+
+  describe("statement.cliff", () => {
+    it("rejects occurrence > occurrences", () => {
+      const result = validateVestingScheduleTemplate({
+        id: "t1",
+        statements: [
+          {
+            ...goodStatement,
+            occurrences: 12,
+            cliff: { occurrence: 13, percentage: { numerator: 1, denominator: 4 } },
+          },
+        ],
+      });
+      expect(result.errors).toContainEqual({
+        path: "statements[0].cliff.occurrence",
+        message:
+          "must be <= statement.occurrences (got 13, occurrences=12)",
+      });
+    });
+
+    it("rejects occurrence 0", () => {
+      const result = validateVestingScheduleTemplate({
+        id: "t1",
+        statements: [
+          {
+            ...goodStatement,
+            cliff: { occurrence: 0, percentage: { numerator: 1, denominator: 4 } },
+          },
+        ],
+      });
+      expect(result.errors).toContainEqual({
+        path: "statements[0].cliff.occurrence",
+        message: "must be an integer >= 1",
+      });
+    });
+
+    it("rejects bad percentage", () => {
+      const result = validateVestingScheduleTemplate({
+        id: "t1",
+        statements: [
+          {
+            ...goodStatement,
+            cliff: { occurrence: 12, percentage: { numerator: 1, denominator: 0 } },
+          },
+        ],
+      });
+      expect(result.errors).toContainEqual({
+        path: "statements[0].cliff.percentage.denominator",
+        message: "must be an integer >= 1",
+      });
+    });
+  });
+
+  it("collects multiple errors at once", () => {
+    const result = validateVestingScheduleTemplate({
+      id: "",
+      statements: [
+        { ...goodStatement, order: 0, occurrences: 0 },
+      ],
+    });
+    expect(result.valid).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(2);
+    expect(result.errors.map((e) => e.path)).toEqual(
+      expect.arrayContaining([
+        "id",
+        "statements[0].order",
+        "statements[0].occurrences",
+      ]),
+    );
+  });
+
+  it("error paths include array indices for nested statements", () => {
+    const result = validateVestingScheduleTemplate({
+      id: "t1",
+      statements: [
+        goodStatement,
+        { ...goodStatement, order: 2, occurrences: 0 },
+      ],
+    });
+    expect(result.errors).toContainEqual({
+      path: "statements[1].occurrences",
+      message: "must be an integer >= 1",
+    });
+  });
+});
+
+describe("validateVestingSchedule", () => {
+  it("accepts a well-formed schedule", () => {
+    expect(validateVestingSchedule(goodSchedule)).toEqual({
+      valid: true,
+      errors: [],
+    });
+  });
+
+  describe("template_id", () => {
+    it("rejects empty string", () => {
+      const result = validateVestingSchedule({ ...goodSchedule, template_id: "" });
+      expect(result.errors).toContainEqual({
+        path: "template_id",
+        message: "must be a non-empty string",
+      });
+    });
+  });
+
+  describe("start_date", () => {
+    it("rejects non-ISO format", () => {
+      const result = validateVestingSchedule({ ...goodSchedule, start_date: "2025/01/01" });
+      expect(result.errors).toContainEqual({
+        path: "start_date",
+        message: "must be an ISO 8601 date string (YYYY-MM-DD)",
+      });
+    });
+
+    it("rejects garbage", () => {
+      const result = validateVestingSchedule({ ...goodSchedule, start_date: "not a date" });
+      expect(result.valid).toBe(false);
+    });
+  });
+});
+
+describe("assertValidVestingScheduleTemplate", () => {
+  it("does not throw on valid input", () => {
+    expect(() => assertValidVestingScheduleTemplate(goodTemplate)).not.toThrow();
+  });
+
+  it("throws with concatenated messages on invalid input", () => {
+    expect(() =>
+      assertValidVestingScheduleTemplate({
+        id: "",
+        statements: [{ ...goodStatement, occurrences: 0 }],
+      }),
+    ).toThrow(/Invalid VestingScheduleTemplate/);
+  });
+});
+
+describe("assertValidVestingSchedule", () => {
+  it("does not throw on valid input", () => {
+    expect(() => assertValidVestingSchedule(goodSchedule)).not.toThrow();
+  });
+
+  it("throws on invalid input", () => {
+    expect(() =>
+      assertValidVestingSchedule({ template_id: "", start_date: "bad" }),
+    ).toThrow(/Invalid VestingSchedule/);
+  });
+});

--- a/vesting_compiler/__tests__/validate.test.ts
+++ b/vesting_compiler/__tests__/validate.test.ts
@@ -1,17 +1,20 @@
 import {
-  assertValidVestingSchedule,
+  assertValidVestingRuntime,
   assertValidVestingScheduleTemplate,
-  validateVestingSchedule,
+  validateVestingRuntime,
   validateVestingScheduleTemplate,
 } from "../validate";
+import type { VestingRuntime } from "../compile";
 import type {
-  VestingSchedule,
   VestingScheduleTemplate,
   VestingStatement,
 } from "../../types/canonical/vesting";
 
+const DATE_BASE = { type: "DATE" as const };
+
 const goodStatement: VestingStatement = {
   order: 1,
+  vesting_base: DATE_BASE,
   occurrences: 48,
   period: 1,
   period_type: "MONTHS",
@@ -22,11 +25,6 @@ const goodStatement: VestingStatement = {
 const goodTemplate: VestingScheduleTemplate = {
   id: "t1",
   statements: [goodStatement],
-};
-
-const goodSchedule: VestingSchedule = {
-  template_id: "t1",
-  start_date: "2025-01-01",
 };
 
 describe("validateVestingScheduleTemplate", () => {
@@ -120,6 +118,102 @@ describe("validateVestingScheduleTemplate", () => {
         statements: [{ ...goodStatement, order: 1.5 }],
       });
       expect(result.valid).toBe(false);
+    });
+  });
+
+  describe("statement.vesting_base", () => {
+    it("rejects missing vesting_base", () => {
+      const { vesting_base, ...stmtWithoutBase } = goodStatement;
+      void vesting_base;
+      const result = validateVestingScheduleTemplate({
+        id: "t1",
+        statements: [stmtWithoutBase as unknown as VestingStatement],
+      });
+      expect(result.errors).toContainEqual({
+        path: "statements[0].vesting_base",
+        message: "is required and must be an object",
+      });
+    });
+
+    it("rejects invalid type", () => {
+      const result = validateVestingScheduleTemplate({
+        id: "t1",
+        statements: [
+          {
+            ...goodStatement,
+            vesting_base: { type: "RELATIVE" } as unknown as VestingStatement["vesting_base"],
+          },
+        ],
+      });
+      expect(result.errors).toContainEqual({
+        path: "statements[0].vesting_base.type",
+        message: 'must be "DATE" or "EVENT"',
+      });
+    });
+
+    it("rejects EVENT without event_id", () => {
+      const result = validateVestingScheduleTemplate({
+        id: "t1",
+        statements: [
+          {
+            ...goodStatement,
+            vesting_base: { type: "EVENT" } as unknown as VestingStatement["vesting_base"],
+          },
+        ],
+      });
+      expect(result.errors).toContainEqual({
+        path: "statements[0].vesting_base.event_id",
+        message: "must be a non-empty string",
+      });
+    });
+
+    it("rejects EVENT with empty event_id", () => {
+      const result = validateVestingScheduleTemplate({
+        id: "t1",
+        statements: [
+          {
+            ...goodStatement,
+            vesting_base: { type: "EVENT", event_id: "" },
+          },
+        ],
+      });
+      expect(result.errors).toContainEqual({
+        path: "statements[0].vesting_base.event_id",
+        message: "must be a non-empty string",
+      });
+    });
+
+    it("rejects DATE with stray event_id", () => {
+      const result = validateVestingScheduleTemplate({
+        id: "t1",
+        statements: [
+          {
+            ...goodStatement,
+            vesting_base: {
+              type: "DATE",
+              event_id: "stray",
+            } as unknown as VestingStatement["vesting_base"],
+          },
+        ],
+      });
+      expect(result.errors).toContainEqual({
+        path: "statements[0].vesting_base.event_id",
+        message: 'must not be present on a vesting_base with type "DATE"',
+      });
+    });
+
+    it("accepts well-formed EVENT base", () => {
+      const result = validateVestingScheduleTemplate({
+        id: "t1",
+        statements: [
+          {
+            ...goodStatement,
+            cliff: undefined,
+            vesting_base: { type: "EVENT", event_id: "ipo" },
+          },
+        ],
+      });
+      expect(result.valid).toBe(true);
     });
   });
 
@@ -322,37 +416,154 @@ describe("validateVestingScheduleTemplate", () => {
   });
 });
 
-describe("validateVestingSchedule", () => {
-  it("accepts a well-formed schedule", () => {
-    expect(validateVestingSchedule(goodSchedule)).toEqual({
-      valid: true,
-      errors: [],
+describe("validateVestingRuntime", () => {
+  const eventTemplate: VestingScheduleTemplate = {
+    id: "t1",
+    statements: [
+      {
+        ...goodStatement,
+        cliff: undefined,
+        vesting_base: { type: "EVENT", event_id: "ipo" },
+      },
+    ],
+  };
+
+  it("accepts an empty runtime when template has only EVENT statements", () => {
+    const result = validateVestingRuntime({}, eventTemplate);
+    expect(result).toEqual({ valid: true, errors: [] });
+  });
+
+  it("requires startDate when any DATE-anchored statement exists", () => {
+    const result = validateVestingRuntime({}, goodTemplate);
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContainEqual({
+      path: "startDate",
+      message:
+        "is required when the template contains any DATE-anchored statement",
     });
   });
 
-  describe("template_id", () => {
-    it("rejects empty string", () => {
-      const result = validateVestingSchedule({ ...goodSchedule, template_id: "" });
-      expect(result.errors).toContainEqual({
-        path: "template_id",
-        message: "must be a non-empty string",
-      });
+  it("accepts a valid startDate for a DATE template", () => {
+    const result = validateVestingRuntime(
+      { startDate: "2025-01-01" },
+      goodTemplate,
+    );
+    expect(result.valid).toBe(true);
+  });
+
+  it("rejects non-ISO startDate", () => {
+    const result = validateVestingRuntime(
+      { startDate: "2025/01/01" },
+      goodTemplate,
+    );
+    expect(result.errors).toContainEqual({
+      path: "startDate",
+      message: "must be an ISO 8601 date string (YYYY-MM-DD)",
     });
   });
 
-  describe("start_date", () => {
-    it("rejects non-ISO format", () => {
-      const result = validateVestingSchedule({ ...goodSchedule, start_date: "2025/01/01" });
-      expect(result.errors).toContainEqual({
-        path: "start_date",
-        message: "must be an ISO 8601 date string (YYYY-MM-DD)",
-      });
+  it("rejects non-ISO grantDate", () => {
+    const result = validateVestingRuntime(
+      { startDate: "2025-01-01", grantDate: "nope" },
+      goodTemplate,
+    );
+    expect(result.errors).toContainEqual({
+      path: "grantDate",
+      message: "must be an ISO 8601 date string (YYYY-MM-DD)",
     });
+  });
 
-    it("rejects garbage", () => {
-      const result = validateVestingSchedule({ ...goodSchedule, start_date: "not a date" });
-      expect(result.valid).toBe(false);
+  it("rejects duplicate event_id in eventFirings", () => {
+    const result = validateVestingRuntime(
+      {
+        eventFirings: [
+          { event_id: "ipo", date: "2026-04-01" },
+          { event_id: "ipo", date: "2026-05-01" },
+        ],
+      },
+      eventTemplate,
+    );
+    expect(result.errors).toContainEqual({
+      path: "eventFirings",
+      message: 'duplicate event_id "ipo" at indices [0, 1]',
     });
+  });
+
+  it("rejects event_id that doesn't match any EVENT statement", () => {
+    const result = validateVestingRuntime(
+      { eventFirings: [{ event_id: "stranger", date: "2026-04-01" }] },
+      eventTemplate,
+    );
+    expect(result.errors).toContainEqual({
+      path: "eventFirings[0].event_id",
+      message:
+        '"stranger" does not match any EVENT-anchored statement in the template',
+    });
+  });
+
+  it("rejects non-ISO firing date", () => {
+    const result = validateVestingRuntime(
+      { eventFirings: [{ event_id: "ipo", date: "not-a-date" }] },
+      eventTemplate,
+    );
+    expect(result.errors).toContainEqual({
+      path: "eventFirings[0].date",
+      message: "must be an ISO 8601 date string (YYYY-MM-DD)",
+    });
+  });
+
+  it("rejects realized_fraction > 1", () => {
+    const result = validateVestingRuntime(
+      {
+        eventFirings: [
+          {
+            event_id: "ipo",
+            date: "2026-04-01",
+            realized_fraction: { numerator: 3, denominator: 2 },
+          },
+        ],
+      },
+      eventTemplate,
+    );
+    expect(result.errors).toContainEqual({
+      path: "eventFirings[0].realized_fraction",
+      message: "must be in the closed interval [0, 1]",
+    });
+  });
+
+  it("rejects negative realized_fraction", () => {
+    const result = validateVestingRuntime(
+      {
+        eventFirings: [
+          {
+            event_id: "ipo",
+            date: "2026-04-01",
+            realized_fraction: { numerator: -1, denominator: 2 },
+          },
+        ],
+      },
+      eventTemplate,
+    );
+    expect(result.errors).toContainEqual({
+      path: "eventFirings[0].realized_fraction",
+      message: "must be in the closed interval [0, 1]",
+    });
+  });
+
+  it("accepts realized_fraction in [0, 1]", () => {
+    const result = validateVestingRuntime(
+      {
+        eventFirings: [
+          {
+            event_id: "ipo",
+            date: "2026-04-01",
+            realized_fraction: { numerator: 3, denominator: 10 },
+          },
+        ],
+      },
+      eventTemplate,
+    );
+    expect(result.valid).toBe(true);
   });
 });
 
@@ -371,14 +582,18 @@ describe("assertValidVestingScheduleTemplate", () => {
   });
 });
 
-describe("assertValidVestingSchedule", () => {
+describe("assertValidVestingRuntime", () => {
+  const goodRuntime: VestingRuntime = { startDate: "2025-01-01" };
+
   it("does not throw on valid input", () => {
-    expect(() => assertValidVestingSchedule(goodSchedule)).not.toThrow();
+    expect(() =>
+      assertValidVestingRuntime(goodRuntime, goodTemplate),
+    ).not.toThrow();
   });
 
   it("throws on invalid input", () => {
-    expect(() =>
-      assertValidVestingSchedule({ template_id: "", start_date: "bad" }),
-    ).toThrow(/Invalid VestingSchedule/);
+    expect(() => assertValidVestingRuntime({}, goodTemplate)).toThrow(
+      /Invalid VestingRuntime/,
+    );
   });
 });

--- a/vesting_compiler/allocate.ts
+++ b/vesting_compiler/allocate.ts
@@ -1,0 +1,62 @@
+import type { Allocation_Type } from "../types";
+import type { Fraction } from "../types/canonical/vesting";
+
+// OCF allocation types are defined in ../types (Allocation_Type). Only
+// CUMULATIVE_ROUND_DOWN is implemented today — the canonical/vesting spec
+// restricts itself to this mode. The other cases in `allocate` throw so the
+// dispatch shape is in place for when the spec carries allocation_type and
+// new modes need to be added.
+
+/**
+ * Compute floor(totalShares × cumulative). Uses BigInt for the intermediate
+ * multiply so the product is exact even when totalShares × numerator would
+ * overflow Number.MAX_SAFE_INTEGER. The final quotient is bounded by
+ * totalShares, which is in safe-integer range by precondition, so the
+ * Number() cast is safe.
+ */
+export const floorSharesAt = (
+  totalShares: number,
+  cumulative: Fraction,
+): number => {
+  const total = BigInt(totalShares);
+  const num = BigInt(cumulative.numerator);
+  const den = BigInt(cumulative.denominator);
+  return Number((total * num) / den);
+};
+
+/**
+ * Compute the integer share amount that should vest at the current event.
+ *
+ * Inputs:
+ *   - type: which allocation method to apply.
+ *   - totalShares: the grant's total share count (integer).
+ *   - cumulative: the running exact-rational fraction-of-grant that has been
+ *     scheduled to vest through (and including) this event.
+ *   - vestedSoFar: the integer share count already emitted by prior events.
+ *
+ * The returned amount, added to vestedSoFar, gives the per-event amounts that
+ * telescope to sum exactly to totalShares once cumulative reaches 1/1.
+ */
+export const allocate = (
+  type: Allocation_Type,
+  totalShares: number,
+  cumulative: Fraction,
+  vestedSoFar: number,
+): number => {
+  switch (type) {
+    case "CUMULATIVE_ROUND_DOWN":
+      // floor(totalShares × cumulative) − vestedSoFar. Cumulative-round-down
+      // invariant: cumulative ends at 1/1, so the final floor === totalShares.
+      return floorSharesAt(totalShares, cumulative) - vestedSoFar;
+
+    case "CUMULATIVE_ROUNDING":
+    case "FRONT_LOADED":
+    case "BACK_LOADED":
+    case "FRONT_LOADED_TO_SINGLE_TRANCHE":
+    case "BACK_LOADED_TO_SINGLE_TRANCHE":
+    case "FRACTIONAL":
+      throw new Error(
+        `Allocation type "${type}" is not yet implemented; only CUMULATIVE_ROUND_DOWN is supported.`,
+      );
+  }
+};

--- a/vesting_compiler/compile.ts
+++ b/vesting_compiler/compile.ts
@@ -2,7 +2,6 @@ import type { Vesting } from "../types";
 import type {
   Fraction,
   OCFDate,
-  VestingSchedule,
   VestingScheduleTemplate,
   VestingStatement,
 } from "../types/canonical/vesting";
@@ -10,9 +9,35 @@ import { allocate } from "./allocate";
 import { addPeriod } from "./dates";
 import { fracAdd, fracMul, fracSub, ONE, ZERO } from "./fractions";
 import {
-  assertValidVestingSchedule,
+  assertValidVestingRuntime,
   assertValidVestingScheduleTemplate,
 } from "./validate";
+
+/**
+ * Per-grant runtime data supplied to the compiler alongside the static
+ * VestingScheduleTemplate. Sources map to canonical transactions:
+ *   - startDate   — from TX_CANONICAL_VESTING_START (one per security, optional
+ *     if the template contains no DATE-anchored statements)
+ *   - eventFirings — from TX_CANONICAL_VESTING_EVENT (zero or more per
+ *     security). Each firing's event_id resolves the matching EVENT-anchored
+ *     statement(s) on the template; multiple statements may match a single
+ *     firing (one firing fans out). Optional realized_fraction scales the
+ *     statement's contribution for partial payouts.
+ *   - grantDate    — from TX_CANONICAL_EQUITY_COMPENSATION_ISSUANCE.date.
+ *     When provided, events whose computed date falls before grantDate are
+ *     held back and emitted as a single aggregated event on grantDate itself
+ *     (implicit cliff at the grant date), modelling that vesting cannot
+ *     legally occur before the grant existed.
+ */
+export interface VestingRuntime {
+  startDate?: OCFDate;
+  eventFirings?: Array<{
+    event_id: string;
+    date: OCFDate;
+    realized_fraction?: Fraction;
+  }>;
+  grantDate?: OCFDate;
+}
 
 /**
  * Computes the per-event fraction of the total grant for each event in a
@@ -20,6 +45,11 @@ import {
  * fractions[i-1] is the share of grant that event i contributes — already
  * multiplied through by statement.percentage, so the values are fraction of
  * grant, not fraction of statement.
+ *
+ * Anchor-agnostic: the same fractional shape applies whether the statement
+ * is DATE- or EVENT-anchored. For EVENT-anchored statements with a partial
+ * realized_fraction, the caller multiplies each entry by that fraction at
+ * the call site.
  *
  * Cliffless statements: every event vests statement.percentage / occurrenceCount.
  *
@@ -70,26 +100,110 @@ const perEventGrantFractions = (statement: VestingStatement): Fraction[] => {
 };
 
 /**
- * Compiles a canonical VestingScheduleTemplate + VestingSchedule into an array
- * of OCF Vesting events ({ date, amount }) under CUMULATIVE_ROUND_DOWN allocation.
+ * Raw event before integer-share materialization. Carries the per-event
+ * fraction-of-grant plus enough metadata to sort the projection
+ * chronologically with a deterministic tie-break.
+ */
+interface RawEvent {
+  date: OCFDate;
+  fractionOfGrant: Fraction;
+  statementOrder: number;
+  occurrence: number;
+}
+
+/**
+ * Expands a single VestingStatement into raw events anchored at the runtime
+ * data appropriate for its vesting_base.
  *
- * Optional grantDate: when provided, events whose computed date falls before
- * grantDate are held back and emitted as a single aggregated event on grantDate
- * itself — an implicit cliff at the grant date. This models the common case of
- * vesting backdated to a hire date earlier than the grant approval. When
- * omitted, the schedule runs unconstrained from start_date.
+ * DATE-anchored: events are anchored at dateCursor; the cursor advances by
+ * the full statement duration (occurrences × period). Statement N+1 then
+ * starts where statement N ended, preserving the bespoke 5/15/40/40-style
+ * chaining semantic ("statements chain implicitly by order").
+ *
+ * EVENT-anchored: events are anchored at the matching firing's date. If no
+ * matching firing exists, the statement is skipped (returns null) — the
+ * grant ends with that portion unvested, which is the correct canonical
+ * semantic. If realized_fraction is present, each per-event fraction is
+ * scaled by it (partial payout). The cursor is not advanced — EVENT
+ * statements break free of the DATE cursor chain.
+ */
+const expandStatement = (
+  statement: VestingStatement,
+  runtime: VestingRuntime,
+  dateCursor: OCFDate | undefined,
+): { events: RawEvent[]; nextCursor: OCFDate | undefined } | null => {
+  const fractions = perEventGrantFractions(statement);
+  const events: RawEvent[] = [];
+
+  if (statement.vesting_base.type === "DATE") {
+    // Validator guarantees dateCursor is defined when any DATE statement exists.
+    const anchor = dateCursor as OCFDate;
+    for (let i = 1; i <= statement.occurrences; i++) {
+      events.push({
+        date: addPeriod(anchor, i * statement.period, statement.period_type),
+        fractionOfGrant: fractions[i - 1],
+        statementOrder: statement.order,
+        occurrence: i,
+      });
+    }
+    const nextCursor = addPeriod(
+      anchor,
+      statement.occurrences * statement.period,
+      statement.period_type,
+    );
+    return { events, nextCursor };
+  }
+
+  // EVENT-anchored
+  const eventId = statement.vesting_base.event_id;
+  const firing = runtime.eventFirings?.find((f) => f.event_id === eventId);
+  if (!firing) return null; // statement doesn't fire; events never produced
+
+  const multiplier = firing.realized_fraction ?? ONE;
+  for (let i = 1; i <= statement.occurrences; i++) {
+    events.push({
+      date: addPeriod(firing.date, i * statement.period, statement.period_type),
+      fractionOfGrant: fracMul(fractions[i - 1], multiplier),
+      statementOrder: statement.order,
+      occurrence: i,
+    });
+  }
+  return { events, nextCursor: dateCursor };
+};
+
+/**
+ * Compiles a canonical VestingScheduleTemplate plus per-grant runtime data
+ * into an array of OCF Vesting events ({ date, amount }) under
+ * CUMULATIVE_ROUND_DOWN allocation.
+ *
+ * The template is the static spec (statements with vesting_base anchors and
+ * fractional structure). The runtime carries per-grant resolution: the start
+ * date for DATE-anchored statements, firings for EVENT-anchored statements,
+ * and an optional grant date that acts as an implicit cliff for any event
+ * computed to land before it.
+ *
+ * Output events are sorted chronologically (tie-break: statement.order, then
+ * occurrence). For pure-DATE templates with statements chaining by order,
+ * the chronological order matches statement order naturally. For hybrid
+ * templates (DATE + EVENT statements), the output reflects a real timeline
+ * with statements interleaved by their actual event dates.
+ *
+ * EVENT statements with no matching firing in runtime are silently skipped:
+ * the corresponding portion of the grant never vests. The validator ensures
+ * runtime.eventFirings only references event_ids that exist in the template,
+ * so a "missing firing" reflects a real "event hasn't fired yet" state, not
+ * a data error.
  *
  * Day-of-month policy: assumes OCF's VESTING_START_DAY_OR_LAST_DAY_OF_MONTH —
- * each event preserves the start_date's day-of-month, clamping to the last day
- * in shorter months. The canonical spec does not currently carry a day_of_month
- * field, so other OCF VestingDayOfMonth values (fixed numeric days, *_OR_LAST_DAY
- * variants) are not supported.
+ * each event preserves the anchor date's day-of-month, clamping to the last
+ * day in shorter months. The canonical spec does not currently carry a
+ * day_of_month field, so other OCF VestingDayOfMonth values (fixed numeric
+ * days, *_OR_LAST_DAY variants) are not supported.
  */
 export const compileVesting = (
   template: VestingScheduleTemplate,
-  schedule: VestingSchedule,
   totalShares: number,
-  grantDate?: OCFDate,
+  runtime: VestingRuntime,
 ): Vesting[] => {
   if (!Number.isInteger(totalShares) || totalShares < 0) {
     throw new Error(
@@ -97,79 +211,76 @@ export const compileVesting = (
     );
   }
   assertValidVestingScheduleTemplate(template);
-  assertValidVestingSchedule(schedule);
+  assertValidVestingRuntime(runtime, template);
 
+  // Step 1: expand each statement into raw events. DATE statements chain
+  // through dateCursor; EVENT statements anchor absolutely at their firing.
   const statements = [...template.statements].sort((a, b) => a.order - b.order);
+  let dateCursor: OCFDate | undefined = runtime.startDate;
+  const rawEvents: RawEvent[] = [];
+  for (const statement of statements) {
+    const result = expandStatement(statement, runtime, dateCursor);
+    if (!result) continue; // EVENT statement with no matching firing
+    rawEvents.push(...result.events);
+    dateCursor = result.nextCursor;
+  }
 
+  // Step 2: sort chronologically. Tie-break on (statementOrder, occurrence)
+  // so two events on the same date have deterministic, spec-traceable order.
+  rawEvents.sort((a, b) => {
+    if (a.date !== b.date) return a.date < b.date ? -1 : 1;
+    if (a.statementOrder !== b.statementOrder)
+      return a.statementOrder - b.statementOrder;
+    return a.occurrence - b.occurrence;
+  });
+
+  // Step 3: cumulative-round-down emission with grant-date implicit cliff.
+  // The cumulative fraction accumulates across all events (single running
+  // total). amount = floor(totalShares × cumulative) − vestedSoFar, which
+  // telescopes to sum exactly to totalShares when all EVENT statements fire
+  // (or less if some never fire, as intended).
   let cumulative: Fraction = ZERO;
   let vestedSoFar = 0;
   const events: Vesting[] = [];
-  let cursor = schedule.start_date;
   // Pre-grant aggregator: amounts whose computed date is before grantDate are
   // held back and emitted on grantDate itself (implicit cliff at grant_date).
   let pendingPreGrant = 0;
 
-  for (const statement of statements) {
-    const fractions = perEventGrantFractions(statement);
-    const occurrenceCount = statement.occurrences;
+  for (const raw of rawEvents) {
+    cumulative = fracAdd(cumulative, raw.fractionOfGrant);
+    const amount = allocate(
+      "CUMULATIVE_ROUND_DOWN",
+      totalShares,
+      cumulative,
+      vestedSoFar,
+    );
+    if (amount === 0) continue;
+    vestedSoFar += amount;
 
-    for (let i = 1; i <= occurrenceCount; i++) {
-      const fraction = fractions[i - 1];
-      // Cumulative-round-down emission via the allocate module. Compute the
-      // event's amount as a delta from what's been emitted before; per-event
-      // amounts telescope to exactly totalShares because cumulative ends at
-      // 1/1. Allocation mode is hardcoded — the canonical spec restricts
-      // itself to CUMULATIVE_ROUND_DOWN. Plumb through from the template once
-      // the spec carries allocation_type.
-      cumulative = fracAdd(cumulative, fraction);
-      const amount = allocate(
-        "CUMULATIVE_ROUND_DOWN",
-        totalShares,
-        cumulative,
-        vestedSoFar,
-      );
-      if (amount === 0) continue;
-      vestedSoFar += amount;
-      const date = addPeriod(
-        cursor,
-        i * statement.period,
-        statement.period_type,
-      );
-
-      // Grant-date handling has three cases:
-      //   (a) date <  grantDate — hold in pendingPreGrant, no event yet.
-      //   (b) date == grantDate — merge held into this event; emit once.
-      //   (c) date >  grantDate — flush held as a standalone event on
-      //       grantDate (implicit cliff), then emit the current event.
-      if (grantDate && date < grantDate) {
-        pendingPreGrant += amount;
+    // Grant-date handling has three cases:
+    //   (a) date <  grantDate — hold in pendingPreGrant, no event yet.
+    //   (b) date == grantDate — merge held into this event; emit once.
+    //   (c) date >  grantDate — flush held as a standalone event on
+    //       grantDate (implicit cliff), then emit the current event.
+    if (runtime.grantDate && raw.date < runtime.grantDate) {
+      pendingPreGrant += amount;
+      continue;
+    }
+    if (pendingPreGrant > 0 && runtime.grantDate) {
+      if (raw.date === runtime.grantDate) {
+        events.push({ date: raw.date, amount: String(amount + pendingPreGrant) });
+        pendingPreGrant = 0;
         continue;
       }
-      if (pendingPreGrant > 0 && grantDate) {
-        if (date === grantDate) {
-          events.push({ date, amount: String(amount + pendingPreGrant) });
-          pendingPreGrant = 0;
-          continue;
-        }
-        events.push({ date: grantDate, amount: String(pendingPreGrant) });
-        pendingPreGrant = 0;
-      }
-      events.push({ date, amount: String(amount) });
+      events.push({ date: runtime.grantDate, amount: String(pendingPreGrant) });
+      pendingPreGrant = 0;
     }
-
-    // Advance by the full statement duration regardless of how many events
-    // emitted, so zero-percent and held-back statements still occupy time
-    // on the schedule (required for chained-statement date arithmetic).
-    cursor = addPeriod(
-      cursor,
-      occurrenceCount * statement.period,
-      statement.period_type,
-    );
+    events.push({ date: raw.date, amount: String(amount) });
   }
 
   // All scheduled events fell before grantDate; emit the aggregate on grantDate.
-  if (pendingPreGrant > 0 && grantDate) {
-    events.push({ date: grantDate, amount: String(pendingPreGrant) });
+  if (pendingPreGrant > 0 && runtime.grantDate) {
+    events.push({ date: runtime.grantDate, amount: String(pendingPreGrant) });
   }
 
   return events;

--- a/vesting_compiler/compile.ts
+++ b/vesting_compiler/compile.ts
@@ -1,0 +1,176 @@
+import type { Vesting } from "../types";
+import type {
+  Fraction,
+  OCFDate,
+  VestingSchedule,
+  VestingScheduleTemplate,
+  VestingStatement,
+} from "../types/canonical/vesting";
+import { allocate } from "./allocate";
+import { addPeriod } from "./dates";
+import { fracAdd, fracMul, fracSub, ONE, ZERO } from "./fractions";
+import {
+  assertValidVestingSchedule,
+  assertValidVestingScheduleTemplate,
+} from "./validate";
+
+/**
+ * Computes the per-event fraction of the total grant for each event in a
+ * VestingStatement. Returns an array of length statement.occurrences where
+ * fractions[i-1] is the share of grant that event i contributes — already
+ * multiplied through by statement.percentage, so the values are fraction of
+ * grant, not fraction of statement.
+ *
+ * Cliffless statements: every event vests statement.percentage / occurrenceCount.
+ *
+ * With a cliff at occurrence K: events 1..K-1 are ZERO (held back), event K
+ * vests cliff.percentage × statement.percentage, and events K+1..N vest the
+ * remaining (1 - cliff.percentage) × statement.percentage spread evenly.
+ */
+const perEventGrantFractions = (statement: VestingStatement): Fraction[] => {
+  const occurrenceCount = statement.occurrences;
+  const stmtFraction = statement.percentage;
+
+  if (!statement.cliff) {
+    const eventFraction = fracMul(stmtFraction, {
+      numerator: 1,
+      denominator: occurrenceCount,
+    });
+    return Array.from({ length: occurrenceCount }, () => eventFraction);
+  }
+
+  // cliff.percentage is the fraction OF THE STATEMENT, not of the grant — so
+  // multiplying by stmtFraction gives the fraction of grant. This lets a cliff
+  // compose cleanly regardless of how much of the grant the containing
+  // statement covers.
+  const cliffEvent = statement.cliff.occurrence;
+  const cliffFractionOfStmt = statement.cliff.percentage;
+  const cliffFractionOfGrant = fracMul(cliffFractionOfStmt, stmtFraction);
+  const postCliffCount = occurrenceCount - cliffEvent;
+  const remainingStmtFraction = fracMul(
+    fracSub(ONE, cliffFractionOfStmt),
+    stmtFraction,
+  );
+  const postCliffEventFraction =
+    postCliffCount === 0
+      ? ZERO
+      : fracMul(remainingStmtFraction, {
+          numerator: 1,
+          denominator: postCliffCount,
+        });
+
+  return Array.from({ length: occurrenceCount }, (_, idx) => {
+    const occurrence = idx + 1;
+    // Pre-cliff installments emit ZERO, which the main loop's amount===0
+    // filter skips so no event is produced for them.
+    if (occurrence < cliffEvent) return ZERO;
+    if (occurrence === cliffEvent) return cliffFractionOfGrant;
+    return postCliffEventFraction;
+  });
+};
+
+/**
+ * Compiles a canonical VestingScheduleTemplate + VestingSchedule into an array
+ * of OCF Vesting events ({ date, amount }) under CUMULATIVE_ROUND_DOWN allocation.
+ *
+ * Optional grantDate: when provided, events whose computed date falls before
+ * grantDate are held back and emitted as a single aggregated event on grantDate
+ * itself — an implicit cliff at the grant date. This models the common case of
+ * vesting backdated to a hire date earlier than the grant approval. When
+ * omitted, the schedule runs unconstrained from start_date.
+ *
+ * Day-of-month policy: assumes OCF's VESTING_START_DAY_OR_LAST_DAY_OF_MONTH —
+ * each event preserves the start_date's day-of-month, clamping to the last day
+ * in shorter months. The canonical spec does not currently carry a day_of_month
+ * field, so other OCF VestingDayOfMonth values (fixed numeric days, *_OR_LAST_DAY
+ * variants) are not supported.
+ */
+export const compileVesting = (
+  template: VestingScheduleTemplate,
+  schedule: VestingSchedule,
+  totalShares: number,
+  grantDate?: OCFDate,
+): Vesting[] => {
+  if (!Number.isInteger(totalShares) || totalShares < 0) {
+    throw new Error(
+      `totalShares must be a non-negative integer (got ${totalShares})`,
+    );
+  }
+  assertValidVestingScheduleTemplate(template);
+  assertValidVestingSchedule(schedule);
+
+  const statements = [...template.statements].sort((a, b) => a.order - b.order);
+
+  let cumulative: Fraction = ZERO;
+  let vestedSoFar = 0;
+  const events: Vesting[] = [];
+  let cursor = schedule.start_date;
+  // Pre-grant aggregator: amounts whose computed date is before grantDate are
+  // held back and emitted on grantDate itself (implicit cliff at grant_date).
+  let pendingPreGrant = 0;
+
+  for (const statement of statements) {
+    const fractions = perEventGrantFractions(statement);
+    const occurrenceCount = statement.occurrences;
+
+    for (let i = 1; i <= occurrenceCount; i++) {
+      const fraction = fractions[i - 1];
+      // Cumulative-round-down emission via the allocate module. Compute the
+      // event's amount as a delta from what's been emitted before; per-event
+      // amounts telescope to exactly totalShares because cumulative ends at
+      // 1/1. Allocation mode is hardcoded — the canonical spec restricts
+      // itself to CUMULATIVE_ROUND_DOWN. Plumb through from the template once
+      // the spec carries allocation_type.
+      cumulative = fracAdd(cumulative, fraction);
+      const amount = allocate(
+        "CUMULATIVE_ROUND_DOWN",
+        totalShares,
+        cumulative,
+        vestedSoFar,
+      );
+      if (amount === 0) continue;
+      vestedSoFar += amount;
+      const date = addPeriod(
+        cursor,
+        i * statement.period,
+        statement.period_type,
+      );
+
+      // Grant-date handling has three cases:
+      //   (a) date <  grantDate — hold in pendingPreGrant, no event yet.
+      //   (b) date == grantDate — merge held into this event; emit once.
+      //   (c) date >  grantDate — flush held as a standalone event on
+      //       grantDate (implicit cliff), then emit the current event.
+      if (grantDate && date < grantDate) {
+        pendingPreGrant += amount;
+        continue;
+      }
+      if (pendingPreGrant > 0 && grantDate) {
+        if (date === grantDate) {
+          events.push({ date, amount: String(amount + pendingPreGrant) });
+          pendingPreGrant = 0;
+          continue;
+        }
+        events.push({ date: grantDate, amount: String(pendingPreGrant) });
+        pendingPreGrant = 0;
+      }
+      events.push({ date, amount: String(amount) });
+    }
+
+    // Advance by the full statement duration regardless of how many events
+    // emitted, so zero-percent and held-back statements still occupy time
+    // on the schedule (required for chained-statement date arithmetic).
+    cursor = addPeriod(
+      cursor,
+      occurrenceCount * statement.period,
+      statement.period_type,
+    );
+  }
+
+  // All scheduled events fell before grantDate; emit the aggregate on grantDate.
+  if (pendingPreGrant > 0 && grantDate) {
+    events.push({ date: grantDate, amount: String(pendingPreGrant) });
+  }
+
+  return events;
+};

--- a/vesting_compiler/dates.ts
+++ b/vesting_compiler/dates.ts
@@ -1,0 +1,65 @@
+import type { OCFDate, PeriodType } from "../types/canonical/vesting";
+
+// Day-of-month behavior: this module implements only OCF's
+// VESTING_START_DAY_OR_LAST_DAY_OF_MONTH policy — the target day is always the
+// start date's day-of-month, clamped down in months that are shorter (e.g.,
+// Jan 31 + 1mo → Feb 28). The canonical spec does not carry a day_of_month
+// field today; if it ever adds one, addPeriod will need a new parameter and
+// branches for fixed numeric days ("01"–"28") and the *_OR_LAST_DAY_OF_MONTH
+// variants.
+
+const MS_PER_DAY = 86_400_000;
+
+// Capture-group form so parseISO can extract year/month/day via .exec().
+// Consumers that only need the format check (e.g. validate.ts) can use
+// .test() on the same pattern — capture groups don't affect boolean tests.
+export const ISO_DATE_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+const parseISO = (
+  iso: OCFDate,
+): { year: number; month: number; day: number } => {
+  const match = ISO_DATE_PATTERN.exec(iso);
+  if (!match) {
+    throw new Error(`Invalid OCF date: ${iso}`);
+  }
+  return {
+    year: Number(match[1]),
+    month: Number(match[2]),
+    day: Number(match[3]),
+  };
+};
+
+export const formatISO = (d: Date): OCFDate => d.toISOString().slice(0, 10);
+
+const daysInMonth = (year: number, month: number): number =>
+  new Date(Date.UTC(year, month, 0)).getUTCDate();
+
+const addMonths = (start: OCFDate, months: number): OCFDate => {
+  const { year, month, day } = parseISO(start);
+  const monthIndex0 = month - 1 + months;
+  const targetYear = year + Math.floor(monthIndex0 / 12);
+  const targetMonth = (((monthIndex0 % 12) + 12) % 12) + 1;
+  const targetDay = Math.min(day, daysInMonth(targetYear, targetMonth));
+  return formatISO(new Date(Date.UTC(targetYear, targetMonth - 1, targetDay)));
+};
+
+const addDays = (start: OCFDate, days: number): OCFDate => {
+  const { year, month, day } = parseISO(start);
+  const base = Date.UTC(year, month - 1, day);
+  return formatISO(new Date(base + days * MS_PER_DAY));
+};
+
+export const addPeriod = (
+  start: OCFDate,
+  units: number,
+  periodType: PeriodType,
+): OCFDate => {
+  switch (periodType) {
+    case "DAYS":
+      return addDays(start, units);
+    case "MONTHS":
+      return addMonths(start, units);
+    case "YEARS":
+      return addMonths(start, units * 12);
+  }
+};

--- a/vesting_compiler/fractions.ts
+++ b/vesting_compiler/fractions.ts
@@ -1,0 +1,36 @@
+import type { Fraction } from "../types/canonical/vesting";
+
+const gcd = (a: number, b: number): number => {
+  let x = Math.abs(a);
+  let y = Math.abs(b);
+  while (y !== 0) {
+    [x, y] = [y, x % y];
+  }
+  return x || 1;
+};
+
+export const fracReduce = (f: Fraction): Fraction => {
+  const d = gcd(f.numerator, f.denominator);
+  return { numerator: f.numerator / d, denominator: f.denominator / d };
+};
+
+export const fracMul = (a: Fraction, b: Fraction): Fraction =>
+  fracReduce({
+    numerator: a.numerator * b.numerator,
+    denominator: a.denominator * b.denominator,
+  });
+
+export const fracAdd = (a: Fraction, b: Fraction): Fraction =>
+  fracReduce({
+    numerator: a.numerator * b.denominator + b.numerator * a.denominator,
+    denominator: a.denominator * b.denominator,
+  });
+
+export const fracSub = (a: Fraction, b: Fraction): Fraction =>
+  fracReduce({
+    numerator: a.numerator * b.denominator - b.numerator * a.denominator,
+    denominator: a.denominator * b.denominator,
+  });
+
+export const ZERO: Fraction = { numerator: 0, denominator: 1 };
+export const ONE: Fraction = { numerator: 1, denominator: 1 };

--- a/vesting_compiler/index.ts
+++ b/vesting_compiler/index.ts
@@ -1,0 +1,8 @@
+export { compileVesting } from "./compile";
+export {
+  assertValidVestingSchedule,
+  assertValidVestingScheduleTemplate,
+  validateVestingSchedule,
+  validateVestingScheduleTemplate,
+} from "./validate";
+export type { ValidationError, ValidationResult } from "./validate";

--- a/vesting_compiler/index.ts
+++ b/vesting_compiler/index.ts
@@ -1,8 +1,9 @@
 export { compileVesting } from "./compile";
+export type { VestingRuntime } from "./compile";
 export {
-  assertValidVestingSchedule,
+  assertValidVestingRuntime,
   assertValidVestingScheduleTemplate,
-  validateVestingSchedule,
+  validateVestingRuntime,
   validateVestingScheduleTemplate,
 } from "./validate";
 export type { ValidationError, ValidationResult } from "./validate";

--- a/vesting_compiler/validate.ts
+++ b/vesting_compiler/validate.ts
@@ -1,0 +1,189 @@
+import type {
+  Cliff,
+  Fraction,
+  PeriodType,
+  VestingSchedule,
+  VestingScheduleTemplate,
+  VestingStatement,
+} from "../types/canonical/vesting";
+import { ISO_DATE_PATTERN } from "./dates";
+
+export interface ValidationError {
+  path: string;
+  message: string;
+}
+
+export interface ValidationResult {
+  valid: boolean;
+  errors: ValidationError[];
+}
+
+const PERIOD_TYPES: ReadonlyArray<PeriodType> = ["DAYS", "MONTHS", "YEARS"];
+
+const isInteger = (n: unknown): n is number =>
+  typeof n === "number" && Number.isInteger(n);
+
+const isPositiveInt = (n: unknown): n is number => isInteger(n) && n > 0;
+
+const isNonNegativeInt = (n: unknown): n is number => isInteger(n) && n >= 0;
+
+const validateFraction = (
+  f: Fraction,
+  path: string,
+  errors: ValidationError[],
+): void => {
+  if (!isInteger(f.numerator)) {
+    errors.push({ path: `${path}.numerator`, message: "must be an integer" });
+  }
+  if (!isPositiveInt(f.denominator)) {
+    errors.push({
+      path: `${path}.denominator`,
+      message: "must be an integer >= 1",
+    });
+  }
+};
+
+const validateCliff = (
+  c: Cliff,
+  occurrences: number,
+  path: string,
+  errors: ValidationError[],
+): void => {
+  if (!isPositiveInt(c.occurrence)) {
+    errors.push({
+      path: `${path}.occurrence`,
+      message: "must be an integer >= 1",
+    });
+  } else if (isPositiveInt(occurrences) && c.occurrence > occurrences) {
+    errors.push({
+      path: `${path}.occurrence`,
+      message: `must be <= statement.occurrences (got ${c.occurrence}, occurrences=${occurrences})`,
+    });
+  }
+  validateFraction(c.percentage, `${path}.percentage`, errors);
+};
+
+const validateStatement = (
+  s: VestingStatement,
+  path: string,
+  errors: ValidationError[],
+): void => {
+  if (!isPositiveInt(s.order)) {
+    errors.push({ path: `${path}.order`, message: "must be an integer >= 1" });
+  }
+  if (!isPositiveInt(s.occurrences)) {
+    errors.push({
+      path: `${path}.occurrences`,
+      message: "must be an integer >= 1",
+    });
+  }
+  if (!isNonNegativeInt(s.period)) {
+    errors.push({
+      path: `${path}.period`,
+      message: "must be an integer >= 0",
+    });
+  }
+  if (!PERIOD_TYPES.includes(s.period_type)) {
+    errors.push({
+      path: `${path}.period_type`,
+      message: `must be one of ${PERIOD_TYPES.join(", ")}`,
+    });
+  }
+  validateFraction(s.percentage, `${path}.percentage`, errors);
+  if (s.cliff) {
+    validateCliff(s.cliff, s.occurrences, `${path}.cliff`, errors);
+  }
+};
+
+/**
+ * Structural validation for a canonical VestingScheduleTemplate. Returns a
+ * { valid, errors[] } result that consumers (the compiler, the OCF validator)
+ * can use to either bail or map into their own report shape. Schema-only:
+ * checks the spec's well-formedness, not compile-time inputs like totalShares.
+ */
+export const validateVestingScheduleTemplate = (
+  t: VestingScheduleTemplate,
+): ValidationResult => {
+  const errors: ValidationError[] = [];
+
+  if (typeof t.id !== "string" || t.id.length === 0) {
+    errors.push({ path: "id", message: "must be a non-empty string" });
+  }
+
+  if (!Array.isArray(t.statements) || t.statements.length === 0) {
+    errors.push({ path: "statements", message: "must be a non-empty array" });
+  } else {
+    t.statements.forEach((s, i) => {
+      validateStatement(s, `statements[${i}]`, errors);
+    });
+
+    const ordersSeen = new Map<number, number[]>();
+    t.statements.forEach((s, i) => {
+      if (isPositiveInt(s.order)) {
+        const indices = ordersSeen.get(s.order) ?? [];
+        indices.push(i);
+        ordersSeen.set(s.order, indices);
+      }
+    });
+    for (const [order, indices] of ordersSeen) {
+      if (indices.length > 1) {
+        errors.push({
+          path: "statements",
+          message: `duplicate order ${order} at indices [${indices.join(", ")}]`,
+        });
+      }
+    }
+  }
+
+  return { valid: errors.length === 0, errors };
+};
+
+/**
+ * Structural validation for a canonical VestingSchedule. Returns a
+ * { valid, errors[] } result. Does NOT verify that template_id resolves to an
+ * existing template — that's a cross-reference check belonging to the consumer.
+ */
+export const validateVestingSchedule = (
+  s: VestingSchedule,
+): ValidationResult => {
+  const errors: ValidationError[] = [];
+
+  if (typeof s.template_id !== "string" || s.template_id.length === 0) {
+    errors.push({ path: "template_id", message: "must be a non-empty string" });
+  }
+
+  if (
+    typeof s.start_date !== "string" ||
+    !ISO_DATE_PATTERN.test(s.start_date)
+  ) {
+    errors.push({
+      path: "start_date",
+      message: "must be an ISO 8601 date string (YYYY-MM-DD)",
+    });
+  }
+
+  return { valid: errors.length === 0, errors };
+};
+
+const formatErrors = (errors: ValidationError[]): string =>
+  errors.map((e) => `  - ${e.path}: ${e.message}`).join("\n");
+
+/** Throws a single Error with all validation messages on invalid input. */
+export const assertValidVestingScheduleTemplate = (
+  t: VestingScheduleTemplate,
+): void => {
+  const result = validateVestingScheduleTemplate(t);
+  if (!result.valid) {
+    throw new Error(
+      `Invalid VestingScheduleTemplate:\n${formatErrors(result.errors)}`,
+    );
+  }
+};
+
+/** Throws a single Error with all validation messages on invalid input. */
+export const assertValidVestingSchedule = (s: VestingSchedule): void => {
+  const result = validateVestingSchedule(s);
+  if (!result.valid) {
+    throw new Error(`Invalid VestingSchedule:\n${formatErrors(result.errors)}`);
+  }
+};

--- a/vesting_compiler/validate.ts
+++ b/vesting_compiler/validate.ts
@@ -2,10 +2,10 @@ import type {
   Cliff,
   Fraction,
   PeriodType,
-  VestingSchedule,
   VestingScheduleTemplate,
   VestingStatement,
 } from "../types/canonical/vesting";
+import type { VestingRuntime } from "./compile";
 import { ISO_DATE_PATTERN } from "./dates";
 
 export interface ValidationError {
@@ -63,6 +63,40 @@ const validateCliff = (
   validateFraction(c.percentage, `${path}.percentage`, errors);
 };
 
+const validateVestingBase = (
+  base: VestingStatement["vesting_base"],
+  path: string,
+  errors: ValidationError[],
+): void => {
+  if (!base || typeof base !== "object") {
+    errors.push({ path, message: "is required and must be an object" });
+    return;
+  }
+  if (base.type !== "DATE" && base.type !== "EVENT") {
+    errors.push({
+      path: `${path}.type`,
+      message: 'must be "DATE" or "EVENT"',
+    });
+    return;
+  }
+  if (base.type === "EVENT") {
+    if (typeof base.event_id !== "string" || base.event_id.length === 0) {
+      errors.push({
+        path: `${path}.event_id`,
+        message: "must be a non-empty string",
+      });
+    }
+  } else {
+    // DATE — no extra fields permitted; specifically, stray event_id is wrong.
+    if ("event_id" in base) {
+      errors.push({
+        path: `${path}.event_id`,
+        message: 'must not be present on a vesting_base with type "DATE"',
+      });
+    }
+  }
+};
+
 const validateStatement = (
   s: VestingStatement,
   path: string,
@@ -71,6 +105,7 @@ const validateStatement = (
   if (!isPositiveInt(s.order)) {
     errors.push({ path: `${path}.order`, message: "must be an integer >= 1" });
   }
+  validateVestingBase(s.vesting_base, `${path}.vesting_base`, errors);
   if (!isPositiveInt(s.occurrences)) {
     errors.push({
       path: `${path}.occurrences`,
@@ -99,7 +134,7 @@ const validateStatement = (
  * Structural validation for a canonical VestingScheduleTemplate. Returns a
  * { valid, errors[] } result that consumers (the compiler, the OCF validator)
  * can use to either bail or map into their own report shape. Schema-only:
- * checks the spec's well-formedness, not compile-time inputs like totalShares.
+ * checks the spec's well-formedness, not runtime inputs.
  */
 export const validateVestingScheduleTemplate = (
   t: VestingScheduleTemplate,
@@ -138,28 +173,135 @@ export const validateVestingScheduleTemplate = (
   return { valid: errors.length === 0, errors };
 };
 
+const fractionInUnitInterval = (f: Fraction): boolean => {
+  // Valid fractions reach this point (denominator >= 1).
+  if (f.numerator < 0) return false;
+  // numerator/denominator <= 1 ⇔ numerator <= denominator
+  return f.numerator <= f.denominator;
+};
+
 /**
- * Structural validation for a canonical VestingSchedule. Returns a
- * { valid, errors[] } result. Does NOT verify that template_id resolves to an
- * existing template — that's a cross-reference check belonging to the consumer.
+ * Validates the per-grant runtime data passed to compileVesting against the
+ * template. Catches mismatches that the static template validator cannot:
+ *   - startDate required when any DATE-anchored statement exists
+ *   - eventFirings must reference event_ids that exist on EVENT statements
+ *   - no duplicate event_id in eventFirings (single firing per event_id)
+ *   - dates must be ISO format
+ *   - realized_fraction (if present) must be a valid Fraction in [0, 1]
  */
-export const validateVestingSchedule = (
-  s: VestingSchedule,
+export const validateVestingRuntime = (
+  runtime: VestingRuntime,
+  template: VestingScheduleTemplate,
 ): ValidationResult => {
   const errors: ValidationError[] = [];
 
-  if (typeof s.template_id !== "string" || s.template_id.length === 0) {
-    errors.push({ path: "template_id", message: "must be a non-empty string" });
-  }
+  const dateAnchoredExists = Array.isArray(template.statements)
+    ? template.statements.some((s) => s?.vesting_base?.type === "DATE")
+    : false;
 
-  if (
-    typeof s.start_date !== "string" ||
-    !ISO_DATE_PATTERN.test(s.start_date)
+  if (dateAnchoredExists) {
+    if (typeof runtime.startDate !== "string") {
+      errors.push({
+        path: "startDate",
+        message:
+          "is required when the template contains any DATE-anchored statement",
+      });
+    } else if (!ISO_DATE_PATTERN.test(runtime.startDate)) {
+      errors.push({
+        path: "startDate",
+        message: "must be an ISO 8601 date string (YYYY-MM-DD)",
+      });
+    }
+  } else if (
+    runtime.startDate !== undefined &&
+    !ISO_DATE_PATTERN.test(runtime.startDate)
   ) {
+    // Tolerated but format-checked.
     errors.push({
-      path: "start_date",
+      path: "startDate",
       message: "must be an ISO 8601 date string (YYYY-MM-DD)",
     });
+  }
+
+  if (runtime.grantDate !== undefined) {
+    if (
+      typeof runtime.grantDate !== "string" ||
+      !ISO_DATE_PATTERN.test(runtime.grantDate)
+    ) {
+      errors.push({
+        path: "grantDate",
+        message: "must be an ISO 8601 date string (YYYY-MM-DD)",
+      });
+    }
+  }
+
+  if (runtime.eventFirings !== undefined) {
+    if (!Array.isArray(runtime.eventFirings)) {
+      errors.push({ path: "eventFirings", message: "must be an array" });
+    } else {
+      const templateEventIds = new Set(
+        (template.statements ?? [])
+          .filter((s) => s?.vesting_base?.type === "EVENT")
+          .map((s) => (s.vesting_base as { event_id: string }).event_id),
+      );
+      const seen = new Map<string, number[]>();
+
+      runtime.eventFirings.forEach((firing, i) => {
+        const path = `eventFirings[${i}]`;
+        if (typeof firing?.event_id !== "string" || firing.event_id.length === 0) {
+          errors.push({
+            path: `${path}.event_id`,
+            message: "must be a non-empty string",
+          });
+        } else {
+          const indices = seen.get(firing.event_id) ?? [];
+          indices.push(i);
+          seen.set(firing.event_id, indices);
+          if (!templateEventIds.has(firing.event_id)) {
+            errors.push({
+              path: `${path}.event_id`,
+              message: `"${firing.event_id}" does not match any EVENT-anchored statement in the template`,
+            });
+          }
+        }
+        if (
+          typeof firing?.date !== "string" ||
+          !ISO_DATE_PATTERN.test(firing.date)
+        ) {
+          errors.push({
+            path: `${path}.date`,
+            message: "must be an ISO 8601 date string (YYYY-MM-DD)",
+          });
+        }
+        if (firing?.realized_fraction !== undefined) {
+          validateFraction(
+            firing.realized_fraction,
+            `${path}.realized_fraction`,
+            errors,
+          );
+          // Only check interval bounds if the fraction itself parsed OK.
+          if (
+            isInteger(firing.realized_fraction.numerator) &&
+            isPositiveInt(firing.realized_fraction.denominator) &&
+            !fractionInUnitInterval(firing.realized_fraction)
+          ) {
+            errors.push({
+              path: `${path}.realized_fraction`,
+              message: "must be in the closed interval [0, 1]",
+            });
+          }
+        }
+      });
+
+      for (const [eventId, indices] of seen) {
+        if (indices.length > 1) {
+          errors.push({
+            path: "eventFirings",
+            message: `duplicate event_id "${eventId}" at indices [${indices.join(", ")}]`,
+          });
+        }
+      }
+    }
   }
 
   return { valid: errors.length === 0, errors };
@@ -181,9 +323,14 @@ export const assertValidVestingScheduleTemplate = (
 };
 
 /** Throws a single Error with all validation messages on invalid input. */
-export const assertValidVestingSchedule = (s: VestingSchedule): void => {
-  const result = validateVestingSchedule(s);
+export const assertValidVestingRuntime = (
+  runtime: VestingRuntime,
+  template: VestingScheduleTemplate,
+): void => {
+  const result = validateVestingRuntime(runtime, template);
   if (!result.valid) {
-    throw new Error(`Invalid VestingSchedule:\n${formatErrors(result.errors)}`);
+    throw new Error(
+      `Invalid VestingRuntime:\n${formatErrors(result.errors)}`,
+    );
   }
 };


### PR DESCRIPTION
## Summary

Introduces the canonical vesting compiler + structural validator in `vesting_compiler/`, ports the canonical vesting types into `types/canonical/vesting/`, and tracks the latest canonical design from OCF-Composed-Schemas (including the `vesting_base: VestingBaseDate | VestingBaseEvent` discriminator and the transaction-driven runtime model).

### `vesting_compiler/`

- **`compileVesting(template, totalShares, runtime)`** produces an OCF Vesting event stream under `CUMULATIVE_ROUND_DOWN` allocation. `runtime` is a `VestingRuntime` bag containing the per-grant inputs that on-the-wire come from canonical transactions:
  - `startDate` → `TX_CANONICAL_VESTING_START` (anchor for DATE-anchored statements)
  - `eventFirings` → zero-or-more `TX_CANONICAL_VESTING_EVENT` (anchors for EVENT-anchored statements, optional `realized_fraction` for partial payouts)
  - `grantDate` → `TX_CANONICAL_EQUITY_COMPENSATION_ISSUANCE.date` (implicit-cliff aggregator)
- Handles DATE vs EVENT statements per `vesting_base`. DATE statements chain by `order` (preserving the existing bespoke-5/15/40/40 chaining semantic). EVENT statements anchor absolutely at their firing date; if no firing matches, the statement is silently skipped (grant ends partly unvested, per canonical spec). One firing fans out to all statements sharing its `event_id`. Output events are sorted chronologically with `(statement.order, occurrence)` as the tie-break.
- Includes exact-rational arithmetic, end-of-month-clamped date math with seed preservation, cliff handling (standard and non-standard), and optional grant-date implicit cliff (events before `grantDate` aggregate onto it, applies uniformly to DATE and EVENT events).
- Sibling modules: `allocate` (dispatch on `Allocation_Type`; only `CUMULATIVE_ROUND_DOWN` implemented, switch in place for future modes), `validate` (returns `{ valid, errors[] }` for `VestingScheduleTemplate` and `VestingRuntime`), `dates` (exports shared `ISO_DATE_PATTERN`), `fractions` (pure rational helpers).

### `types/canonical/vesting/`

Ports the canonical vesting types from OCF-Composed-Schemas: `VestingScheduleTemplate`, `VestingStatement` with the new `vesting_base` field, `VestingBase`/`VestingBaseDate`/`VestingBaseEvent` discriminator, `Cliff`, `Fraction`. The deprecated `VestingSchedule` type is removed (per-grant runtime data now lives in `VestingRuntime` on the OCF-Tools side; on the wire, it lives on `TX_CANONICAL_VESTING_START` and `TX_CANONICAL_VESTING_EVENT`).

### `types/index.ts`

Renames `vestingObject` → `Vesting` (matches OCF schema name directly).

### OCF validator stubs

Adds forward-pointing TODO comments to `ts_vesting_event.ts` and `ts_vesting_start.ts` describing how a follow-up PR will wire them up against the new compiler/validator once `OcfPackageContent` carries canonical templates and transactions.

## Stacking

Stacked on `remove-vesting-generators` (PR #142). A follow-up **PR-B** (separate branch) will port the three canonical TX TypeScript types, update `read_ocf_package` to parse canonical transactions, wire state-machine handlers for `TX_CANONICAL_VESTING_START` and `TX_CANONICAL_VESTING_EVENT`, and migrate sample data.

## Test plan

- [ ] `npm run build` passes (TypeScript type check, strict mode)
- [ ] `npm run test:ci` — 112 Jest tests across `compile`, `allocate`, `dates`, `fractions`, `validate` modules
  - DATE-anchored: standard 4yr/1mo with 25% cliff, non-standard 30% cliff, bespoke 5/15/40/40 chained, DAYS schedule, seed-day preservation, zero-percent statement, full grant-date implicit-cliff coverage
  - EVENT-anchored: instantaneous vest, partial firing with `realized_fraction`, post-event monthly schedule, fan-out (one firing → multiple matching statements), unfired EVENT statement skipped, all-EVENT-unfired
  - Hybrid DATE+EVENT: chronological interleaving; EVENT-firing-before-grant_date aggregation; EVENT-firing-on-grant_date passthrough
  - Runtime validation: missing startDate for DATE templates, duplicate event_id firings, event_id not in template, non-ISO dates, `realized_fraction` outside [0, 1]
- [ ] Spot-check that the worked examples in OCF-Composed-Schemas `canonical/vesting/VestingScheduleTemplate.mapping.md` produce the expected event streams
