### PR TITLE
Remove redundant package read in ocfSnapshot (#162)

### DIFF
--- a/ocf_snapshot/index.ts
+++ b/ocf_snapshot/index.ts
@@ -1,10 +1,8 @@
-import { OcfPackageContent, readOcfPackage } from "../read_ocf_package";
 import { ocfValidator } from "../ocf_validator";
 import type { Snapshot } from "../types/snapshot";
 
 export const ocfSnapshot = (packagePath: string, inputDateStr: string): Snapshot | null => {
-    
-    const ocfPackage: OcfPackageContent = readOcfPackage(packagePath);
+
     const snapshots = ocfValidator(packagePath).snapshots;
     const inputDate = new Date(inputDateStr);
 


### PR DESCRIPTION
Closes #162

`ocfSnapshot` read the OCF package from disk into a local variable that was never
used, then called `ocfValidator(packagePath)`, which reads the package again — so one
snapshot request parsed the package twice. This removes the dead read and its
now-unused import.

No behavior change: `ocfValidator` still reads the package itself, the public
signatures are unchanged, and the characterization snapshot is byte-identical.
