### PR TITLE
Add graded-validator seam to ocfMachine

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -5,5 +5,5 @@ export { ocfSnapshot } from "./ocf_snapshot";
 // Return types of the public entry points, so the surface is nameable by consumers.
 // OcfMachineContext lives in its defining module (the barrel re-exports only the value).
 export type { OcfPackageContent } from "./read_ocf_package";
-export type { OcfMachineContext } from "./ocf_validator/ocfMachine";
+export type { OcfMachineContext } from "./types/validator";
 export type { Snapshot } from "./types/snapshot";

--- a/ocf_validator/ocfMachine.ts
+++ b/ocf_validator/ocfMachine.ts
@@ -305,7 +305,10 @@ export function failureResult(
   context: OcfMachineContext,
   event: ValidatorEvent,
 ): string {
-  const subject = "data" in event && "id" in event.data ? event.data.id : event.type;
+  const subject =
+    typeof event.data === "object" && event.data !== null && "id" in event.data
+      ? event.data.id
+      : event.type;
   if (descriptor && "validate" in descriptor) {
     return failureMessage(context, subject, JSON.stringify(context.lastErrorFindings, null, 2));
   }

--- a/ocf_validator/ocfMachine.ts
+++ b/ocf_validator/ocfMachine.ts
@@ -8,10 +8,16 @@ import type {
 } from "@opencaptablecoalition/ocf-types";
 import type { TransactionFor } from "../types/ocf-input";
 import type { OcfPackageContent } from "../read_ocf_package";
-import type { Snapshot } from "../types/snapshot";
 import type { Finding } from "../types/finding";
+import type { GradedValidator, OcfMachineContext } from "../types/validator";
 import validators from "./validators";
 import run_EOD from "./eod";
+
+// The validator contract types are defined in types/validator.ts; re-exported
+// here because the validator modules and the package barrel import them from
+// this module. The re-export is removed once every module imports
+// types/validator.ts directly.
+export type { GradedValidator, OcfMachineContext } from "../types/validator";
 
 // ---------------------------------------------------------------------------
 // Cap-table collections
@@ -30,18 +36,6 @@ interface CollectionElement {
 }
 
 export type CollectionKey = keyof CollectionElement;
-
-export type OcfMachineContext = {
-  stockIssuances: OCFStockIssuance[];
-  equityCompensation: OCFEquityCompensationIssuance[];
-  convertibleIssuances: OCFConvertibleIssuance[];
-  warrantIssuances: OCFWarrantIssuance[];
-  ocfPackageContent: OcfPackageContent;
-  report: any[];
-  findings: Finding[];
-  snapshots: Snapshot[];
-  result: string;
-};
 
 // ---------------------------------------------------------------------------
 // Per-key event union — each transaction handler's payload is `TransactionFor<K>`
@@ -92,9 +86,15 @@ function removeFromCollection<E extends { security_id: string }>(
 // ---------------------------------------------------------------------------
 
 /**
- * A validator for a transaction whose payload is `T`. The payload sits in a
- * contravariant position and is optional, so control events (which carry no
- * `data`) and the untyped `event: any` validators all satisfy it.
+ * A legacy dual-mode validator for a transaction whose payload is `T`: asked
+ * with `isGuard: true` it returns a validity boolean, with `isGuard: false` its
+ * report-mode entry. The payload sits in a contravariant position and is
+ * optional, so control events (which carry no `data`) and the untyped
+ * `event: any` validators all satisfy it.
+ *
+ * Transitional: this type, the `legacyValidate` field that carries it, and the
+ * legacy arms of the dispatch helpers are all deleted once the last validator
+ * family migrates to the graded shape.
  */
 type Validator<T> = (
   context: OcfMachineContext,
@@ -104,65 +104,89 @@ type Validator<T> = (
 
 /**
  * Everything the machine needs to know about one transaction type, keyed on its
- * `effect`. The validator is referenced once so the guard and the report always
- * use the same one.
+ * `effect`. A non-passthrough descriptor names its validator under exactly one
+ * of two mutually exclusive fields — `legacyValidate` (dual-mode shape) or
+ * `validate` (graded shape) — so which convention a transaction uses is part of
+ * the table's static description, and the machine dispatches on field presence
+ * the same way it dispatches on `effect`. The validator is referenced once so
+ * the guard and the recorded outcome always use the same one. The
+ * `legacyValidate` arms exist only while families migrate; the union collapses
+ * to the graded arms when the last one does.
  *
- *  - `passthrough`: received and silently ignored — no validator, report, or mutation.
- *  - `none`:        validate and report, but mutate no collection.
- *  - `remove`:      validate, report, and filter `collection` by `security_id`.
- *  - `append`:      validate, report, and append the issuance to `collection`.
+ *  - `passthrough`: received and silently ignored — no validator, record, or mutation.
+ *  - `none`:        validate and record, but mutate no collection.
+ *  - `remove`:      validate, record, and filter `collection` by `security_id`.
+ *  - `append`:      validate, record, and append the issuance to `collection`.
  *
- * The `append` variant distributes over `CollectionKey`, tying `collection` to the
- * payload family of its `validate`, so a family-typed validator cannot be declared
- * under a mismatched collection (demonstrated in `types/ocf-machine-table.assert.ts`).
+ * The `none`/`remove` graded arms take `GradedValidator<any>`, not
+ * `GradedValidator<unknown>`: the payload is contravariant, so `unknown` would
+ * reject every family-typed validator — like `Validator<unknown>` over the
+ * `event: any` validators, the `any` constrains the shape, not the payload.
+ *
+ * The `append` variants distribute over `CollectionKey`, tying `collection` to
+ * the payload family of the validator — under either field — so a family-typed
+ * validator cannot be declared under a mismatched collection (demonstrated in
+ * `types/ocf-machine-table.assert.ts`).
  */
 type Descriptor =
   | { effect: "passthrough" }
-  | { effect: "none"; validate: Validator<unknown> }
-  | { effect: "remove"; validate: Validator<unknown>; collection: CollectionKey }
+  | { effect: "none"; legacyValidate: Validator<unknown> }
+  | { effect: "none"; validate: GradedValidator<any> }
+  | { effect: "remove"; legacyValidate: Validator<unknown>; collection: CollectionKey }
+  | { effect: "remove"; validate: GradedValidator<any>; collection: CollectionKey }
   | {
       [C in CollectionKey]: {
         effect: "append";
         collection: C;
-        validate: Validator<CollectionElement[C]>;
+        legacyValidate: Validator<CollectionElement[C]>;
+      };
+    }[CollectionKey]
+  | {
+      [C in CollectionKey]: {
+        effect: "append";
+        collection: C;
+        validate: GradedValidator<CollectionElement[C]>;
       };
     }[CollectionKey];
 
+/** A non-passthrough descriptor — the shape the dispatch helpers consume. */
+export type ActiveDescriptor = Exclude<Descriptor, { effect: "passthrough" }>;
+
 export const TX_DESCRIPTORS = {
   // --- append: issuance appended to its family collection -----------------
-  TX_STOCK_ISSUANCE: { effect: "append", collection: "stockIssuances", validate: validators.valid_tx_stock_issuance },
-  TX_CONVERTIBLE_ISSUANCE: { effect: "append", collection: "convertibleIssuances", validate: validators.valid_tx_convertible_issuance },
-  TX_WARRANT_ISSUANCE: { effect: "append", collection: "warrantIssuances", validate: validators.valid_tx_warrant_issuance },
-  TX_EQUITY_COMPENSATION_ISSUANCE: { effect: "append", collection: "equityCompensation", validate: validators.valid_tx_equity_compensation_issuance },
+  TX_STOCK_ISSUANCE: { effect: "append", collection: "stockIssuances", legacyValidate: validators.valid_tx_stock_issuance },
+  TX_CONVERTIBLE_ISSUANCE: { effect: "append", collection: "convertibleIssuances", legacyValidate: validators.valid_tx_convertible_issuance },
+  TX_WARRANT_ISSUANCE: { effect: "append", collection: "warrantIssuances", legacyValidate: validators.valid_tx_warrant_issuance },
+  TX_EQUITY_COMPENSATION_ISSUANCE: { effect: "append", collection: "equityCompensation", legacyValidate: validators.valid_tx_equity_compensation_issuance },
 
   // --- none: validate + report, no collection mutation --------------------
-  TX_STOCK_ACCEPTANCE: { effect: "none", validate: validators.valid_tx_stock_acceptance },
-  TX_CONVERTIBLE_ACCEPTANCE: { effect: "none", validate: validators.valid_tx_convertible_acceptance },
-  TX_WARRANT_ACCEPTANCE: { effect: "none", validate: validators.valid_tx_warrant_acceptance },
-  TX_EQUITY_COMPENSATION_ACCEPTANCE: { effect: "none", validate: validators.valid_tx_equity_compensation_acceptance },
+  TX_STOCK_ACCEPTANCE: { effect: "none", legacyValidate: validators.valid_tx_stock_acceptance },
+  TX_CONVERTIBLE_ACCEPTANCE: { effect: "none", legacyValidate: validators.valid_tx_convertible_acceptance },
+  TX_WARRANT_ACCEPTANCE: { effect: "none", legacyValidate: validators.valid_tx_warrant_acceptance },
+  TX_EQUITY_COMPENSATION_ACCEPTANCE: { effect: "none", legacyValidate: validators.valid_tx_equity_compensation_acceptance },
   // TX_EQUITY_COMPENSATION_EXERCISE removes nothing today (its collection filter
   // is commented out in the legacy machine), asymmetric with TX_WARRANT_EXERCISE
   // which removes. That asymmetry is PRESERVED pending investigation, not endorsed.
-  TX_EQUITY_COMPENSATION_EXERCISE: { effect: "none", validate: validators.valid_tx_equity_compensation_exercise },
+  TX_EQUITY_COMPENSATION_EXERCISE: { effect: "none", legacyValidate: validators.valid_tx_equity_compensation_exercise },
 
   // --- remove: filter the family collection by security_id ---------------
-  TX_STOCK_RETRACTION: { effect: "remove", collection: "stockIssuances", validate: validators.valid_tx_stock_retraction },
-  TX_STOCK_CANCELLATION: { effect: "remove", collection: "stockIssuances", validate: validators.valid_tx_stock_cancellation },
-  TX_STOCK_CONVERSION: { effect: "remove", collection: "stockIssuances", validate: validators.valid_tx_stock_conversion },
-  TX_STOCK_REISSUANCE: { effect: "remove", collection: "stockIssuances", validate: validators.valid_tx_stock_reissuance },
-  TX_STOCK_REPURCHASE: { effect: "remove", collection: "stockIssuances", validate: validators.valid_tx_stock_repurchase },
-  TX_STOCK_TRANSFER: { effect: "remove", collection: "stockIssuances", validate: validators.valid_tx_stock_transfer },
-  TX_CONVERTIBLE_RETRACTION: { effect: "remove", collection: "convertibleIssuances", validate: validators.valid_tx_convertible_retraction },
-  TX_CONVERTIBLE_CANCELLATION: { effect: "remove", collection: "convertibleIssuances", validate: validators.valid_tx_convertible_cancellation },
-  TX_CONVERTIBLE_TRANSFER: { effect: "remove", collection: "convertibleIssuances", validate: validators.valid_tx_convertible_transfer },
-  TX_CONVERTIBLE_CONVERSION: { effect: "remove", collection: "convertibleIssuances", validate: validators.valid_tx_convertible_conversion },
-  TX_WARRANT_RETRACTION: { effect: "remove", collection: "warrantIssuances", validate: validators.valid_tx_warrant_retraction },
-  TX_WARRANT_CANCELLATION: { effect: "remove", collection: "warrantIssuances", validate: validators.valid_tx_warrant_cancellation },
-  TX_WARRANT_TRANSFER: { effect: "remove", collection: "warrantIssuances", validate: validators.valid_tx_warrant_transfer },
-  TX_WARRANT_EXERCISE: { effect: "remove", collection: "warrantIssuances", validate: validators.valid_tx_warrant_exercise },
-  TX_EQUITY_COMPENSATION_RETRACTION: { effect: "remove", collection: "equityCompensation", validate: validators.valid_tx_equity_compensation_retraction },
-  TX_EQUITY_COMPENSATION_CANCELLATION: { effect: "remove", collection: "equityCompensation", validate: validators.valid_tx_equity_compensation_cancellation },
-  TX_EQUITY_COMPENSATION_TRANSFER: { effect: "remove", collection: "equityCompensation", validate: validators.valid_tx_equity_compensation_transfer },
+  TX_STOCK_RETRACTION: { effect: "remove", collection: "stockIssuances", legacyValidate: validators.valid_tx_stock_retraction },
+  TX_STOCK_CANCELLATION: { effect: "remove", collection: "stockIssuances", legacyValidate: validators.valid_tx_stock_cancellation },
+  TX_STOCK_CONVERSION: { effect: "remove", collection: "stockIssuances", legacyValidate: validators.valid_tx_stock_conversion },
+  TX_STOCK_REISSUANCE: { effect: "remove", collection: "stockIssuances", legacyValidate: validators.valid_tx_stock_reissuance },
+  TX_STOCK_REPURCHASE: { effect: "remove", collection: "stockIssuances", legacyValidate: validators.valid_tx_stock_repurchase },
+  TX_STOCK_TRANSFER: { effect: "remove", collection: "stockIssuances", legacyValidate: validators.valid_tx_stock_transfer },
+  TX_CONVERTIBLE_RETRACTION: { effect: "remove", collection: "convertibleIssuances", legacyValidate: validators.valid_tx_convertible_retraction },
+  TX_CONVERTIBLE_CANCELLATION: { effect: "remove", collection: "convertibleIssuances", legacyValidate: validators.valid_tx_convertible_cancellation },
+  TX_CONVERTIBLE_TRANSFER: { effect: "remove", collection: "convertibleIssuances", legacyValidate: validators.valid_tx_convertible_transfer },
+  TX_CONVERTIBLE_CONVERSION: { effect: "remove", collection: "convertibleIssuances", legacyValidate: validators.valid_tx_convertible_conversion },
+  TX_WARRANT_RETRACTION: { effect: "remove", collection: "warrantIssuances", legacyValidate: validators.valid_tx_warrant_retraction },
+  TX_WARRANT_CANCELLATION: { effect: "remove", collection: "warrantIssuances", legacyValidate: validators.valid_tx_warrant_cancellation },
+  TX_WARRANT_TRANSFER: { effect: "remove", collection: "warrantIssuances", legacyValidate: validators.valid_tx_warrant_transfer },
+  TX_WARRANT_EXERCISE: { effect: "remove", collection: "warrantIssuances", legacyValidate: validators.valid_tx_warrant_exercise },
+  TX_EQUITY_COMPENSATION_RETRACTION: { effect: "remove", collection: "equityCompensation", legacyValidate: validators.valid_tx_equity_compensation_retraction },
+  TX_EQUITY_COMPENSATION_CANCELLATION: { effect: "remove", collection: "equityCompensation", legacyValidate: validators.valid_tx_equity_compensation_cancellation },
+  TX_EQUITY_COMPENSATION_TRANSFER: { effect: "remove", collection: "equityCompensation", legacyValidate: validators.valid_tx_equity_compensation_transfer },
 
   // --- passthrough: received and silently ignored today ------------------
   //   No validator, no report entry, no collection mutation. They stay in
@@ -199,18 +223,100 @@ type ControlEvent = (typeof CONTROL_EVENTS)[number];
 const isControlEvent = (event: OcfMachineEvent): event is Extract<OcfMachineEvent, { type: ControlEvent }> =>
   (CONTROL_EVENTS as readonly string[]).includes(event.type);
 
-/** The descriptor's validator for a transaction type, or `undefined` for passthrough types. */
-const validatorFor = (type: TxKey): Validator<any> | undefined => {
+/** The descriptor for a transaction type, or `undefined` for passthrough types. */
+const activeDescriptorFor = (type: TxKey): ActiveDescriptor | undefined => {
   const descriptor = TX_DESCRIPTORS[type];
-  return "validate" in descriptor ? descriptor.validate : undefined;
+  return descriptor.effect === "passthrough" ? undefined : descriptor;
 };
+
+// ---------------------------------------------------------------------------
+// Validator dispatch — legacyValidate vs validate
+// ---------------------------------------------------------------------------
+//
+// Each helper takes the descriptor as a parameter (rather than resolving it
+// from the table) and branches on which validator field it carries: a
+// `legacyValidate` validator receives the whole event plus the guard flag; a
+// `validate` (graded) validator receives only `event.data` and returns
+// findings. The legacy arms are today's dispatch relocated into one place, not
+// new behavior; they are deleted with `legacyValidate` when the last family
+// migrates, leaving each helper single-armed.
+
+const failureMessage = (context: OcfMachineContext, subject: string, detail: string): string =>
+  `The validation of the OCF package for ${context.ocfPackageContent.manifest.issuer.legal_name} failed on ${subject}: ${detail}`;
+
+/**
+ * The event slice the dispatch helpers read. `data` is `any` for the same
+ * reason legacy validators declare `event: any`: the payload's family is the
+ * descriptor table's concern, not the dispatcher's.
+ */
+type ValidatorEvent = { type: string; data?: any };
+
+/** The single blocking rule for graded findings: only an error blocks. */
+const isErrorFinding = (finding: Finding): boolean => finding.severity === "error";
+
+/**
+ * Guard outcome for one transaction under `descriptor`'s validator. A graded
+ * validator's findings decide: valid iff none carries severity "error", so
+ * warnings alone do not block. A legacy validator is asked directly in guard
+ * (boolean) mode.
+ */
+export function isValidOutcome(
+  descriptor: ActiveDescriptor,
+  context: OcfMachineContext,
+  event: ValidatorEvent,
+): boolean {
+  if ("validate" in descriptor) {
+    return !descriptor.validate(context, event.data).some(isErrorFinding);
+  }
+  return descriptor.legacyValidate(context, event, true);
+}
+
+/**
+ * The record-channel update for one transaction's outcome, valid or invalid:
+ * a graded validator's findings are appended to `findings` and its error
+ * slice is stashed on `lastErrorFindings` for the failure branch; `report` is
+ * never written. A legacy validator's report-mode entry is appended to
+ * `report`.
+ */
+export function outcomeUpdate(
+  descriptor: ActiveDescriptor,
+  context: OcfMachineContext,
+  event: ValidatorEvent,
+): Partial<OcfMachineContext> {
+  if ("validate" in descriptor) {
+    const found = descriptor.validate(context, event.data);
+    return {
+      findings: [...context.findings, ...found],
+      lastErrorFindings: found.filter(isErrorFinding),
+    };
+  }
+  return { report: [...context.report, descriptor.legacyValidate(context, event, false)] };
+}
+
+/**
+ * The invalid-branch `result` message, with a shape-specific failure detail.
+ * Both arms read what the record action wrote immediately before this one,
+ * rather than re-running the (package-scanning) validator: the graded arm
+ * serializes `lastErrorFindings` (this transaction's error findings, in
+ * return order), the legacy arm the report entry at the tail of `report`.
+ */
+export function failureResult(
+  descriptor: ActiveDescriptor | undefined,
+  context: OcfMachineContext,
+  event: ValidatorEvent,
+): string {
+  const subject = "data" in event && "id" in event.data ? event.data.id : event.type;
+  if (descriptor && "validate" in descriptor) {
+    return failureMessage(context, subject, JSON.stringify(context.lastErrorFindings, null, 2));
+  }
+  const lastReport = context.report[context.report.length - 1];
+  const detail = context.report.length ? JSON.stringify(lastReport, null, 2) : "";
+  return failureMessage(context, subject, detail);
+}
 
 // ---------------------------------------------------------------------------
 // The machine — typed via setup({ types, actions, guards })
 // ---------------------------------------------------------------------------
-
-const failureMessage = (context: OcfMachineContext, subject: string, detail: string): string =>
-  `The validation of the OCF package for ${context.ocfPackageContent.manifest.issuer.legal_name} failed on ${subject}: ${detail}`;
 
 /**
  * Valid-branch collection mutation, driven by the descriptor's `effect` and
@@ -272,11 +378,11 @@ function buildTransactionHandlers() {
     {
       guard: "isValidTx",
       target: "capTable",
-      actions: ["appendReport", "mutateCollection"],
+      actions: ["recordOutcome", "mutateCollection"],
     },
     {
       target: "validationError",
-      actions: ["appendReport", "setValidationError"],
+      actions: ["recordOutcome", "setValidationError"],
     },
   ] as const;
   const passthrough = {} as const;
@@ -296,37 +402,31 @@ export const ocfMachine = setup({
     events: OcfMachineEvent;
   },
   guards: {
-    // Guard the valid branch via the type's own validator in `true` (boolean) mode.
-    // Control events never reach this guard (they have their own handlers); the
-    // narrow drops them so `event` carries the `data` the validator reads.
+    // Guard the valid branch via the type's own validator, legacyValidate or
+    // validate (see isValidOutcome). Control events never reach this guard
+    // (they have their own handlers); the narrow drops them so `event` carries
+    // the `data` the validator reads.
     isValidTx: ({ context, event }) => {
       if (isControlEvent(event)) return false;
-      const validator = validatorFor(event.type);
-      return validator ? validator(context, event, true) : false;
+      const descriptor = activeDescriptorFor(event.type);
+      return descriptor ? isValidOutcome(descriptor, context, event) : false;
     },
   },
   actions: {
-    // Append the validator's report entry. Same validator reference as the guard,
-    // so the guard and the report can never diverge.
-    appendReport: assign({
-      report: ({ context, event }) => {
-        if (isControlEvent(event)) return context.report;
-        const validator = validatorFor(event.type);
-        return validator ? [...context.report, validator(context, event, false)] : context.report;
-      },
+    // Record the validator's outcome on its shape's channel — legacy report
+    // entries onto `report`, graded findings onto `findings`. Same descriptor
+    // as the guard, so the guard and the record can never diverge.
+    recordOutcome: assign(({ context, event }) => {
+      if (isControlEvent(event)) return {};
+      const descriptor = activeDescriptorFor(event.type);
+      return descriptor ? outcomeUpdate(descriptor, context, event) : {};
     }),
 
-    // Invalid branch: record the failure message. `appendReport` runs immediately
-    // before this action on the invalid branch, so the validator's report entry is
-    // already at the tail of `report` — reuse it instead of re-running the
-    // (package-scanning) validator a third time.
+    // Invalid branch: record the failure message (see failureResult for the
+    // shape-specific detail sourcing).
     setValidationError: assign({
-      result: ({ context, event }) => {
-        const subject = "data" in event && "id" in event.data ? event.data.id : event.type;
-        const lastReport = context.report[context.report.length - 1];
-        const detail = context.report.length ? JSON.stringify(lastReport, null, 2) : "";
-        return failureMessage(context, subject, detail);
-      },
+      result: ({ context, event }) =>
+        failureResult(isControlEvent(event) ? undefined : activeDescriptorFor(event.type), context, event),
     }),
 
     // Valid branch collection mutation, driven by the descriptor's `effect` and
@@ -353,6 +453,7 @@ export const ocfMachine = setup({
     },
     report: [],
     findings: [],
+    lastErrorFindings: [],
     snapshots: [],
     result: "Incomplete",
   },

--- a/tests/__snapshots__/characterization.test.ts.snap
+++ b/tests/__snapshots__/characterization.test.ts.snap
@@ -35,6 +35,7 @@ exports[`ocfValidator over testPackage > produces a stable validation result and
     },
   ],
   "findings": [],
+  "lastErrorFindings": [],
   "report": [
     {
       "stakeholder_validity": true,

--- a/tests/ocfMachine.test.ts
+++ b/tests/ocfMachine.test.ts
@@ -3,12 +3,16 @@ import { createActor } from "xstate";
 import {
   ocfMachine,
   collectionUpdate,
+  isValidOutcome,
+  outcomeUpdate,
+  failureResult,
   TX_DESCRIPTORS,
-  type OcfMachineContext,
   type OcfMachineEvent,
   type TxKey,
   type CollectionKey,
 } from "../ocf_validator/ocfMachine";
+import type { Finding } from "../types/finding";
+import type { GradedValidator, OcfMachineContext } from "../types/validator";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -32,6 +36,7 @@ const baseContext = (overrides: Partial<OcfMachineContext> = {}): OcfMachineCont
   } as OcfMachineContext["ocfPackageContent"],
   report: [],
   findings: [],
+  lastErrorFindings: [],
   snapshots: [],
   result: "Incomplete",
   ...overrides,
@@ -277,5 +282,155 @@ describe("per-type collection placement", () => {
   it("a passthrough type mutates no collection", () => {
     const result = collectionUpdate(baseContext(), ev("TX_VESTING_START", { security_id: "s" }));
     expect(Object.keys(result)).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Graded validators through the dispatch helpers
+// ---------------------------------------------------------------------------
+
+// No table entry carries a graded `validate` yet, so these drive the exported
+// dispatch helpers directly with synthetic descriptors. The machine-actor
+// route stays legacy-only (next describe) until a validator family migrates.
+
+/** A synthetic `none` descriptor carrying a graded validator. */
+const gradedDescriptor = (validate: GradedValidator<any>) => ({ effect: "none", validate }) as const;
+
+/** A minimal finding; `check` doubles as the distinguishing label. */
+const finding = (severity: Finding["severity"], check: string): Finding => ({
+  severity,
+  check,
+  message: `${check} message`,
+  subject: { object_type: "TX_STOCK_ISSUANCE", id: "si1" },
+});
+
+describe("graded validators through the dispatch helpers", () => {
+  it("passes the transaction payload, not the event wrapper, to the validator", () => {
+    const received: unknown[] = [];
+    const descriptor = gradedDescriptor((_context, data) => {
+      received.push(data);
+      return [];
+    });
+    const data = { id: "si1", security_id: "sec1" };
+
+    isValidOutcome(descriptor, baseContext(), ev("TX_STOCK_ISSUANCE", data));
+
+    expect(received).toHaveLength(1);
+    expect(received[0]).toBe(data);
+  });
+
+  it("warnings alone leave the transaction valid and land on findings, never report", () => {
+    const warning = finding("warning", "advisory");
+    const descriptor = gradedDescriptor(() => [warning]);
+    const earlierFinding = finding("warning", "from-an-earlier-transaction");
+    const context = baseContext({
+      report: [{ marker: "pre-existing report" }],
+      findings: [earlierFinding],
+    });
+    const event = ev("TX_STOCK_ISSUANCE", { id: "si1", security_id: "sec1" });
+
+    expect(isValidOutcome(descriptor, context, event)).toBe(true);
+
+    const update = outcomeUpdate(descriptor, context, event);
+    // The update touches the findings channel and the error stash — no report write…
+    expect(Object.keys(update)).toEqual(["findings", "lastErrorFindings"]);
+    // …appending the new findings after the accumulated ones…
+    expect(update.findings).toEqual([earlierFinding, warning]);
+    // …and stashing no error findings for a warnings-only outcome.
+    expect(update.lastErrorFindings).toEqual([]);
+    // The helper is pure: neither input channel was mutated.
+    expect(context.report).toEqual([{ marker: "pre-existing report" }]);
+    expect(context.findings).toEqual([earlierFinding]);
+  });
+
+  it("an error finding makes the transaction invalid while recording every finding, warnings included", () => {
+    const descriptor = gradedDescriptor(() => [finding("warning", "advisory"), finding("error", "hard-failure")]);
+    const context = baseContext({ report: [{ marker: "pre-existing report" }] });
+    const event = ev("TX_STOCK_ISSUANCE", { id: "si1", security_id: "sec1" });
+
+    expect(isValidOutcome(descriptor, context, event)).toBe(false);
+
+    const update = outcomeUpdate(descriptor, context, event);
+    // Errors and warnings are both recorded, on findings only — the invalid
+    // branch writes no report entry either.
+    expect(Object.keys(update)).toEqual(["findings", "lastErrorFindings"]);
+    expect(update.findings).toEqual([finding("warning", "advisory"), finding("error", "hard-failure")]);
+    // Only the error slice is stashed for the failure branch.
+    expect(update.lastErrorFindings).toEqual([finding("error", "hard-failure")]);
+    expect(context.report).toEqual([{ marker: "pre-existing report" }]);
+  });
+
+  it("serializes only this transaction's error findings, in return order, in the failure result", () => {
+    const firstError = finding("error", "first-error");
+    const warning = finding("warning", "advisory");
+    const secondError = finding("error", "second-error");
+    let invocations = 0;
+    const descriptor = gradedDescriptor(() => {
+      invocations += 1;
+      return [firstError, warning, secondError];
+    });
+    // Decoys on both channels: an exact-match assertion proves the detail comes
+    // from the record stash, not from the report tail or the findings
+    // accumulator.
+    const context = baseContext({
+      report: [{ marker: "pre-existing report" }],
+      findings: [finding("error", "from-an-earlier-transaction")],
+    });
+    const event = ev("TX_STOCK_ISSUANCE", { id: "si1", security_id: "sec1" });
+
+    // Mirror the machine's invalid branch: record first, then build the result.
+    const recorded = { ...context, ...outcomeUpdate(descriptor, context, event) };
+
+    expect(failureResult(descriptor, recorded, event)).toBe(
+      `The validation of the OCF package for Test Co failed on si1: ${JSON.stringify([firstError, secondError], null, 2)}`,
+    );
+    // The failure detail comes from the stash; the validator ran only at record time.
+    expect(invocations).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Legacy validators through the machine
+// ---------------------------------------------------------------------------
+
+// These pin the old convention while table entries still carry it; they are
+// deleted with `legacyValidate` when the last family migrates.
+
+describe("legacy validators through the machine", () => {
+  const seededWithStakeholder = () =>
+    baseContext({
+      ocfPackageContent: {
+        ...baseContext().ocfPackageContent,
+        stakeholders: [{ id: "sh1" }],
+      } as OcfMachineContext["ocfPackageContent"],
+    });
+
+  it("records a validated transaction's report entry and leaves findings empty", () => {
+    const actor = startSeeded(seededWithStakeholder());
+    actor.send(ev("TX_WARRANT_ISSUANCE", { id: "wi1", security_id: "war1", stakeholder_id: "sh1" }));
+
+    const snapshot = actor.getSnapshot();
+    expect(snapshot.value).toBe("capTable");
+    expect(snapshot.context.report).toHaveLength(1);
+    expect(snapshot.context.report[0]).toMatchObject({
+      transaction_type: "TX_WARRANT_ISSUANCE",
+      transaction_id: "wi1",
+      stakeholder_validity: true,
+    });
+    expect(snapshot.context.findings).toEqual([]);
+  });
+
+  it("fails an invalid transaction with the report entry serialized in the result and findings still empty", () => {
+    const actor = startSeeded(seededWithStakeholder());
+    // No such stakeholder — the warrant issuance validator rejects it.
+    actor.send(ev("TX_WARRANT_ISSUANCE", { id: "wi1", security_id: "war1", stakeholder_id: "nobody" }));
+
+    const snapshot = actor.getSnapshot();
+    expect(snapshot.value).toBe("validationError");
+    expect(snapshot.context.report).toHaveLength(1);
+    expect(snapshot.context.result).toBe(
+      `The validation of the OCF package for Test Co failed on wi1: ${JSON.stringify(snapshot.context.report[0], null, 2)}`,
+    );
+    expect(snapshot.context.findings).toEqual([]);
   });
 });

--- a/types/ocf-machine-table.assert.ts
+++ b/types/ocf-machine-table.assert.ts
@@ -3,11 +3,12 @@
  * file is type-checked by `tsc` (the build) because it is not a `*.test.ts` file,
  * so a broken invariant fails the build.
  *
- * Covers three guarantees:
+ * Covers four guarantees:
  *  - the descriptors are exhaustive over every `TxKey` (dropping any key fails);
  *  - `appendToCollection` rejects a wrong-family payload;
  *  - an `append` descriptor rejects a collection whose family does not match the
- *    payload its validator checks.
+ *    payload its `legacyValidate` checks;
+ *  - the same family match holds for graded `validate` descriptors.
  */
 import type {
   OCFWarrantIssuance,
@@ -16,10 +17,10 @@ import type {
 import {
   appendToCollection,
   TX_DESCRIPTORS,
-  type OcfMachineContext,
   type TxKey,
   type Descriptor,
 } from "../ocf_validator/ocfMachine";
+import type { GradedValidator, OcfMachineContext } from "./validator";
 import type { Expect, Equal } from "./type-assert";
 
 // --- Exhaustiveness: the descriptors cover every TX key --------------------
@@ -42,17 +43,31 @@ appendToCollection("warrantIssuances", [] as OCFWarrantIssuance[], {} as OCFWarr
 // @ts-expect-error — OCFWarrantIssuance is not assignable to the convertible family.
 appendToCollection("convertibleIssuances", [] as OCFConvertibleIssuance[], {} as OCFWarrantIssuance);
 
-// --- Wrong-family append descriptor is a compile error ---------------------
+// --- Wrong-family legacy append descriptor is a compile error ---------------
+// (Deleted with the legacy convention when the last family migrates.)
 
-// A validator whose payload is a warrant issuance.
-const warrantValidate = (
+// A legacy validator whose payload is a warrant issuance.
+const warrantLegacyValidate = (
   _context: OcfMachineContext,
   _event: { data?: OCFWarrantIssuance },
   _isGuard: boolean,
 ): boolean => true;
 
 // The warrant validator pairs with the warrant collection…
-const _appendWarrant: Descriptor = { effect: "append", collection: "warrantIssuances", validate: warrantValidate };
+const _appendWarrant: Descriptor = { effect: "append", collection: "warrantIssuances", legacyValidate: warrantLegacyValidate };
 // …but the same validator cannot type the convertible collection (differs only in family).
 // @ts-expect-error — a warrant validator does not match the convertible collection's payload.
-const _appendWrongFamily: Descriptor = { effect: "append", collection: "convertibleIssuances", validate: warrantValidate };
+const _appendWrongFamily: Descriptor = { effect: "append", collection: "convertibleIssuances", legacyValidate: warrantLegacyValidate };
+
+// --- Wrong-family graded append descriptor is a compile error ---------------
+
+// A graded validator whose payload is a warrant issuance. Declared by type
+// annotation, not defined, so this file stays runtime-free; only the
+// compile-time shape matters to these checks.
+declare const warrantValidate: GradedValidator<OCFWarrantIssuance>;
+
+// The graded warrant validator pairs with the warrant collection…
+const _appendGradedWarrant: Descriptor = { effect: "append", collection: "warrantIssuances", validate: warrantValidate };
+// …but the same graded validator cannot type the convertible collection.
+// @ts-expect-error — a graded warrant validator does not match the convertible collection's payload.
+const _appendGradedWrongFamily: Descriptor = { effect: "append", collection: "convertibleIssuances", validate: warrantValidate };

--- a/types/validator.ts
+++ b/types/validator.ts
@@ -1,0 +1,62 @@
+import type {
+  OCFStockIssuance,
+  OCFConvertibleIssuance,
+  OCFWarrantIssuance,
+  OCFEquityCompensationIssuance,
+} from "@opencaptablecoalition/ocf-types";
+import type { OcfPackageContent } from "../read_ocf_package";
+import type { Snapshot } from "./snapshot";
+import type { Finding } from "./finding";
+
+/**
+ * The machine context a validator receives: the package under validation, the
+ * per-family collections accumulated so far, and the record channels —
+ * `report` for legacy dual-mode validators, `findings` for graded ones.
+ * `report` retires with the legacy convention once every family returns
+ * findings.
+ */
+export type OcfMachineContext = {
+  stockIssuances: OCFStockIssuance[];
+  equityCompensation: OCFEquityCompensationIssuance[];
+  convertibleIssuances: OCFConvertibleIssuance[];
+  warrantIssuances: OCFWarrantIssuance[];
+  ocfPackageContent: OcfPackageContent;
+  report: any[];
+  findings: Finding[];
+  /**
+   * Machine bookkeeping, not validator input: the error findings of the most
+   * recently recorded transaction. Written at record time, read only by the
+   * failure branch to build the failure message.
+   */
+  lastErrorFindings: Finding[];
+  snapshots: Snapshot[];
+  result: string;
+};
+
+/**
+ * Recursively readonly view of `T`: every property is readonly and every array
+ * loses its mutating methods. Validator inputs are typed through this so that
+ * mutating them is a compile error.
+ */
+export type DeepReadonly<T> = T extends readonly (infer E)[]
+  ? readonly DeepReadonly<E>[]
+  : T extends Function
+    ? T
+    : T extends object
+      ? { readonly [K in keyof T]: DeepReadonly<T[K]> }
+      : T;
+
+/**
+ * A graded validator for a transaction whose payload is `T`: receives the
+ * payload directly — no guard flag — and returns findings. The machine derives
+ * everything else from that one return value: the transaction is valid iff no
+ * finding carries severity "error" (warnings alone do not block), and the
+ * findings are recorded on `context.findings`, never on `context.report`.
+ * The machine invokes a validator up to twice per transaction (guard and
+ * record), always with identical inputs, so a validator must be pure; its
+ * inputs are typed `DeepReadonly` so mutating them is a compile error.
+ */
+export type GradedValidator<T> = (
+  context: DeepReadonly<OcfMachineContext>,
+  data: DeepReadonly<T>,
+) => Finding[];


### PR DESCRIPTION
Issue #159 moves each validator module from returning loose, untyped report objects to returning structured findings, each classified as an `error` (blocks validation) or a `warning` (recorded, doesn't block). To keep review manageable that migration will land as one PR per validator family. Every validator dispatches through this machine file, so the machine has to understand both the old and new validator styles while families migrate one at a time. This PR teaches it both.

## What changed

- A descriptor now names its validator under one of two fields: `legacyValidate:` (the existing style — the validator receives the whole event plus a guard flag) or `validate:` (the new style — the validator receives its transaction payload directly and returns `Finding[]`, the model from #156). Which style each transaction uses is part of the table's static description, alongside its `effect` and `collection`.
- This PR renames every active entry to `legacyValidate:` — nothing else on those lines changes. Each family migration PR rewrites its validator files to the graded shape, exports a descriptor per transaction module, and replaces its central-table entries with imports of those descriptors, so a migrated module is already in its final form and the central table shrinks to exactly the not-yet-migrated set.
- For the new style, the machine derives everything from the one findings return:
  - the transaction is valid if no finding is an `error` — warnings alone don't block;
  - findings are recorded on `context.findings`; new-style validators no longer write `context.report` (findings replace the report as families migrate — rationale in the decisions comment on #159);
  - when validation fails, the failure message serializes the error findings the record step stashed for that transaction, mirroring how it serializes a report entry today.
- The dispatch lives in three small exported helpers (`isValidOutcome`, `outcomeUpdate`, `failureResult`) that take the descriptor as a parameter, so unit tests exercise both styles directly with synthetic descriptors.
- Type safety carries over: pairing a validator with the wrong collection family is a compile error under either field (checks in `types/ocf-machine-table.assert.ts`).
- The contract types a migrated module codes against, `OcfMachineContext` and the new `GradedValidator`, live in `types/validator.ts`, next to the `Finding` type a graded validator returns. A validator's inputs are typed deep-readonly, so mutating the context or the payload is a compile error. The machine re-exports both so that existing importers keep their paths; family PRs move their modules to the canonical path, and the cleanup PR removes the re-export.

## What's permanent here vs. removed by the series' cleanup PR

**Permanent** — the end-state rules: the new validator signature, the validity rule (only an `error` finding blocks), findings recorded on `context.findings`, failure messages built from error findings, the three helpers that implement those rules, their tests, the type-level family checks, and the contract types' home in `types/validator.ts`. Nothing from #188 is reworked: the descriptor table, effects, and collection handling are untouched — this PR changes only how a validator is invoked, the edge #188 explicitly deferred to #159.

**Removed at cleanup, once every family has migrated** — everything whose job is keeping the old style working during the transition. Each of the new helpers has two arms, one per style; the old-style arms are today's behavior relocated into one place, not newly written code. Alongside them go the `legacyValidate` field and its type declarations, the tests that pin old-style behavior, and the machine's re-export of the contract types once every module imports them from `types/validator.ts` directly. Once the last family migrates nothing uses the old style, and the deletion is a small contained diff because this PR gathered it into a few marked spots instead of leaving it woven through the machine.

## Nothing changes behavior yet

No validator file changes in this PR, and no descriptor changes its effect, collection, or validator — only the field renames. The new code paths are exercised by unit tests only. The returned context gains one always-empty field, `lastErrorFindings` (the failure-branch stash, populated only when a graded validator records an error finding); the characterization snapshot changes by exactly that line and is otherwise identical.

## What's next in the series

One PR per validator family (stock, convertible, warrant, equity compensation). Each rewrites its validator files to the graded shape, exports one descriptor per transaction module, swaps its central-table entries to imports of those descriptors, and prunes its retired `valid_tx_*` entries from the validators barrel. A final cleanup PR then removes the old calling convention, retires `report`, and replaces the central table with a map assembled in the validators barrel from the module descriptors, re-homing the exhaustiveness check at the assembly and typing the map per transaction. Everything currently handled as passthrough stays passthrough.

Part of #159



