### PR TITLE
Type the public API return shapes (#154)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,9 @@
 export { readOcfPackage } from "./read_ocf_package";
 export { ocfValidator } from "./ocf_validator";
 export { ocfSnapshot } from "./ocf_snapshot";
+
+// Return types of the public entry points, so the surface is nameable by consumers.
+// OcfMachineContext lives in its defining module (the barrel re-exports only the value).
+export type { OcfPackageContent } from "./read_ocf_package";
+export type { OcfMachineContext } from "./ocf_validator/ocfMachine";
+export type { Snapshot } from "./types/snapshot";

--- a/ocf_snapshot/index.ts
+++ b/ocf_snapshot/index.ts
@@ -1,15 +1,16 @@
 import { OcfPackageContent, readOcfPackage } from "../read_ocf_package";
 import { ocfValidator } from "../ocf_validator";
+import type { Snapshot } from "../types/snapshot";
 
-export const ocfSnapshot = (packagePath: string, inputDateStr: string) => {
+export const ocfSnapshot = (packagePath: string, inputDateStr: string): Snapshot | null => {
     
     const ocfPackage: OcfPackageContent = readOcfPackage(packagePath);
     const snapshots = ocfValidator(packagePath).snapshots;
     const inputDate = new Date(inputDateStr);
 
-    const filteredSnapshots = snapshots.filter((snapshot: any) => new Date(snapshot.date) <= inputDate);
+    const filteredSnapshots = snapshots.filter((snapshot: Snapshot) => new Date(snapshot.date) <= inputDate);
 
-    filteredSnapshots.sort((a: any, b: any) => new Date(b.date).getTime() - new Date(a.date).getTime());
+    filteredSnapshots.sort((a: Snapshot, b: Snapshot) => new Date(b.date).getTime() - new Date(a.date).getTime());
 
     const snapshot = filteredSnapshots.length? filteredSnapshots[0]: null;
     

--- a/ocf_validator/index.ts
+++ b/ocf_validator/index.ts
@@ -1,9 +1,9 @@
 import { createMachine, createActor } from "xstate";
 import { OcfPackageContent, readOcfPackage } from "../read_ocf_package";
 import constants from "./constants/constants";
-import { ocfMachine } from "./ocfMachine";
+import { ocfMachine, type OcfMachineContext } from "./ocfMachine";
 
-export const ocfValidator = (packagePath: string): any => {
+export const ocfValidator = (packagePath: string): OcfMachineContext => {
   const ocfPackage: OcfPackageContent = readOcfPackage(packagePath);
   const { manifest, transactions } = ocfPackage;
 
@@ -39,5 +39,9 @@ export const ocfValidator = (packagePath: string): any => {
     ocfXstateActor.send({ type: "RUN_END", date: currentDate });
   }
 
-  return (ocfXstateActor.getSnapshot().context);
+  // xstate types getSnapshot().context as Record<string, any> (the machine config is
+  // still annotated `any`), so cast to the real context shape at this boundary. #157
+  // types the machine via setup() and MUST drop this cast — left in place, it would
+  // suppress a genuine mismatch between the declared and actual context.
+  return ocfXstateActor.getSnapshot().context as OcfMachineContext;
 };

--- a/types/public-api.assert.ts
+++ b/types/public-api.assert.ts
@@ -1,0 +1,30 @@
+/**
+ * Compile-time assertions for the public API return shapes (#154). No runtime —
+ * type-checked by `tsc` (the build) because it is not a `*.test.ts` file.
+ *
+ * Scope of what these pin: the *resolved* return type of each public entry point.
+ * They are a regression guard against the return drifting to `any` — NOT a proof
+ * that the type matches the real machine. For `ocfValidator` in particular the
+ * value side is reached through an `as OcfMachineContext` cast (the machine config
+ * is still `any`), so this assert cannot see past the cast; the genuine check lands
+ * with #157 when the cast is removed. The internal `Snapshot`-typed callbacks in
+ * `ocfSnapshot` are NOT pinned here (callback params don't affect a return type) —
+ * those are a reviewer check.
+ */
+import { readOcfPackage } from "../read_ocf_package";
+import { ocfValidator } from "../ocf_validator";
+import { ocfSnapshot } from "../ocf_snapshot";
+import type { OcfPackageContent } from "../read_ocf_package";
+import type { OcfMachineContext } from "../ocf_validator/ocfMachine";
+import type { Snapshot } from "./snapshot";
+import type { Expect, Equal } from "./type-assert";
+
+type _ReadOcfPackage = Expect<
+  Equal<ReturnType<typeof readOcfPackage>, OcfPackageContent>
+>;
+type _OcfValidator = Expect<
+  Equal<ReturnType<typeof ocfValidator>, OcfMachineContext>
+>;
+type _OcfSnapshot = Expect<
+  Equal<ReturnType<typeof ocfSnapshot>, Snapshot | null>
+>;


### PR DESCRIPTION
Closes #154.

Completes the Phase 2 typed surface — the three public entry points now have typed return shapes. Type-only / behavior-neutral. Stacked on #177.

## What this types
- **`ocfValidator`**: `any` → `OcfMachineContext`. xstate types the machine context as `Record<string, any>` (the machine config is still `any`), so the return uses an `as OcfMachineContext` cast at that boundary. **#157** types the machine via `setup()` and must *remove* this cast — left in, it would suppress a real declared-vs-actual mismatch.
- **`ocfSnapshot`**: now `Snapshot | null`, with its internal filter/sort callbacks typed `Snapshot`.
- **`readOcfPackage`**: already `OcfPackageContent` (#172) — unchanged, pinned for regression.
- Root `index.ts` re-exports `OcfPackageContent`, `OcfMachineContext`, `Snapshot` as `export type`, so consumers can name the returns.
- **`types/public-api.assert.ts`**: pins each return via `ReturnType<typeof fn>`. These are regression guards on the annotations — they can't see past the `ocfValidator` cast to the machine's real context; that verification lands with #157.

## Scope
Faithful typing only — `npm run build` + `npm run test:ci` green, characterization snapshot unchanged. Deliberately NOT done: curating the public return shape (#166), fixing `ocfSnapshot`'s double read (#162), typing the machine itself (#157).

**Known caveat (type- vs runtime-faithful):** typing `ocfValidator` as the *full* context means the published type includes `ocfPackageContent`, which is `{}` on the zero-transaction path (START never fires). Type-faithful, but the surface over-promises in that edge case — noted so #157/#166 inherit it knowingly.

Stacked on #177 (base `issue-156-graded-findings`); retargets down the stack as parents merge.

