### PR TITLE
Fix taget→target transition typos and drop dead predictableActionArguments (XState v5 housekeeping)

### DIFF
--- a/ocf_validator/ocfMachine.ts
+++ b/ocf_validator/ocfMachine.ts
@@ -21,7 +21,6 @@ export type OcfMachineEvent = {
 };
 
 export const ocfMachine: any = {
-  predictableActionArguments: true,
   id: "OCF-xstate",
   initial: "capTable",
   context: {
@@ -887,14 +886,14 @@ export const ocfMachine: any = {
           },
         ],
         RUN_EOD: {
-          taget: "capTable",
+          target: "capTable",
           actions: assign({
             snapshots: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => 
               [...context.snapshots, run_EOD(context, event)]
           }),
         },
         RUN_END: {
-          taget: "capTable",
+          target: "capTable",
           actions: [
           assign ({
             result: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => `The validation of the OCF package for ${context.ocfPackageContent.manifest.issuer.legal_name} is complete and the package appears valid.`


### PR DESCRIPTION
Closes #158.

Two XState v5 housekeeping fixes in `ocf_validator/ocfMachine.ts`, off `main` (no dependency on the typing/refactor work):

- **`taget` → `target`** on `RUN_EOD` / `RUN_END`. The misspelled key meant those self-transitions carried no `target`; restored the intended `target: "capTable"`.
- **Drop `predictableActionArguments`** — a v4-only flag, ignored under XState v5.

**Behavior-neutral.** The transition `actions` already executed regardless of the typo, and `capTable` has no entry/exit actions, so correcting the target changes nothing observable. The characterization snapshot is unchanged; `npm run build` and `npm run test:ci` pass.
