### PR TITLE
Type the machine context data fields

### DIFF
--- a/ocf_validator/eod.ts
+++ b/ocf_validator/eod.ts
@@ -1,10 +1,11 @@
 import { OcfMachineContext } from "./ocfMachine";
+import type { Snapshot } from "../types/snapshot";
 
-const RUN_EOD = (context: OcfMachineContext, event: any): any => {
-  let snapshot: any = {date: event.date, stockIssuances: [], convertibles: [], warrants: [], equityCompensation: []};
+const RUN_EOD = (context: OcfMachineContext, event: any): Snapshot => {
+  let snapshot: Snapshot = {date: event.date, stockIssuances: [], convertibles: [], warrants: [], equityCompensation: []};
 
   
-  context.stockIssuances.forEach((issuance: any) => {
+  context.stockIssuances.forEach((issuance) => {
     snapshot.stockIssuances.push({
             date: issuance.date,
       custom_id: issuance.custom_id,

--- a/ocf_validator/ocfMachine.ts
+++ b/ocf_validator/ocfMachine.ts
@@ -1,17 +1,24 @@
 import { assign } from "xstate";
-import { OcfPackageContent } from "../read_ocf_package";
+import type {
+  OCFStockIssuance,
+  OCFConvertibleIssuance,
+  OCFWarrantIssuance,
+  OCFEquityCompensationIssuance,
+} from "@opencaptablecoalition/ocf-types";
+import type { OcfPackageContent } from "../read_ocf_package";
+import type { Snapshot } from "../types/snapshot";
 import validators from "./validators";
 import run_EOD from "./eod";
 
 export type OcfMachineContext = {
-  stockIssuances: any[];
-  equityCompensation: any[];
-  convertibleIssuances: any[];
-  warrantIssuances: any[];
+  stockIssuances: OCFStockIssuance[];
+  equityCompensation: OCFEquityCompensationIssuance[];
+  convertibleIssuances: OCFConvertibleIssuance[];
+  warrantIssuances: OCFWarrantIssuance[];
   ocfPackageContent: OcfPackageContent;
   report: any[];
-  snapshots: any[],
-  result : any
+  snapshots: Snapshot[];
+  result: string;
 };
 
 export type OcfMachineEvent = {

--- a/types/machine-context.assert.ts
+++ b/types/machine-context.assert.ts
@@ -1,0 +1,27 @@
+/**
+ * Compile-time assertions for the typed machine context (#155). No runtime —
+ * this file is type-checked by `tsc` (the build) because it is not a `*.test.ts`
+ * file, so a broken invariant fails the build.
+ */
+import type { OcfMachineContext } from "../ocf_validator/ocfMachine";
+import type { Snapshot } from "./snapshot";
+import type {
+  OCFStockIssuance,
+  OCFConvertibleIssuance,
+  OCFWarrantIssuance,
+  OCFEquityCompensationIssuance,
+} from "@opencaptablecoalition/ocf-types";
+import type { Expect, Equal } from "./type-assert";
+
+type _Stock = Expect<Equal<OcfMachineContext["stockIssuances"], OCFStockIssuance[]>>;
+type _Convertible = Expect<
+  Equal<OcfMachineContext["convertibleIssuances"], OCFConvertibleIssuance[]>
+>;
+type _Warrant = Expect<
+  Equal<OcfMachineContext["warrantIssuances"], OCFWarrantIssuance[]>
+>;
+type _EquityComp = Expect<
+  Equal<OcfMachineContext["equityCompensation"], OCFEquityCompensationIssuance[]>
+>;
+type _Snapshots = Expect<Equal<OcfMachineContext["snapshots"], Snapshot[]>>;
+type _Result = Expect<Equal<OcfMachineContext["result"], string>>;

--- a/types/snapshot.ts
+++ b/types/snapshot.ts
@@ -1,0 +1,44 @@
+/**
+ * The end-of-day snapshot element produced by `run_EOD` (ocf_validator/eod.ts)
+ * and accumulated in `OcfMachineContext.snapshots`. This is a hand-written,
+ * lossy projection of the cap-table state — there is no generated OCF type for
+ * it. Field values are projected from the (currently untyped) issuance records.
+ */
+
+export interface SnapshotStockIssuance {
+  date: string;
+  custom_id: string;
+  stakeholder: string;
+  stock_class: string;
+  quantity: string;
+}
+
+export interface SnapshotConvertibleIssuance {
+  date: string;
+  custom_id: string;
+  stakeholder: string;
+  purchase_price: unknown;
+}
+
+export interface SnapshotWarrantIssuance {
+  date: string;
+  custom_id: string;
+  stakeholder: string;
+  purchase_price: unknown;
+}
+
+export interface SnapshotEquityCompensation {
+  date: string;
+  custom_id: string;
+  stakeholder: string;
+  quantity: string;
+  availableToExercise: unknown;
+}
+
+export interface Snapshot {
+  date: string;
+  stockIssuances: SnapshotStockIssuance[];
+  convertibles: SnapshotConvertibleIssuance[];
+  warrants: SnapshotWarrantIssuance[];
+  equityCompensation: SnapshotEquityCompensation[];
+}


### PR DESCRIPTION
Closes #155.

Types the data fields of `OcfMachineContext` using the vendored OCF types (#172) — the first step of the typed surface.

- `stockIssuances` / `convertibleIssuances` / `warrantIssuances` / `equityCompensation` → the per-schema OCF issuance types (`OCFStockIssuance` etc.).
- `result` → `string`; `snapshots` → a new hand-written `Snapshot` type (`types/snapshot.ts`) for the EOD projection (no generated type exists for it).
- Adds `types/machine-context.assert.ts`, a compile-time assertion (checked by `tsc`) pinning the new field types.

**Scope:** data fields only. Event typing and the `setup()`/data-driven-table rework are deferred to #157; `report`'s shape is left to #156 (graded findings); `manifest` / `OcfPackageContent` tightening is #154.

**Behavior-neutral:** type-only. The characterization snapshot is unchanged; `npm run build` and `npm run test:ci` pass.

Stacked on #172 (base `vendor-ocf-types-581`); will retarget to `main` when #172 merges.
