### PR TITLE
Add the graded `findings` model (typed `Finding` + `findings[]` channel)

### DIFF
--- a/ocf_validator/ocfMachine.ts
+++ b/ocf_validator/ocfMachine.ts
@@ -7,6 +7,7 @@ import type {
 } from "@opencaptablecoalition/ocf-types";
 import type { OcfPackageContent } from "../read_ocf_package";
 import type { Snapshot } from "../types/snapshot";
+import type { Finding } from "../types/finding";
 import validators from "./validators";
 import run_EOD from "./eod";
 
@@ -17,6 +18,7 @@ export type OcfMachineContext = {
   warrantIssuances: OCFWarrantIssuance[];
   ocfPackageContent: OcfPackageContent;
   report: any[];
+  findings: Finding[];
   snapshots: Snapshot[];
   result: string;
 };
@@ -38,6 +40,7 @@ export const ocfMachine: any = {
     warrantIssuances: [],
     ocfPackageContent: {},
     report: [],
+    findings: [],
     snapshots: [],
     result: 'Incomplete'
   },

--- a/tests/__snapshots__/characterization.test.ts.snap
+++ b/tests/__snapshots__/characterization.test.ts.snap
@@ -34,6 +34,7 @@ exports[`ocfValidator over testPackage > produces a stable validation result and
       "vesting_terms_id": "four_year_monthly_one_year_cliff_cumulative_round_down",
     },
   ],
+  "findings": [],
   "report": [
     {
       "stakeholder_validity": true,

--- a/types/finding.assert.ts
+++ b/types/finding.assert.ts
@@ -1,0 +1,85 @@
+/**
+ * Compile-time assertions for the graded findings model (#156). No runtime —
+ * this file is type-checked by `tsc` (the build) because it is not a `*.test.ts`
+ * file, so a broken invariant fails the build.
+ */
+import type { OcfMachineContext } from "../ocf_validator/ocfMachine";
+import type { Finding, Severity } from "./finding";
+import type { ObjectTypeMap } from "@opencaptablecoalition/ocf-types";
+import type { Expect, Equal } from "./type-assert";
+
+// Pin 1: the findings channel is typed as Finding[].
+type _FindingsChannel = Expect<Equal<OcfMachineContext["findings"], Finding[]>>;
+
+// Pin 2: Severity is exactly "error" | "warning" — no other string is assignable.
+type _Severity = Expect<Equal<Severity, "error" | "warning">>;
+
+// Pin 3: Finding has exactly these fields — catches drift if a field is added or renamed.
+type _FindingKeys = Expect<
+  Equal<keyof Finding, "severity" | "check" | "message" | "subject">
+>;
+
+// Pin 3b: the subject locator is { object_type, id }, with object_type keyed to
+// the generated OCF schema map (any OCF object, not only transactions).
+type _SubjectKeys = Expect<Equal<keyof Finding["subject"], "object_type" | "id">>;
+type _SubjectObjectType = Expect<
+  Equal<Finding["subject"]["object_type"], keyof ObjectTypeMap>
+>;
+
+// Pin 4: All fields are required — no field may be accidentally made optional.
+type _FindingRequired = Expect<Equal<Finding, Required<Finding>>>;
+
+// Pin 5a: Positive literal with severity "warning" and a transaction subject.
+const _warningFinding: Finding = {
+  severity: "warning",
+  check: "EXAMPLE_CHECK",
+  message: "Example warning message",
+  subject: { object_type: "TX_STOCK_ISSUANCE", id: "tx_001" },
+};
+
+// Pin 5b: Positive literal with severity "error" and a NON-transaction subject
+// (proves the subject locator generalizes beyond transactions).
+const _errorFinding: Finding = {
+  severity: "error",
+  check: "EXAMPLE_CHECK",
+  message: "Example error message",
+  subject: { object_type: "STAKEHOLDER", id: "st_001" },
+};
+
+// Pin 5c: Negative — severity "info" must be rejected.
+const _infoFinding: Finding = {
+  // @ts-expect-error — "info" is not assignable to Severity ("error" | "warning")
+  severity: "info",
+  check: "EXAMPLE_CHECK",
+  message: "Example info message",
+  subject: { object_type: "TX_STOCK_ISSUANCE", id: "tx_003" },
+};
+
+// Pin 5d: Negative — a non-OCF object_type must be rejected (proves the
+// keyof ObjectTypeMap tightening actually constrains the value).
+const _badSubject: Finding = {
+  severity: "error",
+  check: "EXAMPLE_CHECK",
+  message: "Example message",
+  subject: {
+    // @ts-expect-error — "NOT_A_REAL_OBJECT_TYPE" is not a key of ObjectTypeMap
+    object_type: "NOT_A_REAL_OBJECT_TYPE",
+    id: "x_001",
+  },
+};
+
+// Pin 6: Accumulation guard — xstate-style append must type-check.
+const _acc = (c: OcfMachineContext, f: Finding): Finding[] => [
+  ...c.findings,
+  f,
+];
+
+// Optional: pin that report's declared type is left untouched.
+type _Report = Expect<Equal<OcfMachineContext["report"], any[]>>;
+
+// Silence unused-variable warnings from tsc.
+void _warningFinding;
+void _errorFinding;
+void _infoFinding;
+void _badSubject;
+void _acc;

--- a/types/finding.ts
+++ b/types/finding.ts
@@ -1,0 +1,17 @@
+import type { ObjectTypeMap } from "@opencaptablecoalition/ocf-types";
+
+export type Severity = "error" | "warning";
+
+export interface Finding {
+  severity: Severity;
+  check: string;
+  message: string;
+  /**
+   * The OCF object this finding is about — any object, not only a transaction.
+   * `object_type` is keyed to the generated schema map, so an unknown type is a
+   * compile error; `id` is that object's OCF id. A non-object-scoped check (e.g.
+   * package/file-level) would widen `object_type` here — deliberately a conscious
+   * change rather than a silently-bogus value.
+   */
+  subject: { object_type: keyof ObjectTypeMap; id: string };
+}


### PR DESCRIPTION
Closes #156.

Adds the graded findings **model** — the typed channel later issues consume — with **no validation-behavior change**. Phase 2 (Types), stacked on #175.

## What this adds
- **`types/finding.ts`** — `Severity = "error" | "warning"` and a flat `Finding` interface (six required `string` fields: `severity`, `check`, `message`, `transaction_type`, `transaction_id`, `transaction_date`). The shape mirrors vestlang's `Diagnostic`, so the later `@vestlang/core` integration (#165) is a straight map.
- **`OcfMachineContext.findings: Finding[]`** — a new graded channel **alongside the untouched `report: any[]`**, initialized `[]`. Division of labor: `report` = the existing per-transaction pass/fail audit trail (kept as-is); `findings` = a flat, severity-filterable problem stream.
- **`types/finding.assert.ts`** — build-checked compile-time pins (the channel type, the exact `Severity` union, `Finding`'s exact required field set, a negative `@ts-expect-error` rejecting `"info"`, and an accumulation guard). It lives in a non-`*.test.ts` file so `tsc` (the build) actually enforces it.

## Scope (deliberately narrow)
- **Pure model only.** No validator migration, no per-check `error`/`warning` classification, no halting/behavior change — those belong to **#159** (Engine), which consumes this model.
- **Behavior-neutral.** `report` is untouched; the only runtime change is the characterization snapshot additively gaining `findings: []`. `npm run build` and `npm run test:ci` are green.
- `info` severity and the richer discriminated-union-with-payload shape are deferred to the `@vestlang/core` integration (**#165**).

Stacked on #175 (base `issue-155-machine-context`); will retarget down the stack as parents merge.

