### PR TITLE
Type the XState machine with `setup()` and collapse handlers into a data-driven table (#157)

### DIFF
--- a/ocf_validator/index.ts
+++ b/ocf_validator/index.ts
@@ -1,19 +1,23 @@
-import { createMachine, createActor } from "xstate";
+import { createActor } from "xstate";
 import { OcfPackageContent, readOcfPackage } from "../read_ocf_package";
 import constants from "./constants/constants";
-import { ocfMachine, type OcfMachineContext } from "./ocfMachine";
+import { ocfMachine, type OcfMachineContext, type OcfMachineEvent } from "./ocfMachine";
 
 export const ocfValidator = (packagePath: string): OcfMachineContext => {
   const ocfPackage: OcfPackageContent = readOcfPackage(packagePath);
   const { manifest, transactions } = ocfPackage;
 
+  // `constants.transaction_types` is a sort-only keyspace, intentionally narrower
+  // than the machine's TX_TABLE — it doesn't list every transaction type, and
+  // reconciling the two is out of scope here. Unknown object_types sort to the
+  // front via indexOf === -1.
   const transactionTypes = constants.transaction_types;
 
   const sortedTransactions = transactions.sort((a: { date: string; object_type: string }, b: { date: string; object_type: string }) => a.date.localeCompare(b.date) || transactionTypes.indexOf(a.object_type) - transactionTypes.indexOf(b.object_type));
 
-  const ocfXstateMachine = createMachine(ocfMachine);
-
-  const ocfXstateActor = createActor(ocfXstateMachine).start();
+  // `ocfMachine` is already a configured machine (built with setup()), so it is
+  // passed straight to createActor — no createMachine() wrapping.
+  const ocfXstateActor = createActor(ocfMachine).start();
 
   let currentDate: any = null;
 
@@ -30,7 +34,11 @@ export const ocfValidator = (packagePath: string): OcfMachineContext => {
         }
       }
       currentDate = ele.date;
-      ocfXstateActor.send({ type: ele.object_type, data: ele });
+      // Boundary cast: `ele.object_type` and `ele` are read from disk, so TS
+      // cannot correlate the runtime `type` with its matching payload in the
+      // per-key event union. This single declared cast bridges parsed input to
+      // the typed event; the machine's `'*'` handler rejects any unknown type.
+      ocfXstateActor.send({ type: ele.object_type, data: ele } as OcfMachineEvent);
     }
   }
 
@@ -39,9 +47,7 @@ export const ocfValidator = (packagePath: string): OcfMachineContext => {
     ocfXstateActor.send({ type: "RUN_END", date: currentDate });
   }
 
-  // xstate types getSnapshot().context as Record<string, any> (the machine config is
-  // still annotated `any`), so cast to the real context shape at this boundary. #157
-  // types the machine via setup() and MUST drop this cast — left in place, it would
-  // suppress a genuine mismatch between the declared and actual context.
-  return ocfXstateActor.getSnapshot().context as OcfMachineContext;
+  // The machine is typed via setup(), so getSnapshot().context is OcfMachineContext
+  // with no cast needed.
+  return ocfXstateActor.getSnapshot().context;
 };

--- a/ocf_validator/ocfMachine.ts
+++ b/ocf_validator/ocfMachine.ts
@@ -1,15 +1,35 @@
-import { assign } from "xstate";
+import { setup, assign } from "xstate";
 import type {
+  ObjectTypeMap,
   OCFStockIssuance,
   OCFConvertibleIssuance,
   OCFWarrantIssuance,
   OCFEquityCompensationIssuance,
 } from "@opencaptablecoalition/ocf-types";
+import type { TransactionFor } from "../types/ocf-input";
 import type { OcfPackageContent } from "../read_ocf_package";
 import type { Snapshot } from "../types/snapshot";
 import type { Finding } from "../types/finding";
 import validators from "./validators";
 import run_EOD from "./eod";
+
+// ---------------------------------------------------------------------------
+// Cap-table collections
+// ---------------------------------------------------------------------------
+
+/**
+ * The element type held by each family collection. Pairing a collection name
+ * with a payload of the wrong family is a *compile* error (see
+ * `appendToCollection`).
+ */
+interface CollectionElement {
+  stockIssuances: OCFStockIssuance;
+  convertibleIssuances: OCFConvertibleIssuance;
+  warrantIssuances: OCFWarrantIssuance;
+  equityCompensation: OCFEquityCompensationIssuance;
+}
+
+export type CollectionKey = keyof CollectionElement;
 
 export type OcfMachineContext = {
   stockIssuances: OCFStockIssuance[];
@@ -23,14 +43,287 @@ export type OcfMachineContext = {
   result: string;
 };
 
-export type OcfMachineEvent = {
-  type: string;
-  data: any;
-  date: string;
+// ---------------------------------------------------------------------------
+// Per-key event union — each transaction handler's payload is `TransactionFor<K>`
+// ---------------------------------------------------------------------------
+
+/** Every `TX_*` value a package can carry. */
+export type TxKey = Extract<keyof ObjectTypeMap, `TX_${string}`>;
+
+/** One event variant per `TxKey`, so a handler for `K` receives `TransactionFor<K>`. */
+type TxEvent = {
+  [K in TxKey]: { type: K; data: TransactionFor<K>; date?: string };
+}[TxKey];
+
+export type OcfMachineEvent =
+  | TxEvent
+  | { type: "START"; data: OcfPackageContent; date: string }
+  | { type: "RUN_EOD"; date: string }
+  | { type: "RUN_END"; date: string };
+
+// ---------------------------------------------------------------------------
+// Family-collection helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Append `data` to a family collection. The `collection` literal pins `C`, so
+ * `current` and `data` must both belong to that family — appending a wrong-family
+ * payload (e.g. a warrant payload onto the convertible collection) is a COMPILE
+ * error. Exercised in `types/ocf-machine-table.assert.ts`.
+ */
+export function appendToCollection<C extends CollectionKey>(
+  _collection: C,
+  current: CollectionElement[C][],
+  data: CollectionElement[C],
+): CollectionElement[C][] {
+  return [...current, data];
+}
+
+/** Remove every member of a collection matching `securityId`. */
+function removeFromCollection<E extends { security_id: string }>(
+  current: E[],
+  securityId: unknown,
+): E[] {
+  return current.filter((obj) => obj.security_id !== securityId);
+}
+
+/**
+ * The family collection a transaction belongs to, derived from its `TX_<FAMILY>_*`
+ * prefix. Single source of truth for the family→collection mapping, shared by the
+ * machine's `remove` path and the per-type tests.
+ */
+export const collectionKeyFor = (type: TxKey): CollectionKey => {
+  if (type.startsWith("TX_STOCK_")) return "stockIssuances";
+  if (type.startsWith("TX_CONVERTIBLE_")) return "convertibleIssuances";
+  if (type.startsWith("TX_WARRANT_")) return "warrantIssuances";
+  return "equityCompensation";
 };
 
-export const ocfMachine: any = {
-  predictableActionArguments: true,
+// ---------------------------------------------------------------------------
+// The data-driven transaction table
+// ---------------------------------------------------------------------------
+
+type Validator = (
+  context: OcfMachineContext,
+  event: OcfMachineEvent,
+  isGuard: boolean,
+) => any;
+
+/**
+ * One row per `TxKey`. An active row carries the *operation* and the *validator*
+ * for that key, referenced once so the guard and the report always use the same
+ * validator. A `passthrough` row is a type the machine receives and silently
+ * ignores.
+ *
+ *  - `append`: validate, report, and append the issuance to its family collection.
+ *  - `none`:   validate and report, but mutate no collection.
+ *  - `remove`: validate, report, and filter the family collection by `security_id`.
+ */
+type TxRow =
+  | { op: "append" | "none" | "remove"; validator: Validator }
+  | { op: "passthrough" };
+
+const TX_TABLE = {
+  // --- append: issuance appended to its family collection -----------------
+  TX_STOCK_ISSUANCE: { op: "append", validator: validators.valid_tx_stock_issuance },
+  TX_CONVERTIBLE_ISSUANCE: { op: "append", validator: validators.valid_tx_convertible_issuance },
+  TX_WARRANT_ISSUANCE: { op: "append", validator: validators.valid_tx_warrant_issuance },
+  TX_EQUITY_COMPENSATION_ISSUANCE: { op: "append", validator: validators.valid_tx_equity_compensation_issuance },
+
+  // --- none: validate + report, no collection mutation --------------------
+  TX_STOCK_ACCEPTANCE: { op: "none", validator: validators.valid_tx_stock_acceptance },
+  TX_CONVERTIBLE_ACCEPTANCE: { op: "none", validator: validators.valid_tx_convertible_acceptance },
+  TX_WARRANT_ACCEPTANCE: { op: "none", validator: validators.valid_tx_warrant_acceptance },
+  TX_EQUITY_COMPENSATION_ACCEPTANCE: { op: "none", validator: validators.valid_tx_equity_compensation_acceptance },
+  // TX_EQUITY_COMPENSATION_EXERCISE removes nothing today (its collection filter
+  // is commented out in the legacy machine), asymmetric with TX_WARRANT_EXERCISE
+  // which removes. That asymmetry is PRESERVED pending investigation, not endorsed.
+  TX_EQUITY_COMPENSATION_EXERCISE: { op: "none", validator: validators.valid_tx_equity_compensation_exercise },
+
+  // --- remove: filter the family collection by security_id ---------------
+  TX_STOCK_RETRACTION: { op: "remove", validator: validators.valid_tx_stock_retraction },
+  TX_STOCK_CANCELLATION: { op: "remove", validator: validators.valid_tx_stock_cancellation },
+  TX_STOCK_CONVERSION: { op: "remove", validator: validators.valid_tx_stock_conversion },
+  TX_STOCK_REISSUANCE: { op: "remove", validator: validators.valid_tx_stock_reissuance },
+  TX_STOCK_REPURCHASE: { op: "remove", validator: validators.valid_tx_stock_repurchase },
+  TX_STOCK_TRANSFER: { op: "remove", validator: validators.valid_tx_stock_transfer },
+  TX_CONVERTIBLE_RETRACTION: { op: "remove", validator: validators.valid_tx_convertible_retraction },
+  TX_CONVERTIBLE_CANCELLATION: { op: "remove", validator: validators.valid_tx_convertible_cancellation },
+  TX_CONVERTIBLE_TRANSFER: { op: "remove", validator: validators.valid_tx_convertible_transfer },
+  TX_CONVERTIBLE_CONVERSION: { op: "remove", validator: validators.valid_tx_convertible_conversion },
+  TX_WARRANT_RETRACTION: { op: "remove", validator: validators.valid_tx_warrant_retraction },
+  TX_WARRANT_CANCELLATION: { op: "remove", validator: validators.valid_tx_warrant_cancellation },
+  TX_WARRANT_TRANSFER: { op: "remove", validator: validators.valid_tx_warrant_transfer },
+  TX_WARRANT_EXERCISE: { op: "remove", validator: validators.valid_tx_warrant_exercise },
+  TX_EQUITY_COMPENSATION_RETRACTION: { op: "remove", validator: validators.valid_tx_equity_compensation_retraction },
+  TX_EQUITY_COMPENSATION_CANCELLATION: { op: "remove", validator: validators.valid_tx_equity_compensation_cancellation },
+  TX_EQUITY_COMPENSATION_TRANSFER: { op: "remove", validator: validators.valid_tx_equity_compensation_transfer },
+
+  // --- passthrough: received and silently ignored today ------------------
+  //   No validator, no report entry, no collection mutation. They stay in
+  //   `capTable` so today's behavior (and the characterization snapshot, which
+  //   contains TX_VESTING_START) is byte-identical. `satisfies Record<TxKey, …>`
+  //   below forces any future OCF transaction type to be classified here — a
+  //   compile error until it is.
+  TX_EQUITY_COMPENSATION_RELEASE: { op: "passthrough" },
+  TX_EQUITY_COMPENSATION_REPRICING: { op: "passthrough" },
+  TX_ISSUER_AUTHORIZED_SHARES_ADJUSTMENT: { op: "passthrough" },
+  TX_PLAN_SECURITY_ACCEPTANCE: { op: "passthrough" },
+  TX_PLAN_SECURITY_CANCELLATION: { op: "passthrough" },
+  TX_PLAN_SECURITY_EXERCISE: { op: "passthrough" },
+  TX_PLAN_SECURITY_ISSUANCE: { op: "passthrough" },
+  TX_PLAN_SECURITY_RELEASE: { op: "passthrough" },
+  TX_PLAN_SECURITY_RETRACTION: { op: "passthrough" },
+  TX_PLAN_SECURITY_TRANSFER: { op: "passthrough" },
+  TX_STOCK_CLASS_AUTHORIZED_SHARES_ADJUSTMENT: { op: "passthrough" },
+  TX_STOCK_CLASS_CONVERSION_RATIO_ADJUSTMENT: { op: "passthrough" },
+  TX_STOCK_CLASS_SPLIT: { op: "passthrough" },
+  TX_STOCK_CONSOLIDATION: { op: "passthrough" },
+  TX_STOCK_PLAN_POOL_ADJUSTMENT: { op: "passthrough" },
+  TX_STOCK_PLAN_RETURN_TO_POOL: { op: "passthrough" },
+  TX_VESTING_ACCELERATION: { op: "passthrough" },
+  TX_VESTING_EVENT: { op: "passthrough" },
+  TX_VESTING_START: { op: "passthrough" },
+} satisfies Record<TxKey, TxRow>;
+
+export type TxTable = typeof TX_TABLE;
+export type { TxRow };
+
+const CONTROL_EVENTS = ["START", "RUN_EOD", "RUN_END"] as const;
+type ControlEvent = (typeof CONTROL_EVENTS)[number];
+
+const isControlEvent = (event: OcfMachineEvent): event is Extract<OcfMachineEvent, { type: ControlEvent }> =>
+  (CONTROL_EVENTS as readonly string[]).includes(event.type);
+
+/** The derived validator for an event, or `undefined` for control/passthrough events. */
+const validatorForEvent = (event: OcfMachineEvent): Validator | undefined => {
+  if (isControlEvent(event)) return undefined;
+  const row = TX_TABLE[event.type];
+  return "validator" in row ? row.validator : undefined;
+};
+
+// ---------------------------------------------------------------------------
+// The machine — typed via setup({ types, actions, guards })
+// ---------------------------------------------------------------------------
+
+const failureMessage = (context: OcfMachineContext, subject: string, detail: string): string =>
+  `The validation of the OCF package for ${context.ocfPackageContent.manifest.issuer.legal_name} failed on ${subject}: ${detail}`;
+
+/**
+ * Valid-branch collection mutation, derived from the table `op` and the TX family
+ * prefix. `append` rows push the issuance onto their family collection; `remove`
+ * rows filter it by `security_id`; `none` rows (and control events) mutate nothing.
+ */
+export function collectionUpdate(
+  context: OcfMachineContext,
+  event: OcfMachineEvent,
+): Partial<OcfMachineContext> {
+  if (isControlEvent(event)) return {};
+  const row = TX_TABLE[event.type];
+
+  if (row.op === "append") {
+    // The per-key narrowing makes `event.data` the matching family payload, so a
+    // wrong-family append is a compile error (see appendToCollection).
+    switch (event.type) {
+      case "TX_STOCK_ISSUANCE":
+        return { stockIssuances: appendToCollection("stockIssuances", context.stockIssuances, event.data) };
+      case "TX_CONVERTIBLE_ISSUANCE":
+        return { convertibleIssuances: appendToCollection("convertibleIssuances", context.convertibleIssuances, event.data) };
+      case "TX_WARRANT_ISSUANCE":
+        return { warrantIssuances: appendToCollection("warrantIssuances", context.warrantIssuances, event.data) };
+      case "TX_EQUITY_COMPENSATION_ISSUANCE":
+        return { equityCompensation: appendToCollection("equityCompensation", context.equityCompensation, event.data) };
+      default:
+        return {};
+    }
+  }
+
+  if (row.op === "remove") {
+    const securityId = "security_id" in event.data ? event.data.security_id : undefined;
+    // `removeFromCollection` is family-agnostic (it only needs security_id); the
+    // concrete field per case keeps the assign cast-free.
+    switch (collectionKeyFor(event.type)) {
+      case "stockIssuances":
+        return { stockIssuances: removeFromCollection(context.stockIssuances, securityId) };
+      case "convertibleIssuances":
+        return { convertibleIssuances: removeFromCollection(context.convertibleIssuances, securityId) };
+      case "warrantIssuances":
+        return { warrantIssuances: removeFromCollection(context.warrantIssuances, securityId) };
+      case "equityCompensation":
+        return { equityCompensation: removeFromCollection(context.equityCompensation, securityId) };
+    }
+  }
+
+  return {};
+}
+
+/**
+ * Build the `on` map for every key in `TX_TABLE`: active keys share the
+ * two-branch transition; passthrough keys are an explicit no-op (`{}`).
+ */
+function buildTransactionHandlers() {
+  const activeTransitions = [
+    {
+      guard: "isValidTx",
+      target: "capTable",
+      actions: ["appendReport", "mutateCollection"],
+    },
+    {
+      target: "validationError",
+      actions: ["appendReport", "setValidationError"],
+    },
+  ] as const;
+  const passthrough = {} as const;
+
+  return (Object.keys(TX_TABLE) as TxKey[]).reduce(
+    (handlers, type) => {
+      handlers[type] = TX_TABLE[type].op === "passthrough" ? passthrough : activeTransitions;
+      return handlers;
+    },
+    {} as Record<TxKey, typeof activeTransitions | typeof passthrough>,
+  );
+}
+
+export const ocfMachine = setup({
+  types: {} as {
+    context: OcfMachineContext;
+    events: OcfMachineEvent;
+  },
+  guards: {
+    // Guard the valid branch via the type's own validator in `true` (boolean) mode.
+    isValidTx: ({ context, event }) => {
+      const validator = validatorForEvent(event);
+      return validator ? validator(context, event, true) : false;
+    },
+  },
+  actions: {
+    // Append the validator's report entry. Same validator reference as the guard,
+    // so the guard and the report can never diverge.
+    appendReport: assign({
+      report: ({ context, event }) => {
+        const validator = validatorForEvent(event);
+        return validator ? [...context.report, validator(context, event, false)] : context.report;
+      },
+    }),
+
+    // Invalid branch: record the failure message. `appendReport` runs immediately
+    // before this action on the invalid branch, so the validator's report entry is
+    // already at the tail of `report` — reuse it instead of re-running the
+    // (package-scanning) validator a third time.
+    setValidationError: assign({
+      result: ({ context, event }) => {
+        const subject = "data" in event && "id" in event.data ? event.data.id : event.type;
+        const lastReport = context.report[context.report.length - 1];
+        const detail = context.report.length ? JSON.stringify(lastReport, null, 2) : "";
+        return failureMessage(context, subject, detail);
+      },
+    }),
+
+    // Valid branch collection mutation, derived from the table `op` and the TX
+    // family prefix. `none` rows (and control events) mutate nothing.
+    mutateCollection: assign(({ context, event }) => collectionUpdate(context, event)),
+  },
+}).createMachine({
   id: "OCF-xstate",
   initial: "capTable",
   context: {
@@ -38,878 +331,55 @@ export const ocfMachine: any = {
     equityCompensation: [],
     convertibleIssuances: [],
     warrantIssuances: [],
-    ocfPackageContent: {},
+    ocfPackageContent: {
+      manifest: {},
+      stakeholders: [],
+      stockClasses: [],
+      transactions: [],
+      stockLegends: [],
+      stockPlans: [],
+      vestingTerms: [],
+      valuations: [],
+    },
     report: [],
     findings: [],
     snapshots: [],
-    result: 'Incomplete'
+    result: "Incomplete",
   },
   states: {
     capTable: {
       on: {
-        START: [
-          {
-            target: "capTable",
-            actions: [
-              assign({
-                ocfPackageContent: ({ event }: {event: OcfMachineEvent }) => event.data,
-              }),
-            ],
-          },
-        ],
-        TX_STOCK_ISSUANCE: [
-          {
-            guard: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => {
-              return validators.valid_tx_stock_issuance(context, event, true);
-            },
-            actions: [
-              assign({
-                report: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => 
-                  [...context.report, validators.valid_tx_stock_issuance(context, event, false)]
-
-              }),
-              assign({
-                stockIssuances: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => 
-                  [...context.stockIssuances, event.data],
-              }),
-            ],
-            target: "capTable",
-          },
-          {
-            target: "validationError",
-            actions: [
-              assign({
-                report: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) =>
-                  [...context.report, validators.valid_tx_stock_issuance(context, event, false)]
-              }),
-              assign({
-                result: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) =>
-                  `The validation of the OCF package for ${context.ocfPackageContent.manifest.issuer.legal_name} failed on ${event.data.id}: ${JSON.stringify(validators.valid_tx_stock_issuance(context, event, false),null, 2)}`
-              }),
-            ],
-          },
-        ],
-        TX_STOCK_RETRACTION: [
-          {
-            guard: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => {
-              return validators.valid_tx_stock_retraction(context, event, true);
-            },
-            target: 'capTable',
-            actions: [
-              assign({
-                report: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => 
-                  [...context.report, validators.valid_tx_stock_issuance(context, event, false)]
-              }),
-              assign({
-                stockIssuances: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => 
-                  context.stockIssuances.filter((obj: any) => { return obj.security_id !== event.data.security_id; }
-                  ),
-              }),
-
-            ],
-          },
-          {
-            target: "validationError",
-            actions: [
-              assign({
-                report: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) =>
-                  [...context.report, validators.valid_tx_stock_retraction(context, event, false)]
-              }),
-              assign({
-                result: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) =>
-                  `The validation of the OCF package for ${context.ocfPackageContent.manifest.issuer.legal_name} failed on ${event.data.id}: ${JSON.stringify(validators.valid_tx_stock_retraction(context, event, false),null, 2)}`
-              }),
-            ],
-          },
-        ],
-        TX_STOCK_ACCEPTANCE: [
-          {
-            guard: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => {
-              return validators.valid_tx_stock_acceptance(context, event, true);
-            },
-            target: 'capTable',
-            actions: [
-              assign({
-                report: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => 
-                  [...context.report, validators.valid_tx_stock_acceptance(context, event, false)]
-              }),
-            ],
-          },
-          {
-            target: "validationError",
-            actions: [
-              assign({
-                report: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) =>
-                  [...context.report, validators.valid_tx_stock_acceptance(context, event, false)]
-              }),
-              assign({
-                result: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) =>
-                  `The validation of the OCF package for ${context.ocfPackageContent.manifest.issuer.legal_name} failed on ${event.data.id}: ${JSON.stringify(validators.valid_tx_stock_acceptance(context, event, false),null, 2)}`
-              }),
-            ],
-          },
-        ],
-        TX_STOCK_CANCELLATION: [
-          {
-            guard: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => {
-              return validators.valid_tx_stock_cancellation(context, event, true);
-            },
-            target: 'capTable',
-            actions: [
-              assign({
-                report: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => 
-                  [...context.report, validators.valid_tx_stock_cancellation(context, event, false)]
-              }),
-              assign({
-                stockIssuances: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => 
-                  context.stockIssuances.filter((obj: any) => { return obj.security_id !== event.data.security_id; }
-                  ),
-              }),
-
-            ],
-          },
-          {
-            target: "validationError",
-            actions: [
-              assign({
-                report: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) =>
-                  [...context.report, validators.valid_tx_stock_cancellation(context, event, false)]
-              }),
-              assign({
-                result: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) =>
-                  `The validation of the OCF package for ${context.ocfPackageContent.manifest.issuer.legal_name} failed on ${event.data.id}: ${JSON.stringify(validators.valid_tx_stock_cancellation(context, event, false),null, 2)}`  
-              }),
-            ],
-          },
-        ], 
-        TX_STOCK_TRANSFER: [
-          {
-            guard: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => {
-              return validators.valid_tx_stock_transfer(context, event, true);
-            },
-            target: 'capTable',
-            actions: [
-              assign({
-                report: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => 
-                  [...context.report, validators.valid_tx_stock_transfer(context, event, false)]
-              }),
-              assign({
-                stockIssuances: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => 
-                  context.stockIssuances.filter((obj: any) => { return obj.security_id !== event.data.security_id; }
-                  ),
-              }),
-
-            ],
-          },
-          {
-            target: "validationError",
-            actions: [
-              assign({
-                report: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) =>
-                  [...context.report, validators.valid_tx_stock_transfer(context, event, false)]
-              }),
-              assign({
-                result: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) =>
-                  `The validation of the OCF package for ${context.ocfPackageContent.manifest.issuer.legal_name} failed on ${event.data.id}: ${JSON.stringify(validators.valid_tx_stock_transfer(context, event, false),null, 2)}`
-              }),
-            ],
-          },
-        ],
-        TX_STOCK_CONVERSION: [
-          {
-            guard: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => {
-              return validators.valid_tx_stock_conversion(context, event, true);
-            },
-            target: 'capTable',
-            actions: [
-              assign({
-                report: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => 
-                  [...context.report, validators.valid_tx_stock_conversion(context, event, false)]
-              }),
-              assign({
-                stockIssuances: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => 
-                  context.stockIssuances.filter((obj: any) => { return obj.security_id !== event.data.security_id; }
-                  ),
-              }),
-
-            ],
-          },
-          {
-            target: "validationError",
-            actions: [
-              assign({
-                report: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) =>
-                  [...context.report, validators.valid_tx_stock_conversion(context, event, false)]
-              }),
-              assign({
-                result: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) =>
-                  `The validation of the OCF package for ${context.ocfPackageContent.manifest.issuer.legal_name} failed on ${event.data.id}: ${JSON.stringify(validators.valid_tx_stock_conversion(context, event, false),null, 2)}`
-              }),
-            ],
-          },
-        ],
-        TX_STOCK_REISSUANCE: [
-          {
-            guard: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => {
-              return validators.valid_tx_stock_reissuance(context, event, true);
-            },
-            target: 'capTable',
-            actions: [
-              assign({
-                report: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => 
-                  [...context.report, validators.valid_tx_stock_reissuance(context, event, false)]
-              }),
-              assign({
-                stockIssuances: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => 
-                  context.stockIssuances.filter((obj: any) => { return obj.security_id !== event.data.security_id; }
-                  ),
-              }),
-
-            ],
-          },
-          {
-            target: "validationError",
-            actions: [
-              assign({
-                report: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) =>
-                  [...context.report, validators.valid_tx_stock_reissuance(context, event, false)]
-              }),
-              assign({
-                result: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) =>
-                  `The validation of the OCF package for ${context.ocfPackageContent.manifest.issuer.legal_name} failed on ${event.data.id}: ${JSON.stringify(validators.valid_tx_stock_reissuance(context, event, false),null, 2)}`
-              }),
-            ],
-          },
-        ],
-        TX_STOCK_REPURCHASE: [
-          {
-            guard: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => {
-              return validators.valid_tx_stock_repurchase(context, event, true);
-            },
-            target: 'capTable',
-            actions: [
-              assign({
-                report: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => 
-                  [...context.report, validators.valid_tx_stock_repurchase(context, event, false)]
-              }),
-              assign({
-                stockIssuances: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => 
-                  context.stockIssuances.filter((obj: any) => { return obj.security_id !== event.data.security_id; }
-                  ),
-              }),
-
-            ],
-          },
-          {
-            target: "validationError",
-            actions: [
-              assign({
-                report: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) =>
-                  [...context.report, validators.valid_tx_stock_repurchase(context, event, false)]
-              }),
-              assign({
-                result: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) =>
-                  `The validation of the OCF package for ${context.ocfPackageContent.manifest.issuer.legal_name} failed on ${event.data.id}: ${JSON.stringify(validators.valid_tx_stock_repurchase(context, event, false),null, 2)}`
-              }),
-            ],
-          },
-        ],
-        TX_CONVERTIBLE_ISSUANCE: [
-          {
-            guard: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => {
-              return validators.valid_tx_convertible_issuance(context, event, true);
-            },
-            actions: [
-              assign({
-                report: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => 
-                  [...context.report, validators.valid_tx_convertible_issuance(context, event, false)]
-
-              }),
-              assign({
-                convertibleIssuances: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => 
-                  [...context.convertibleIssuances, event.data],
-              }),
-            ],
-            target: "capTable",
-          },
-          {
-            target: "validationError",
-            actions: [
-              assign({
-                report: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) =>
-                  [...context.report, validators.valid_tx_convertible_issuance(context, event, false)]
-              }),
-              assign({
-                result: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) =>
-                  `The validation of the OCF package for ${context.ocfPackageContent.manifest.issuer.legal_name} failed on ${event.data.id}: ${JSON.stringify(validators.valid_tx_convertible_issuance(context, event, false),null, 2)}`
-              }),
-            ],
-          },
-        ],
-        TX_CONVERTIBLE_RETRACTION: [
-          {
-            guard: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => {
-              return validators.valid_tx_convertible_retraction(context, event, true);
-            },
-            target: 'capTable',
-            actions: [
-              assign({
-                report: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => 
-                  [...context.report, validators.valid_tx_convertible_retraction(context, event, false)]
-              }),
-              assign({
-                convertibleIssuances: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => 
-                  context.convertibleIssuances.filter((obj: any) => { return obj.security_id !== event.data.security_id; }
-                  ),
-              }),
-
-            ],
-          },
-          {
-            target: "validationError",
-            actions: [
-              assign({
-                report: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) =>
-                  [...context.report, validators.valid_tx_convertible_retraction(context, event, false)]
-              }),
-              assign({
-                result: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) =>
-                  `The validation of the OCF package for ${context.ocfPackageContent.manifest.issuer.legal_name} failed on ${event.data.id}: ${JSON.stringify(validators.valid_tx_convertible_retraction(context, event, false),null, 2)}`
-              }),
-            ],
-          },
-        ],
-        TX_CONVERTIBLE_ACCEPTANCE: [
-          {
-            guard: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => {
-              return validators.valid_tx_convertible_acceptance(context, event, true);
-            },
-            target: 'capTable',
-            actions: [
-              assign({
-                report: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => 
-                  [...context.report, validators.valid_tx_convertible_acceptance(context, event, false)]
-              }),
-            ],
-          },
-          {
-            target: "validationError",
-            actions: [
-              assign({
-                report: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) =>
-                  [...context.report, validators.valid_tx_convertible_acceptance(context, event, false)]
-              }),
-              assign({
-                result: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) =>
-                  `The validation of the OCF package for ${context.ocfPackageContent.manifest.issuer.legal_name} failed on ${event.data.id}: ${JSON.stringify(validators.valid_tx_convertible_acceptance(context, event, false),null, 2)}`
-              }),
-            ],
-          },
-        ],
-        TX_CONVERTIBLE_CANCELLATION: [
-          {
-            guard: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => {
-              return validators.valid_tx_convertible_cancellation(context, event, true);
-            },
-            target: 'capTable',
-            actions: [
-              assign({
-                report: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => 
-                  [...context.report, validators.valid_tx_convertible_cancellation(context, event, false)]
-              }),
-              assign({
-                convertibleIssuances: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => 
-                  context.convertibleIssuances.filter((obj: any) => { return obj.security_id !== event.data.security_id; }
-                  ),
-              }),
-
-            ],
-          },
-          {
-            target: "validationError",
-            actions: [
-              assign({
-                report: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) =>
-                  [...context.report, validators.valid_tx_convertible_cancellation(context, event, false)]
-              }),
-              assign({
-                result: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) =>
-                  `The validation of the OCF package for ${context.ocfPackageContent.manifest.issuer.legal_name} failed on ${event.data.id}: ${JSON.stringify(validators.valid_tx_convertible_cancellation(context, event, false),null, 2)}`  
-              }),
-            ],
-          },
-        ], 
-        TX_CONVERTIBLE_TRANSFER: [
-          {
-            guard: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => {
-              return validators.valid_tx_convertible_transfer(context, event, true);
-            },
-            target: 'capTable',
-            actions: [
-              assign({
-                report: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => 
-                  [...context.report, validators.valid_tx_convertible_transfer(context, event, false)]
-              }),
-              assign({
-                convertibleIssuances: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => 
-                  context.convertibleIssuances.filter((obj: any) => { return obj.security_id !== event.data.security_id; }
-                  ),
-              }),
-
-            ],
-          },
-          {
-            target: "validationError",
-            actions: [
-              assign({
-                report: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) =>
-                  [...context.report, validators.valid_tx_convertible_transfer(context, event, false)]
-              }),
-              assign({
-                result: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) =>
-                  `The validation of the OCF package for ${context.ocfPackageContent.manifest.issuer.legal_name} failed on ${event.data.id}: ${JSON.stringify(validators.valid_tx_convertible_transfer(context, event, false),null, 2)}`
-              }),
-            ],
-          },
-        ],
-        TX_CONVERTIBLE_CONVERSION: [
-          {
-            guard: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => {
-              return validators.valid_tx_convertible_conversion(context, event, true);
-            },
-            target: 'capTable',
-            actions: [
-              assign({
-                report: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => 
-                  [...context.report, validators.valid_tx_convertible_conversion(context, event, false)]
-              }),
-              assign({
-                convertibleIssuances: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => 
-                  context.convertibleIssuances.filter((obj: any) => { return obj.security_id !== event.data.security_id; }
-                  ),
-              }),
-
-            ],
-          },
-          {
-            target: "validationError",
-            actions: [
-              assign({
-                report: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) =>
-                  [...context.report, validators.valid_tx_convertible_conversion(context, event, false)]
-              }),
-              assign({
-                result: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) =>
-                  `The validation of the OCF package for ${context.ocfPackageContent.manifest.issuer.legal_name} failed on ${event.data.id}: ${JSON.stringify(validators.valid_tx_convertible_conversion(context, event, false),null, 2)}`
-              }),
-            ],
-          },
-        ],
-        TX_WARRANT_ISSUANCE: [
-          {
-            guard: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => {
-              return validators.valid_tx_warrant_issuance(context, event, true);
-            },
-            actions: [
-              assign({
-                report: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => 
-                  [...context.report, validators.valid_tx_warrant_issuance(context, event, false)]
-
-              }),
-              assign({
-                warrantIssuances: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => 
-                  [...context.convertibleIssuances, event.data],
-              }),
-            ],
-            target: "capTable",
-          },
-          {
-            target: "validationError",
-            actions: [
-              assign({
-                report: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) =>
-                  [...context.report, validators.valid_tx_warrant_issuance(context, event, false)]
-              }),
-              assign({
-                result: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) =>
-                  `The validation of the OCF package for ${context.ocfPackageContent.manifest.issuer.legal_name} failed on ${event.data.id}: ${JSON.stringify(validators.valid_tx_warrant_issuance(context, event, false),null, 2)}`
-              }),
-            ],
-          },
-        ],
-        TX_WARRANT_RETRACTION: [
-          {
-            guard: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => {
-              return validators.valid_tx_warrant_retraction(context, event, true);
-            },
-            target: 'capTable',
-            actions: [
-              assign({
-                report: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => 
-                  [...context.report, validators.valid_tx_warrant_retraction(context, event, false)]
-              }),
-              assign({
-                warrantIssuances: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => 
-                  context.warrantIssuances.filter((obj: any) => { return obj.security_id !== event.data.security_id; }
-                  ),
-              }),
-
-            ],
-          },
-          {
-            target: "validationError",
-            actions: [
-              assign({
-                report: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) =>
-                  [...context.report, validators.valid_tx_warrant_retraction(context, event, false)]
-              }),
-              assign({
-                result: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) =>
-                  `The validation of the OCF package for ${context.ocfPackageContent.manifest.issuer.legal_name} failed on ${event.data.id}: ${JSON.stringify(validators.valid_tx_warrant_retraction(context, event, false),null, 2)}`
-              }),
-            ],
-          },
-        ],
-        TX_WARRANT_ACCEPTANCE: [
-          {
-            guard: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => {
-              return validators.valid_tx_warrant_acceptance(context, event, true);
-            },
-            target: 'capTable',
-            actions: [
-              assign({
-                report: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => 
-                  [...context.report, validators.valid_tx_warrant_acceptance(context, event, false)]
-              }),
-            ],
-          },
-          {
-            target: "validationError",
-            actions: [
-              assign({
-                report: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) =>
-                  [...context.report, validators.valid_tx_warrant_acceptance(context, event, false)]
-              }),
-              assign({
-                result: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) =>
-                  `The validation of the OCF package for ${context.ocfPackageContent.manifest.issuer.legal_name} failed on ${event.data.id}: ${JSON.stringify(validators.valid_tx_warrant_acceptance(context, event, false),null, 2)}`
-              }),
-            ],
-          },
-        ],
-        TX_WARRANT_CANCELLATION: [
-          {
-            guard: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => {
-              return validators.valid_tx_warrant_cancellation(context, event, true);
-            },
-            target: 'capTable',
-            actions: [
-              assign({
-                report: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => 
-                  [...context.report, validators.valid_tx_warrant_cancellation(context, event, false)]
-              }),
-              assign({
-                warrantIssuances: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => 
-                  context.warrantIssuances.filter((obj: any) => { return obj.security_id !== event.data.security_id; }
-                  ),
-              }),
-
-            ],
-          },
-          {
-            target: "validationError",
-            actions: [
-              assign({
-                report: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) =>
-                  [...context.report, validators.valid_tx_warrant_cancellation(context, event, false)]
-              }),
-              assign({
-                result: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) =>
-                  `The validation of the OCF package for ${context.ocfPackageContent.manifest.issuer.legal_name} failed on ${event.data.id}: ${JSON.stringify(validators.valid_tx_warrant_cancellation(context, event, false),null, 2)}`  
-              }),
-            ],
-          },
-        ], 
-        TX_WARRANT_TRANSFER: [
-          {
-            guard: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => {
-              return validators.valid_tx_warrant_transfer(context, event, true);
-            },
-            target: 'capTable',
-            actions: [
-              assign({
-                report: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => 
-                  [...context.report, validators.valid_tx_warrant_transfer(context, event, false)]
-              }),
-              assign({
-                warrantIssuances: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => 
-                  context.warrantIssuances.filter((obj: any) => { return obj.security_id !== event.data.security_id; }
-                  ),
-              }),
-
-            ],
-          },
-          {
-            target: "validationError",
-            actions: [
-              assign({
-                report: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) =>
-                  [...context.report, validators.valid_tx_warrant_transfer(context, event, false)]
-              }),
-              assign({
-                result: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) =>
-                  `The validation of the OCF package for ${context.ocfPackageContent.manifest.issuer.legal_name} failed on ${event.data.id}: ${JSON.stringify(validators.valid_tx_warrant_transfer(context, event, false),null, 2)}`
-              }),
-            ],
-          },
-        ],
-        TX_WARRANT_EXERCISE: [
-          {
-            guard: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => {
-              return validators.valid_tx_warrant_exercise(context, event, true);
-            },
-            target: 'capTable',
-            actions: [
-              assign({
-                report: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => 
-                  [...context.report, validators.valid_tx_warrant_exercise(context, event, false)]
-              }),
-              assign({
-                warrantIssuances: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => 
-                  context.warrantIssuances.filter((obj: any) => { return obj.security_id !== event.data.security_id; }
-                  ),
-              }),
-
-            ],
-          },
-          {
-            target: "validationError",
-            actions: [
-              assign({
-                report: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) =>
-                  [...context.report, validators.valid_tx_warrant_exercise(context, event, false)]
-              }),
-              assign({
-                result: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) =>
-                  `The validation of the OCF package for ${context.ocfPackageContent.manifest.issuer.legal_name} failed on ${event.data.id}: ${JSON.stringify(validators.valid_tx_warrant_exercise(context, event, false),null, 2)}`
-              }),
-            ],
-          },
-        ],
-        TX_EQUITY_COMPENSATION_ISSUANCE: [
-          {
-            guard: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => {
-              return validators.valid_tx_equity_compensation_issuance(context, event, true);
-            },
-            actions: [
-              assign({
-                report: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => 
-                  [...context.report, validators.valid_tx_equity_compensation_issuance(context, event, false)]
-
-              }),
-              assign({
-                equityCompensation: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => 
-                  [...context.equityCompensation, event.data],
-              }),
-            ],
-            target: "capTable",
-          },
-          {
-            target: "validationError",
-            actions: [
-              assign({
-                report: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) =>
-                  [...context.report, validators.valid_tx_equity_compensation_issuance(context, event, false)]
-              }),
-              assign({
-                result: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) =>
-                  `The validation of the OCF package for ${context.ocfPackageContent.manifest.issuer.legal_name} failed on ${event.data.id}: ${JSON.stringify(validators.valid_tx_equity_compensation_issuance(context, event, false),null, 2)}`
-              }),
-            ],
-          },
-        ],
-        TX_EQUITY_COMPENSATION_RETRACTION: [
-          {
-            guard: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => {
-              return validators.valid_tx_equity_compensation_retraction(context, event, true);
-            },
-            target: 'capTable',
-            actions: [
-              assign({
-                report: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => 
-                  [...context.report, validators.valid_tx_equity_compensation_retraction(context, event, false)]
-              }),
-              assign({
-                equityCompensation: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => 
-                  context.equityCompensation.filter((obj: any) => { return obj.security_id !== event.data.security_id; }
-                  ),
-              }),
-
-            ],
-          },
-          {
-            target: "validationError",
-            actions: [
-              assign({
-                report: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) =>
-                  [...context.report, validators.valid_tx_equity_compensation_retraction(context, event, false)]
-              }),
-              assign({
-                result: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) =>
-                  `The validation of the OCF package for ${context.ocfPackageContent.manifest.issuer.legal_name} failed on ${event.data.id}: ${JSON.stringify(validators.valid_tx_equity_compensation_retraction(context, event, false),null, 2)}`
-              }),
-            ],
-          },
-        ],
-        TX_EQUITY_COMPENSATION_ACCEPTANCE: [
-          {
-            guard: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => {
-              return validators.valid_tx_equity_compensation_acceptance(context, event, true);
-            },
-            target: 'capTable',
-            actions: [
-              assign({
-                report: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => 
-                  [...context.report, validators.valid_tx_equity_compensation_acceptance(context, event, false)]
-              }),
-            ],
-          },
-          {
-            target: "validationError",
-            actions: [
-              assign({
-                report: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) =>
-                  [...context.report, validators.valid_tx_equity_compensation_acceptance(context, event, false)]
-              }),
-              assign({
-                result: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) =>
-                  `The validation of the OCF package for ${context.ocfPackageContent.manifest.issuer.legal_name} failed on ${event.data.id}: ${JSON.stringify(validators.valid_tx_equity_compensation_acceptance(context, event, false),null, 2)}`
-              }),
-            ],
-          },
-        ],
-        TX_EQUITY_COMPENSATION_CANCELLATION: [
-          {
-            guard: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => {
-              return validators.valid_tx_equity_compensation_cancellation(context, event, true);
-            },
-            target: 'capTable',
-            actions: [
-              assign({
-                report: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => 
-                  [...context.report, validators.valid_tx_equity_compensation_cancellation(context, event, false)]
-              }),
-              assign({
-                equityCompensation: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => 
-                  context.equityCompensation.filter((obj: any) => { return obj.security_id !== event.data.security_id; }
-                  ),
-              }),
-
-            ],
-          },
-          {
-            target: "validationError",
-            actions: [
-              assign({
-                report: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) =>
-                  [...context.report, validators.valid_tx_equity_compensation_cancellation(context, event, false)]
-              }),
-              assign({
-                result: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) =>
-                  `The validation of the OCF package for ${context.ocfPackageContent.manifest.issuer.legal_name} failed on ${event.data.id}: ${JSON.stringify(validators.valid_tx_equity_compensation_cancellation(context, event, false),null, 2)}`  
-              }),
-            ],
-          },
-        ], 
-        TX_EQUITY_COMPENSATION_TRANSFER: [
-          {
-            guard: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => {
-              return validators.valid_tx_equity_compensation_transfer(context, event, true);
-            },
-            target: 'capTable',
-            actions: [
-              assign({
-                report: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => 
-                  [...context.report, validators.valid_tx_equity_compensation_transfer(context, event, false)]
-              }),
-              assign({
-                equityCompensation: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => 
-                  context.equityCompensation.filter((obj: any) => { return obj.security_id !== event.data.security_id; }
-                  ),
-              }),
-
-            ],
-          },
-          {
-            target: "validationError",
-            actions: [
-              assign({
-                report: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) =>
-                  [...context.report, validators.valid_tx_equity_compensation_transfer(context, event, false)]
-              }),
-              assign({
-                result: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) =>
-                  `The validation of the OCF package for ${context.ocfPackageContent.manifest.issuer.legal_name} failed on ${event.data.id}: ${JSON.stringify(validators.valid_tx_equity_compensation_transfer(context, event, false),null, 2)}`
-              }),
-            ],
-          },
-        ],
-        TX_EQUITY_COMPENSATION_EXERCISE: [
-          {
-            guard: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => {
-              return validators.valid_tx_equity_compensation_exercise(context, event, true);
-            },
-            target: 'capTable',
-            actions: [
-              assign({
-                report: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => 
-                  [...context.report, validators.valid_tx_equity_compensation_exercise(context, event, false)]
-              }),
-              // assign({
-              //   equityCompensation: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => 
-              //     context.equityCompensation.filter((obj: any) => { return obj.security_id !== event.data.security_id; }
-              //     ),
-              // }),
-
-            ],
-          },
-          {
-            target: "validationError",
-            actions: [
-              assign({
-                report: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) =>
-                  [...context.report, validators.valid_tx_equity_compensation_exercise(context, event, false)]
-              }),
-              assign({
-                result: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) =>
-                  `The validation of the OCF package for ${context.ocfPackageContent.manifest.issuer.legal_name} failed on ${event.data.id}: ${JSON.stringify(validators.valid_tx_equity_compensation_exercise(context, event, false),null, 2)}`
-              }),
-            ],
-          },
-        ],
-        INVALID_TX: [
-          {
-            target: "validationError",
-            actions: assign({
-              result: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => 
-                `The validation of the OCF package for ${context.ocfPackageContent.manifest.issuer.legal_name} failed on ${event.data.id} because it is not a valid TX type.`
-            }),
-          },
-        ],
-        RUN_EOD: {
-          taget: "capTable",
+        // Active handlers all share this two-branch shape; the table-driven
+        // actions resolve the per-type validator/op. Passthrough handlers
+        // are explicit no-ops so the `'*'` wildcard never catches a known type.
+        ...buildTransactionHandlers(),
+        START: {
+          target: "capTable",
           actions: assign({
-            snapshots: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => 
-              [...context.snapshots, run_EOD(context, event)]
+            ocfPackageContent: ({ event }) => event.data,
+          }),
+        },
+        RUN_EOD: {
+          target: "capTable",
+          actions: assign({
+            snapshots: ({ context, event }) => [...context.snapshots, run_EOD(context, event)],
           }),
         },
         RUN_END: {
-          taget: "capTable",
-          actions: [
-          assign ({
-            result: ({ context, event }: { context: OcfMachineContext; event: OcfMachineEvent }) => `The validation of the OCF package for ${context.ocfPackageContent.manifest.issuer.legal_name} is complete and the package appears valid.`
-          })
-        ] 
+          target: "capTable",
+          actions: assign({
+            result: ({ context }) =>
+              `The validation of the OCF package for ${context.ocfPackageContent.manifest.issuer.legal_name} is complete and the package appears valid.`,
+          }),
+        },
+        // Fires only for runtime `type` strings outside TxKey (genuinely unknown /
+        // malformed). Builds its message from `event.type`, never `event.data`.
+        "*": {
+          target: "validationError",
+          actions: assign({
+            result: ({ context, event }) =>
+              `The validation of the OCF package for ${context.ocfPackageContent.manifest?.issuer?.legal_name} failed on ${event.type} because it is not a valid TX type.`,
+          }),
         },
       },
     },
@@ -917,4 +387,4 @@ export const ocfMachine: any = {
       type: "final",
     },
   },
-};
+});

--- a/tests/ocfMachine.test.ts
+++ b/tests/ocfMachine.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect } from "vitest";
+import { createActor } from "xstate";
+import {
+  ocfMachine,
+  collectionUpdate,
+  collectionKeyFor,
+  type OcfMachineContext,
+  type OcfMachineEvent,
+  type TxKey,
+} from "../ocf_validator/ocfMachine";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** A full, mostly-empty machine context; `overrides` replace top-level fields. */
+const baseContext = (overrides: Partial<OcfMachineContext> = {}): OcfMachineContext => ({
+  stockIssuances: [],
+  convertibleIssuances: [],
+  warrantIssuances: [],
+  equityCompensation: [],
+  ocfPackageContent: {
+    manifest: { issuer: { legal_name: "Test Co" } },
+    stakeholders: [],
+    stockClasses: [],
+    transactions: [],
+    stockLegends: [],
+    stockPlans: [],
+    vestingTerms: [],
+    valuations: [],
+  } as OcfMachineContext["ocfPackageContent"],
+  report: [],
+  findings: [],
+  snapshots: [],
+  result: "Incomplete",
+  ...overrides,
+});
+
+/** Start an actor seeded into `capTable` with the given context. */
+const startSeeded = (context: OcfMachineContext) =>
+  createActor(ocfMachine, {
+    snapshot: ocfMachine.resolveState({ value: "capTable", context }),
+  }).start();
+
+/** Cast a hand-built event to the typed event union (test-only boundary). */
+const ev = (type: string, data: Record<string, unknown> = {}): OcfMachineEvent =>
+  ({ type, data } as unknown as OcfMachineEvent);
+
+// ---------------------------------------------------------------------------
+// Unknown transaction types
+// ---------------------------------------------------------------------------
+
+describe("unknown transaction types", () => {
+  it("drives the machine to validationError with the offending type in result", () => {
+    const actor = startSeeded(baseContext());
+    actor.send(ev("TX_NOT_A_REAL_TYPE"));
+
+    const snapshot = actor.getSnapshot();
+    expect(snapshot.value).toBe("validationError");
+    expect(snapshot.context.result).toContain("TX_NOT_A_REAL_TYPE");
+    expect(snapshot.context.result).toContain("not a valid TX type");
+  });
+
+  it("builds its message without assuming event.data exists", () => {
+    const actor = startSeeded(baseContext());
+    // No `data` on the event at all — the wildcard must not throw.
+    actor.send({ type: "WHO_KNOWS" } as unknown as OcfMachineEvent);
+    expect(actor.getSnapshot().value).toBe("validationError");
+    expect(actor.getSnapshot().context.result).toContain("WHO_KNOWS");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Recognized-but-unhandled transaction types
+// ---------------------------------------------------------------------------
+
+describe("recognized-but-unhandled transaction types are no-ops", () => {
+  it("leaves capTable and every channel deep-equal after TX_VESTING_START + TX_STOCK_CLASS_SPLIT", () => {
+    const seeded = baseContext({
+      stockIssuances: [{ id: "si", security_id: "s" }] as any,
+      convertibleIssuances: [{ id: "ci", security_id: "c" }] as any,
+      warrantIssuances: [{ id: "wi", security_id: "w" }] as any,
+      equityCompensation: [{ id: "ec", security_id: "e" }] as any,
+      report: [{ marker: "pre-existing report" }],
+      findings: [
+        { severity: "error", check: "demo", message: "m", subject: { object_type: "TX_STOCK_ISSUANCE", id: "x" } },
+      ],
+      snapshots: [{ date: "2020-01-01", stockIssuances: [], convertibles: [], warrants: [], equityCompensation: [] }],
+      result: "PRESERVED",
+    });
+
+    // A passthrough must change *nothing* — one deep snapshot, one deep compare
+    // (also covers ocfPackageContent, a superset of the required channels).
+    const before = structuredClone(seeded);
+
+    const actor = startSeeded(seeded);
+    actor.send(ev("TX_VESTING_START", { id: "vs", security_id: "s" }));
+    actor.send(ev("TX_STOCK_CLASS_SPLIT", { id: "scs" }));
+
+    const after = actor.getSnapshot();
+    expect(after.value).toBe("capTable");
+    expect(after.context).toEqual(before);
+  });
+
+  it("produces NO report entry for TX_VESTING_START (the fixture case)", () => {
+    const actor = startSeeded(baseContext());
+    actor.send(ev("TX_VESTING_START", { id: "vs", security_id: "s" }));
+    expect(actor.getSnapshot().context.report).toHaveLength(0);
+    expect(actor.getSnapshot().value).toBe("capTable");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Stock retraction
+// ---------------------------------------------------------------------------
+
+describe("stock retraction reports retraction-specific content", () => {
+  it("reports the retraction validator's output on the valid branch, not the issuance validator's", () => {
+    // Seed a prior matching stock issuance (in the live collection AND the package
+    // transaction history) so valid_tx_stock_retraction(..., true) passes.
+    const seeded = baseContext({
+      stockIssuances: [
+        { id: "si1", security_id: "sec1", object_type: "TX_STOCK_ISSUANCE", date: "2020-01-01" },
+      ] as any,
+      ocfPackageContent: {
+        ...baseContext().ocfPackageContent,
+        transactions: [
+          { id: "si1", security_id: "sec1", object_type: "TX_STOCK_ISSUANCE", date: "2020-01-01" },
+        ],
+      } as any,
+    });
+
+    const actor = startSeeded(seeded);
+    actor.send(ev("TX_STOCK_RETRACTION", { id: "sr1", security_id: "sec1", date: "2021-01-01" }));
+
+    const snapshot = actor.getSnapshot();
+    // Valid branch keeps the machine in capTable.
+    expect(snapshot.value).toBe("capTable");
+    const entry = snapshot.context.report.at(-1);
+    expect(entry.transaction_type).toBe("TX_STOCK_RETRACTION");
+    // A retraction-only field the issuance validator never emits.
+    expect(entry).toHaveProperty("incoming_stockIssuance_validity");
+    expect(entry).not.toHaveProperty("stockClass_validity");
+    // And the security was removed from the live collection (remove op).
+    expect(snapshot.context.stockIssuances.some((s: any) => s.security_id === "sec1")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Warrant issuance
+// ---------------------------------------------------------------------------
+
+describe("warrant issuance lands in its own family collection", () => {
+  it("appends only the warrant and never spreads convertibleIssuances", () => {
+    const sentinel = { id: "ci1", security_id: "conv1", object_type: "TX_CONVERTIBLE_ISSUANCE" };
+    const seeded = baseContext({
+      convertibleIssuances: [sentinel] as any,
+      ocfPackageContent: {
+        ...baseContext().ocfPackageContent,
+        stakeholders: [{ id: "sh1" }],
+      } as any,
+    });
+
+    const actor = startSeeded(seeded);
+    actor.send(ev("TX_WARRANT_ISSUANCE", { id: "wi1", security_id: "war1", stakeholder_id: "sh1" }));
+
+    const ctx = actor.getSnapshot().context;
+    // The warrant landed in warrantIssuances…
+    expect(ctx.warrantIssuances.some((w: any) => w.id === "wi1")).toBe(true);
+    // …the convertible collection did not leak into warrantIssuances…
+    expect(ctx.warrantIssuances.some((w: any) => w.id === "ci1")).toBe(false);
+    expect(ctx.warrantIssuances).toHaveLength(1);
+    // …and convertibleIssuances is untouched.
+    expect(ctx.convertibleIssuances).toEqual([sentinel]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Per-type collection operation
+// ---------------------------------------------------------------------------
+
+const OP_CASES: Array<[TxKey, "append" | "none" | "remove"]> = [
+  // append
+  ["TX_STOCK_ISSUANCE", "append"],
+  ["TX_CONVERTIBLE_ISSUANCE", "append"],
+  ["TX_WARRANT_ISSUANCE", "append"],
+  ["TX_EQUITY_COMPENSATION_ISSUANCE", "append"],
+  // none
+  ["TX_STOCK_ACCEPTANCE", "none"],
+  ["TX_CONVERTIBLE_ACCEPTANCE", "none"],
+  ["TX_WARRANT_ACCEPTANCE", "none"],
+  ["TX_EQUITY_COMPENSATION_ACCEPTANCE", "none"],
+  ["TX_EQUITY_COMPENSATION_EXERCISE", "none"],
+  // remove
+  ["TX_STOCK_RETRACTION", "remove"],
+  ["TX_STOCK_CANCELLATION", "remove"],
+  ["TX_STOCK_CONVERSION", "remove"],
+  ["TX_STOCK_REISSUANCE", "remove"],
+  ["TX_STOCK_REPURCHASE", "remove"],
+  ["TX_STOCK_TRANSFER", "remove"],
+  ["TX_CONVERTIBLE_RETRACTION", "remove"],
+  ["TX_CONVERTIBLE_CANCELLATION", "remove"],
+  ["TX_CONVERTIBLE_TRANSFER", "remove"],
+  ["TX_CONVERTIBLE_CONVERSION", "remove"],
+  ["TX_WARRANT_RETRACTION", "remove"],
+  ["TX_WARRANT_CANCELLATION", "remove"],
+  ["TX_WARRANT_TRANSFER", "remove"],
+  ["TX_WARRANT_EXERCISE", "remove"],
+  ["TX_EQUITY_COMPENSATION_RETRACTION", "remove"],
+  ["TX_EQUITY_COMPENSATION_CANCELLATION", "remove"],
+  ["TX_EQUITY_COMPENSATION_TRANSFER", "remove"],
+];
+
+describe("per-type collection operation", () => {
+  it("covers all 26 active handlers", () => {
+    expect(OP_CASES).toHaveLength(26);
+  });
+
+  it.each(OP_CASES)("%s performs op '%s' on its family collection", (type, op) => {
+    const fam = collectionKeyFor(type);
+    const matching = { id: "match", security_id: "SEC", object_type: "seed" };
+    const other = { id: "other", security_id: "OTHER", object_type: "seed" };
+    const ctx = baseContext({ [fam]: [matching, other] } as Partial<OcfMachineContext>);
+    const data = { id: "incoming", security_id: "SEC", object_type: type };
+
+    const result = collectionUpdate(ctx, ev(type, data)) as Record<string, any[]>;
+
+    if (op === "append") {
+      expect(Object.keys(result)).toEqual([fam]);
+      expect(result[fam]).toHaveLength(3);
+      expect(result[fam].at(-1)).toEqual(data);
+    } else if (op === "none") {
+      expect(Object.keys(result)).toHaveLength(0);
+    } else {
+      // remove: the matching security_id is filtered out, others retained.
+      expect(Object.keys(result)).toEqual([fam]);
+      expect(result[fam].some((x) => x.security_id === "SEC")).toBe(false);
+      expect(result[fam].some((x) => x.security_id === "OTHER")).toBe(true);
+    }
+  });
+
+  it("a passthrough type mutates no collection", () => {
+    const result = collectionUpdate(baseContext(), ev("TX_VESTING_START", { security_id: "s" }));
+    expect(Object.keys(result)).toHaveLength(0);
+  });
+});

--- a/types/ocf-machine-table.assert.ts
+++ b/types/ocf-machine-table.assert.ts
@@ -1,0 +1,40 @@
+/**
+ * Compile-time assertions for the data-driven transaction table. No runtime —
+ * this file is type-checked by `tsc` (the build) because it is not a `*.test.ts`
+ * file, so a broken invariant fails the build.
+ *
+ * Covers two guarantees:
+ *  - the table is exhaustive over every `TxKey` (dropping any key fails);
+ *  - pairing a collection with a non-matching-family payload is a compile error.
+ */
+import type {
+  OCFWarrantIssuance,
+  OCFConvertibleIssuance,
+} from "@opencaptablecoalition/ocf-types";
+import {
+  appendToCollection,
+  type TxKey,
+  type TxRow,
+  type TxTable,
+} from "../ocf_validator/ocfMachine";
+import type { Expect, Equal } from "./type-assert";
+
+// --- Exhaustiveness: the table covers every TX key -------------------------
+
+// The table's keys are exactly `TxKey` — drop any key and this turns false.
+type _Exhaustive = Expect<Equal<keyof TxTable, TxKey>>;
+
+// A table missing any key does not satisfy `Record<TxKey, …>`. Demonstrated by
+// omitting all but one key from an annotated sample.
+// @ts-expect-error — Record<TxKey, TxRow> requires every TxKey to be present.
+const _keyOmitted: Record<TxKey, TxRow> = {
+  TX_VESTING_START: { op: "passthrough" },
+};
+
+// --- Wrong-family payload is a compile error -------------------------------
+
+// The matching family compiles…
+appendToCollection("warrantIssuances", [] as OCFWarrantIssuance[], {} as OCFWarrantIssuance);
+// …but a warrant payload cannot be appended onto the convertible collection.
+// @ts-expect-error — OCFWarrantIssuance is not assignable to the convertible family.
+appendToCollection("convertibleIssuances", [] as OCFConvertibleIssuance[], {} as OCFWarrantIssuance);

--- a/types/public-api.assert.ts
+++ b/types/public-api.assert.ts
@@ -1,15 +1,13 @@
 /**
- * Compile-time assertions for the public API return shapes (#154). No runtime —
+ * Compile-time assertions for the public API return shapes. No runtime —
  * type-checked by `tsc` (the build) because it is not a `*.test.ts` file.
  *
- * Scope of what these pin: the *resolved* return type of each public entry point.
- * They are a regression guard against the return drifting to `any` — NOT a proof
- * that the type matches the real machine. For `ocfValidator` in particular the
- * value side is reached through an `as OcfMachineContext` cast (the machine config
- * is still `any`), so this assert cannot see past the cast; the genuine check lands
- * with #157 when the cast is removed. The internal `Snapshot`-typed callbacks in
- * `ocfSnapshot` are NOT pinned here (callback params don't affect a return type) —
- * those are a reviewer check.
+ * These pin the *resolved* return type of each public entry point, guarding
+ * against a return drifting to `any`. The machine is typed via `setup()`, so
+ * `ocfValidator` returns `getSnapshot().context` with no cast and this assert
+ * sees the machine's real context type end-to-end. The internal `Snapshot`-typed
+ * callbacks in `ocfSnapshot` are not pinned here (callback params don't affect a
+ * return type).
  */
 import { readOcfPackage } from "../read_ocf_package";
 import { ocfValidator } from "../ocf_validator";


### PR DESCRIPTION
Closes #157. Closes #160. Closes #161.

Phase 3 (Engine). **Stacks on #178** — base branch `issue-154-public-return-types` (→ #177 → #175 → #172), which provides `ObjectTypeMap`, `TransactionFor`, the typed machine context, and `Finding`.

## What this does

Collapses the 26 near-identical transaction handlers in `ocf_validator/ocfMachine.ts` (~910 lines) into a single data-driven table, typed via XState v5 `setup()`.

- **Typed `setup()` machine.** Per-key event union (`{ type: K; data: TransactionFor<K> }`) so each handler receives its correctly-typed payload. Completes the v4→v5 transition: drops `predictableActionArguments`, fixes the `taget`→`target` typos on `RUN_EOD`/`RUN_END`, removes the dead `INVALID_TX` handler.
- **Exhaustive, derived table.** `TX_TABLE satisfies Record<TxKey, TxRow>` is exhaustive over all 45 `TX_*` object types at compile time. Each row's validator and target collection are *derived* from the type, not hand-authored — so the two copy-paste bugs the duplication bred can't recur:
  - **#161** (stock retraction called the issuance validator) — the validator is referenced once per row, so the guard and the report can't diverge.
  - **#160** (warrant issuance spread `convertibleIssuances`) — the collection is derived from the TX family and the payload is typed `TransactionFor<K>`, so a wrong-family append doesn't compile.
- **Loud wildcard.** A `'*'` handler fails loudly (→ `validationError`) for genuinely unknown transaction types, closing the silent-ignore gap. The 19 known-but-unprocessed types (e.g. `TX_VESTING_START`) are explicit pass-through no-ops — behavior preserved, and any future OCF type now forces a classification decision (compile error until classified).
- **Drops the `as OcfMachineContext` cast** in `ocf_validator/index.ts` (the typed machine now flows the context through); one declared `as OcfMachineEvent` boundary cast remains on the dynamic `send` of a parsed `object_type`.

## Verification

- `npm run build` + `npm run test:ci` green; 35 tests pass.
- Characterization snapshot **byte-identical**. #160/#161 are latent for the test fixture (it has no retraction or warrant transaction), so they are proven by dedicated **seeded** regression tests that fail on the unfixed code — not by snapshot drift.
- New compile-time asserts (`types/ocf-machine-table.assert.ts`) pin table exhaustiveness and demonstrate the wrong-family-payload rejection.

## Notes

- Overlaps the #158 housekeeping (`taget` / `predictableActionArguments`), which #174 fixes independently off `main`; left alone here — the rewrite lands the same fix on the stack.
- A **pre-existing** validator landmine (`valid_tx_equity_compensation_acceptance` dereferences a nonexistent context field) is left untouched (out of scope) — worth a follow-up issue.
- `TX_EQUITY_COMPENSATION_EXERCISE`'s no-collection-removal (asymmetric with `TX_WARRANT_EXERCISE`) is preserved with an inline note, pending investigation — not endorsed.

