### PR TITLE
Declare per-module check metadata on graded descriptors

### DIFF
--- a/ocf_validator/ocfMachine.ts
+++ b/ocf_validator/ocfMachine.ts
@@ -9,7 +9,7 @@ import type {
 import type { TransactionFor } from "../types/ocf-input";
 import type { OcfPackageContent } from "../read_ocf_package";
 import type { Finding } from "../types/finding";
-import type { GradedValidator, OcfMachineContext } from "../types/validator";
+import type { Check, GradedValidator, OcfMachineContext } from "../types/validator";
 import validators from "./validators";
 import run_EOD from "./eod";
 
@@ -127,13 +127,19 @@ type Validator<T> = (
  * the payload family of the validator — under either field — so a family-typed
  * validator cannot be declared under a mismatched collection (demonstrated in
  * `types/ocf-machine-table.assert.ts`).
+ *
+ * Each graded arm also carries `checks`: the module's declared validation
+ * coverage as structured `Check` data (see `types/validator.ts`). The machine
+ * never reads it — it is documentation-grade metadata for the coverage-report
+ * generator — but requiring it on the graded arms makes declaring the checks
+ * inseparable from migrating a family to the graded shape. Legacy arms carry none.
  */
 type Descriptor =
   | { effect: "passthrough" }
   | { effect: "none"; legacyValidate: Validator<unknown> }
-  | { effect: "none"; validate: GradedValidator<any> }
+  | { effect: "none"; validate: GradedValidator<any>; checks: readonly Check[] }
   | { effect: "remove"; legacyValidate: Validator<unknown>; collection: CollectionKey }
-  | { effect: "remove"; validate: GradedValidator<any>; collection: CollectionKey }
+  | { effect: "remove"; validate: GradedValidator<any>; collection: CollectionKey; checks: readonly Check[] }
   | {
       [C in CollectionKey]: {
         effect: "append";
@@ -146,6 +152,7 @@ type Descriptor =
         effect: "append";
         collection: C;
         validate: GradedValidator<CollectionElement[C]>;
+        checks: readonly Check[];
       };
     }[CollectionKey];
 

--- a/tests/checkMetadata.test.ts
+++ b/tests/checkMetadata.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { TX_DESCRIPTORS } from "../ocf_validator/ocfMachine";
+
+// ---------------------------------------------------------------------------
+// Per-descriptor check-id uniqueness
+// ---------------------------------------------------------------------------
+//
+// Declared check ids are unique per descriptor, not globally: the coverage
+// report renders per transaction type, so reusing a generic id (e.g.
+// `stakeholder-exists`) across modules is fine, even desirable. A duplicate is
+// therefore only a duplicate within one descriptor's own `checks`. The detector
+// below scans a descriptor map and returns structured diagnostics rather than
+// throwing, so the guard test can assert on its return value — and so synthetic
+// maps can exercise it while the real table declares no graded checks yet.
+
+/** A single check id a descriptor declares more than once. */
+type DuplicateCheckId = { key: string; id: string };
+
+/**
+ * The slice of a descriptor the detector reads: its declared checks, if any.
+ * `effect` is named only so the input is typed as descriptor-shaped rather than
+ * an arbitrary bag of optional fields; the detector itself reads only `checks`.
+ */
+type CheckedDescriptor = { effect: string; checks?: readonly { id: string }[] };
+
+/**
+ * Report every check id a descriptor declares more than once, naming the
+ * transaction key and the repeated id. Each repeated id is reported once per
+ * descriptor; a descriptor with no `checks` contributes nothing. An empty result
+ * means every descriptor's own ids are distinct.
+ */
+function findDuplicateCheckIds(
+  descriptors: Record<string, CheckedDescriptor>,
+): DuplicateCheckId[] {
+  const duplicates: DuplicateCheckId[] = [];
+  for (const [key, descriptor] of Object.entries(descriptors)) {
+    const seen = new Set<string>();
+    const reported = new Set<string>();
+    for (const { id } of descriptor.checks ?? []) {
+      if (seen.has(id) && !reported.has(id)) {
+        duplicates.push({ key, id });
+        reported.add(id);
+      }
+      seen.add(id);
+    }
+  }
+  return duplicates;
+}
+
+describe("per-descriptor check-id uniqueness", () => {
+  it("flags a descriptor that repeats a check id, naming the key and id", () => {
+    const descriptors = {
+      TX_STOCK_ISSUANCE: {
+        effect: "append",
+        checks: [{ id: "stakeholder-exists" }, { id: "stakeholder-exists" }],
+      },
+    };
+    expect(findDuplicateCheckIds(descriptors)).toEqual([
+      { key: "TX_STOCK_ISSUANCE", id: "stakeholder-exists" },
+    ]);
+  });
+
+  it("returns nothing when ids are distinct within each descriptor, even if shared across descriptors", () => {
+    const descriptors = {
+      TX_STOCK_ISSUANCE: { effect: "append", checks: [{ id: "stakeholder-exists" }, { id: "quantity-positive" }] },
+      // The same id under a different transaction type is not a duplicate.
+      TX_WARRANT_ISSUANCE: { effect: "append", checks: [{ id: "stakeholder-exists" }] },
+    };
+    expect(findDuplicateCheckIds(descriptors)).toEqual([]);
+  });
+
+  it("reports no duplicate check ids across the real descriptor table", () => {
+    expect(findDuplicateCheckIds(TX_DESCRIPTORS)).toEqual([]);
+  });
+});

--- a/tests/ocfMachine.test.ts
+++ b/tests/ocfMachine.test.ts
@@ -293,8 +293,9 @@ describe("per-type collection placement", () => {
 // dispatch helpers directly with synthetic descriptors. The machine-actor
 // route stays legacy-only (next describe) until a validator family migrates.
 
-/** A synthetic `none` descriptor carrying a graded validator. */
-const gradedDescriptor = (validate: GradedValidator<any>) => ({ effect: "none", validate }) as const;
+/** A synthetic `none` descriptor carrying a graded validator and (empty) checks. */
+const gradedDescriptor = (validate: GradedValidator<any>) =>
+  ({ effect: "none", validate, checks: [] }) as const;
 
 /** A minimal finding; `check` doubles as the distinguishing label. */
 const finding = (severity: Finding["severity"], check: string): Finding => ({

--- a/types/ocf-machine-table.assert.ts
+++ b/types/ocf-machine-table.assert.ts
@@ -3,12 +3,16 @@
  * file is type-checked by `tsc` (the build) because it is not a `*.test.ts` file,
  * so a broken invariant fails the build.
  *
- * Covers four guarantees:
+ * Covers:
  *  - the descriptors are exhaustive over every `TxKey` (dropping any key fails);
  *  - `appendToCollection` rejects a wrong-family payload;
  *  - an `append` descriptor rejects a collection whose family does not match the
  *    payload its `legacyValidate` checks;
- *  - the same family match holds for graded `validate` descriptors.
+ *  - the same family match holds for graded `validate` descriptors;
+ *  - a `Check` literal requires `id`, `severity`, and `description`, and admits
+ *    `implemented` only when absent or literally `false`;
+ *  - every graded descriptor arm carries its declared `checks`, and a graded
+ *    descriptor missing `checks` is not a `Descriptor`.
  */
 import type {
   OCFWarrantIssuance,
@@ -20,8 +24,66 @@ import {
   type TxKey,
   type Descriptor,
 } from "../ocf_validator/ocfMachine";
-import type { GradedValidator, OcfMachineContext } from "./validator";
+import type { Check, GradedValidator, OcfMachineContext } from "./validator";
 import type { Expect, Equal } from "./type-assert";
+
+// --- Declared check metadata ------------------------------------------------
+
+// A well-formed check collection — one implemented check and one declared gap —
+// reused by the graded descriptor examples below.
+const _gradedChecks: readonly Check[] = [
+  { id: "stakeholder-exists", severity: "error", description: "The referenced stakeholder exists in the package." },
+  { id: "quantity-positive", severity: "warning", description: "The issued quantity is positive.", implemented: false },
+];
+
+// A graded validator whose payload family the none/remove arms ignore (they take
+// GradedValidator<any>); declared, not defined, so this file stays runtime-free.
+declare const gradedValidate: GradedValidator<any>;
+
+// An implemented check omits `implemented`; each required field is present.
+const _check: Check = {
+  id: "stakeholder-exists",
+  severity: "error",
+  description: "The referenced stakeholder exists in the package.",
+};
+
+// A declared gap sets `implemented: false` — the only value the field admits.
+const _checkGap: Check = {
+  id: "stakeholder-exists",
+  severity: "warning",
+  description: "The referenced stakeholder exists in the package.",
+  implemented: false,
+};
+
+// Dropping `id` (the one-field delta from `_check`) fails to compile.
+// @ts-expect-error — a Check requires `id`.
+const _checkNoId: Check = {
+  severity: "error",
+  description: "The referenced stakeholder exists in the package.",
+};
+
+// Dropping `severity` fails to compile.
+// @ts-expect-error — a Check requires `severity`.
+const _checkNoSeverity: Check = {
+  id: "stakeholder-exists",
+  description: "The referenced stakeholder exists in the package.",
+};
+
+// Dropping `description` fails to compile.
+// @ts-expect-error — a Check requires `description`.
+const _checkNoDescription: Check = {
+  id: "stakeholder-exists",
+  severity: "error",
+};
+
+// `implemented: true` is unrepresentable — the field is a gap marker, not a claim.
+const _checkImplementedTrue: Check = {
+  id: "stakeholder-exists",
+  severity: "error",
+  description: "The referenced stakeholder exists in the package.",
+  // @ts-expect-error — `implemented` is `false` (a declared gap) or absent, never true.
+  implemented: true,
+};
 
 // --- Exhaustiveness: the descriptors cover every TX key --------------------
 
@@ -67,7 +129,24 @@ const _appendWrongFamily: Descriptor = { effect: "append", collection: "converti
 declare const warrantValidate: GradedValidator<OCFWarrantIssuance>;
 
 // The graded warrant validator pairs with the warrant collection…
-const _appendGradedWarrant: Descriptor = { effect: "append", collection: "warrantIssuances", validate: warrantValidate };
-// …but the same graded validator cannot type the convertible collection.
+const _appendGradedWarrant: Descriptor = { effect: "append", collection: "warrantIssuances", validate: warrantValidate, checks: _gradedChecks };
+// …but the same graded validator cannot type the convertible collection. The
+// checks array is well-formed, so the mismatched collection is the sole reason.
 // @ts-expect-error — a graded warrant validator does not match the convertible collection's payload.
-const _appendGradedWrongFamily: Descriptor = { effect: "append", collection: "convertibleIssuances", validate: warrantValidate };
+const _appendGradedWrongFamily: Descriptor = { effect: "append", collection: "convertibleIssuances", validate: warrantValidate, checks: _gradedChecks };
+
+// --- Every graded arm carries its declared checks ---------------------------
+
+// The none and remove graded arms are assignable to Descriptor with checks;
+// together with `_appendGradedWarrant` above (which declares an `implemented:
+// false` entry) this covers all three graded effects.
+const _gradedNone: Descriptor = { effect: "none", validate: gradedValidate, checks: _gradedChecks };
+const _gradedRemove: Descriptor = { effect: "remove", collection: "stockIssuances", validate: gradedValidate, checks: _gradedChecks };
+
+// --- A graded descriptor missing checks is not a Descriptor -----------------
+
+// The same none descriptor with an (empty, still valid) checks array is assignable…
+const _gradedWithChecks: Descriptor = { effect: "none", validate: gradedValidate, checks: [] };
+// …but dropping `checks` (the one-field delta) leaves it matching no arm.
+// @ts-expect-error — a graded descriptor must declare `checks`.
+const _gradedNoChecks: Descriptor = { effect: "none", validate: gradedValidate };

--- a/types/validator.ts
+++ b/types/validator.ts
@@ -6,7 +6,7 @@ import type {
 } from "@opencaptablecoalition/ocf-types";
 import type { OcfPackageContent } from "../read_ocf_package";
 import type { Snapshot } from "./snapshot";
-import type { Finding } from "./finding";
+import type { Finding, Severity } from "./finding";
 
 /**
  * The machine context a validator receives: the package under validation, the
@@ -60,3 +60,30 @@ export type GradedValidator<T> = (
   context: DeepReadonly<OcfMachineContext>,
   data: DeepReadonly<T>,
 ) => Finding[];
+
+/**
+ * One declared validation check for a module, written as structured data in
+ * place of the free-text `CURRENT CHECKS` / `MISSING CHECKS` comment blocks.
+ * This is documentation-grade metadata: the machine never reads it at runtime —
+ * a finding's own severity, not the declared one here, drives validity — so it
+ * exists purely to be rolled up by the coverage-report generator.
+ *
+ *  - `id`:          the check's identifier, unique within its own descriptor (the
+ *                   report renders per transaction type), not globally — reusing a
+ *                   generic id across modules is fine.
+ *  - `severity`:    the severity the report renders for this check, reusing the
+ *                   `Finding` severities. It states declared intent; it does not
+ *                   constrain the severity a validator actually emits.
+ *  - `description`: the human-readable sentence the report renders. Required — it
+ *                   is what replaces the prose comment blocks.
+ *  - `implemented`: absent for a check the module performs, or literally `false`
+ *                   for a declared gap (replacing today's `MISSING CHECKS` prose).
+ *                   Typing it `false` makes `implemented: true` noise
+ *                   unrepresentable, so the field is only ever a gap marker.
+ */
+export type Check = {
+  id: string;
+  severity: Severity;
+  description: string;
+  implemented?: false;
+};


### PR DESCRIPTION
Part of #191. Stacked on #189 (`issue-159-graded-foundation`); the base retargets to `main` when #189 merges.

## What this adds

As each validator family migrates to the graded convention (#159) it will declare the checks it performs as structured data, replacing the free-text `CURRENT CHECKS` / `MISSING CHECKS` comment blocks. This PR lands the shape those declarations use:

- A `Check` type in `types/validator.ts`: `{ id, severity, description, implemented?: false }`. The `description` is the sentence a future coverage report renders. `implemented: false` marks a declared gap, replacing the `MISSING CHECKS` prose.
- The machine's three graded descriptor arms now require `checks: readonly Check[]`, so declaring metadata is inseparable from migrating a family. Legacy arms are unchanged, and no live table entry uses a graded arm yet, so nothing changes at runtime.
- Compile-time assertions in `types/ocf-machine-table.assert.ts` pin the `Check` field rules and the `checks` requirement.
- A test guards per-descriptor check-id uniqueness across the table. Ids are scoped per descriptor. The report renders per transaction type, so reusing a generic id like `stakeholder-exists` across modules is fine.

## What this deliberately does not do

The declarations are documentation-grade data. The machine never reads `checks` at runtime, and a finding's own severity, not the declared one, is what drives validity. Typed declarations can drift from code just as silently as prose; the protection arrives downstream: the coverage report makes the declarations visible, and the family migration PRs add runtime tests that emitted finding ids stay within each module's declared set.

I considered compile-time enforcement (narrowing `Finding.check` to each module's declared ids) but decided against it. It would have required a lot of heavy typescript machinery on every migration for a guarantee that only protects report accuracy, and it can be layered on later without reshaping the data.

The coverage-report generator also stays out; it lands once family declarations exist for it to consume. #191 stays open tracking it, which is why this PR does not close the issue.

## Verification

`npm run build` and `npm run test:ci` are green, and the characterization snapshot is untouched relative to the base branch.
