### PR TITLE
Migrate convertible validators to graded descriptors

### DIFF
--- a/ocf_validator/ocfMachine.ts
+++ b/ocf_validator/ocfMachine.ts
@@ -11,6 +11,11 @@ import type { OcfPackageContent } from "../read_ocf_package";
 import type { Finding } from "../types/finding";
 import type { Check, GradedValidator, OcfMachineContext } from "../types/validator";
 import validators from "./validators";
+import { TX_CONVERTIBLE_ISSUANCE } from "./validators/convertible/tx_convertible_issuance";
+import { TX_CONVERTIBLE_ACCEPTANCE } from "./validators/convertible/tx_convertible_acceptance";
+import { TX_CONVERTIBLE_RETRACTION } from "./validators/convertible/tx_convertible_retraction";
+import { TX_CONVERTIBLE_CANCELLATION } from "./validators/convertible/tx_convertible_cancellation";
+import { TX_CONVERTIBLE_TRANSFER } from "./validators/convertible/tx_convertible_transfer";
 import run_EOD from "./eod";
 
 // The validator contract types are defined in types/validator.ts; re-exported
@@ -162,13 +167,13 @@ export type ActiveDescriptor = Exclude<Descriptor, { effect: "passthrough" }>;
 export const TX_DESCRIPTORS = {
   // --- append: issuance appended to its family collection -----------------
   TX_STOCK_ISSUANCE: { effect: "append", collection: "stockIssuances", legacyValidate: validators.valid_tx_stock_issuance },
-  TX_CONVERTIBLE_ISSUANCE: { effect: "append", collection: "convertibleIssuances", legacyValidate: validators.valid_tx_convertible_issuance },
+  TX_CONVERTIBLE_ISSUANCE,
   TX_WARRANT_ISSUANCE: { effect: "append", collection: "warrantIssuances", legacyValidate: validators.valid_tx_warrant_issuance },
   TX_EQUITY_COMPENSATION_ISSUANCE: { effect: "append", collection: "equityCompensation", legacyValidate: validators.valid_tx_equity_compensation_issuance },
 
   // --- none: validate + report, no collection mutation --------------------
   TX_STOCK_ACCEPTANCE: { effect: "none", legacyValidate: validators.valid_tx_stock_acceptance },
-  TX_CONVERTIBLE_ACCEPTANCE: { effect: "none", legacyValidate: validators.valid_tx_convertible_acceptance },
+  TX_CONVERTIBLE_ACCEPTANCE,
   TX_WARRANT_ACCEPTANCE: { effect: "none", legacyValidate: validators.valid_tx_warrant_acceptance },
   TX_EQUITY_COMPENSATION_ACCEPTANCE: { effect: "none", legacyValidate: validators.valid_tx_equity_compensation_acceptance },
   // TX_EQUITY_COMPENSATION_EXERCISE removes nothing today (its collection filter
@@ -183,9 +188,9 @@ export const TX_DESCRIPTORS = {
   TX_STOCK_REISSUANCE: { effect: "remove", collection: "stockIssuances", legacyValidate: validators.valid_tx_stock_reissuance },
   TX_STOCK_REPURCHASE: { effect: "remove", collection: "stockIssuances", legacyValidate: validators.valid_tx_stock_repurchase },
   TX_STOCK_TRANSFER: { effect: "remove", collection: "stockIssuances", legacyValidate: validators.valid_tx_stock_transfer },
-  TX_CONVERTIBLE_RETRACTION: { effect: "remove", collection: "convertibleIssuances", legacyValidate: validators.valid_tx_convertible_retraction },
-  TX_CONVERTIBLE_CANCELLATION: { effect: "remove", collection: "convertibleIssuances", legacyValidate: validators.valid_tx_convertible_cancellation },
-  TX_CONVERTIBLE_TRANSFER: { effect: "remove", collection: "convertibleIssuances", legacyValidate: validators.valid_tx_convertible_transfer },
+  TX_CONVERTIBLE_RETRACTION,
+  TX_CONVERTIBLE_CANCELLATION,
+  TX_CONVERTIBLE_TRANSFER,
   TX_CONVERTIBLE_CONVERSION: { effect: "remove", collection: "convertibleIssuances", legacyValidate: validators.valid_tx_convertible_conversion },
   TX_WARRANT_RETRACTION: { effect: "remove", collection: "warrantIssuances", legacyValidate: validators.valid_tx_warrant_retraction },
   TX_WARRANT_CANCELLATION: { effect: "remove", collection: "warrantIssuances", legacyValidate: validators.valid_tx_warrant_cancellation },

--- a/ocf_validator/validators/convertible/tx_convertible_acceptance.ts
+++ b/ocf_validator/validators/convertible/tx_convertible_acceptance.ts
@@ -63,7 +63,7 @@ const validate: GradedValidator<Acceptance> = (context, data) => {
     findings.push({
       severity: "error",
       check: "date-order",
-      message: `The transaction is dated before the convertible issuance it references (security_id ${data.security_id}).`,
+      message: `The transaction is not dated on or after a convertible issuance with security_id ${data.security_id}.`,
       subject,
     });
   }

--- a/ocf_validator/validators/convertible/tx_convertible_acceptance.ts
+++ b/ocf_validator/validators/convertible/tx_convertible_acceptance.ts
@@ -1,72 +1,90 @@
-const valid_tx_convertible_acceptance = (context: any, event: any, isGuard: Boolean) => {
-  const {transactions} = context.ocfPackageContent;
+import type { TransactionFor } from "../../../types/ocf-input";
+import type { Check, GradedValidator } from "../../../types/validator";
+import type { Finding } from "../../../types/finding";
+import type { Descriptor } from "../../ocfMachine";
 
-  let validity = false;
-  let report: any = {transaction_type: "TX_CONVERTIBLE_ACCEPTANCE", transaction_id: event.data.id, transaction_date: event.data.date};
+type Acceptance = TransactionFor<"TX_CONVERTIBLE_ACCEPTANCE">;
 
-  // Check that convertible issuance in incoming security_id referenced by transaction exists in current state.
-  let incoming_convertibleIssuance_validity = false;
-  context.convertibleIssuances.forEach((ele: any) => {
-    if (
-      ele.security_id === event.data.security_id &&
-      ele.object_type === 'TX_CONVERTIBLE_ISSUANCE'
-    ) {
-      incoming_convertibleIssuance_validity = true;
-      report.incoming_convertibleIssuance_validity = true;
+const checks: readonly Check[] = [
+  {
+    id: "issuance-exists",
+    severity: "error",
+    description:
+      "The convertible issuance referenced by the transaction's security_id exists in the current cap-table state.",
+  },
+  {
+    id: "date-order",
+    severity: "error",
+    description:
+      "The transaction is dated on or after the convertible issuance it references.",
+  },
+  {
+    id: "no-retraction",
+    severity: "error",
+    description: "No convertible retraction references the transaction's security_id.",
+  },
+];
+
+const validate: GradedValidator<Acceptance> = (context, data) => {
+  const findings: Finding[] = [];
+  const subject = { object_type: data.object_type, id: data.id };
+  const { transactions } = context.ocfPackageContent;
+
+  // issuance-exists scans the live convertible collection.
+  let issuanceExists = false;
+  context.convertibleIssuances.forEach((ele) => {
+    if (ele.security_id === data.security_id && ele.object_type === "TX_CONVERTIBLE_ISSUANCE") {
+      issuanceExists = true;
     }
   });
-  if (!incoming_convertibleIssuance_validity) {
-    report.incoming_convertibleIssuance_validity = false;
+  if (!issuanceExists) {
+    findings.push({
+      severity: "error",
+      check: "issuance-exists",
+      message: `No convertible issuance with security_id ${data.security_id} exists in the current cap-table state.`,
+      subject,
+    });
   }
 
-  // Check to ensure that the date of transaction is the same day or after the date of the incoming convertible issuance.
-  let incoming_date_validity = false;
-  transactions.forEach((ele: any) => {
+  // date-order scans the full package transaction history for the issuance.
+  // The object_type test leads so it narrows the transaction union to a
+  // security_id-bearing member before the other reads.
+  let dateOrdered = false;
+  transactions.forEach((ele) => {
     if (
-      ele.security_id === event.data.security_id &&
-      ele.object_type === 'TX_CONVERTIBLE_ISSUANCE'
+      ele.object_type === "TX_CONVERTIBLE_ISSUANCE" &&
+      ele.security_id === data.security_id &&
+      ele.date <= data.date
     ) {
-      if (ele.date <= event.data.date) {
-        incoming_date_validity = true;
-        report.incoming_date_validity = true;
-      }
+      dateOrdered = true;
     }
   });
-  if (!incoming_date_validity) {
-    report.incoming_date_validity = false;
+  if (!dateOrdered) {
+    findings.push({
+      severity: "error",
+      check: "date-order",
+      message: `The transaction is dated before the convertible issuance it references (security_id ${data.security_id}).`,
+      subject,
+    });
   }
 
-  // Check that convertible issuance in incoming security_id does not have a convertible retraction transaction associated with it.
-  let no_convertible_retraction_validity = false;
-  let convertible_retraction_exists = false;
-  transactions.forEach((ele: any) => {
-    if (
-      ele.security_id === event.data.security_id &&
-      ele.object_type === 'TX_CONVERTIBLE_RETRACTION'
-    ) {
-      convertible_retraction_exists = true;
+  // no-retraction emits one finding per convertible retraction on this security_id.
+  transactions.forEach((ele) => {
+    if (ele.object_type === "TX_CONVERTIBLE_RETRACTION" && ele.security_id === data.security_id) {
+      findings.push({
+        severity: "error",
+        check: "no-retraction",
+        message: `A convertible retraction (${ele.id}) references the transaction's security_id.`,
+        subject,
+      });
     }
   });
 
-  if (!convertible_retraction_exists) {
-    no_convertible_retraction_validity = true;
-    report.no_convertible_retraction_validity = true;
-  }
-  if (!no_convertible_retraction_validity) {
-    report.no_convertible_retraction_validity = false;
-  }
-
-  if (
-    incoming_convertibleIssuance_validity &&
-    incoming_date_validity &&
-    no_convertible_retraction_validity
-  ) {
-    validity = true;
-  }
-
-  const result = isGuard ? validity : report;
-  
-  return result;
+  return findings;
 };
 
-export default valid_tx_convertible_acceptance;
+export const TX_CONVERTIBLE_ACCEPTANCE = {
+  effect: "none",
+  validate,
+  checks,
+} satisfies Descriptor;

--- a/ocf_validator/validators/convertible/tx_convertible_cancellation.ts
+++ b/ocf_validator/validators/convertible/tx_convertible_cancellation.ts
@@ -1,79 +1,103 @@
-// Reference for tx_convertible_cancellation: https://open-cap-table-coalition.github.io/Open-Cap-Format-OCF/schema_markdown/schema/objects/transactions/cancellation/StockCancellation/
-/*
-  CURRENT CHECKS:
-    1. Check that convertible issuance in incoming security_id reference by transaction exists in current state.
-    2. Check to ensure that the date of transaction is the same day or after the date of the incoming convertible issuance.
-    3. The security_id of the convertible issuance referred to in the security_id variable must not be the security_id related to any other transactions with the exception of a convertible acceptance transaction.
-*/
+import type { TransactionFor } from "../../../types/ocf-input";
+import type { Check, GradedValidator } from "../../../types/validator";
+import type { Finding } from "../../../types/finding";
+import type { Descriptor } from "../../ocfMachine";
 
-import {OcfMachineContext} from '../../ocfMachine';
+type Cancellation = TransactionFor<"TX_CONVERTIBLE_CANCELLATION">;
 
-const valid_tx_convertible_cancellation = (
-  context: OcfMachineContext,
-  event: any,
-  isGuard: Boolean = false
-) => {
-  let validity = false;
-  let report: any = {transaction_type: "TX_CONVERTIBLE_CANCELLATION", transaction_id: event.data.id, transaction_date: event.data.date};
+const checks: readonly Check[] = [
+  {
+    id: "issuance-exists",
+    severity: "error",
+    description:
+      "The convertible issuance referenced by the transaction's security_id exists in the current cap-table state.",
+  },
+  {
+    id: "date-order",
+    severity: "error",
+    description:
+      "The transaction is dated on or after the convertible issuance it references.",
+  },
+  {
+    id: "no-other-transactions",
+    severity: "error",
+    description:
+      "No other transaction references the transaction's security_id, other than a convertible acceptance.",
+  },
+];
 
-  const {transactions} = context.ocfPackageContent;
-  // 1. Check that convertible issuance in incoming security_id reference by transaction exists in current state.
-  let incoming_convertibleIssuance_validity = false;
-  context.convertibleIssuances.forEach((ele: any) => {
-    if (ele.security_id === event.data.security_id) {
-      incoming_convertibleIssuance_validity = true;
-      report.incoming_convertibleIssuance_validity = true;
+const validate: GradedValidator<Cancellation> = (context, data) => {
+  const findings: Finding[] = [];
+  const subject = { object_type: data.object_type, id: data.id };
+  const { transactions } = context.ocfPackageContent;
+
+  // issuance-exists here matches on security_id alone — unlike the sibling
+  // validators it does not also require object_type TX_CONVERTIBLE_ISSUANCE.
+  let issuanceExists = false;
+  context.convertibleIssuances.forEach((ele) => {
+    if (ele.security_id === data.security_id) {
+      issuanceExists = true;
     }
   });
-
-  if (!incoming_convertibleIssuance_validity) {
-    report.incoming_convertibleIssuance_validity = false;
+  if (!issuanceExists) {
+    findings.push({
+      severity: "error",
+      check: "issuance-exists",
+      message: `No convertible issuance with security_id ${data.security_id} exists in the current cap-table state.`,
+      subject,
+    });
   }
 
-  // 2. Check to ensure that the date of transaction is the same day or after the date of the incoming convertible issuance.
-  let incoming_date_validity = false;
-  transactions.forEach((ele: any) => {
+  // date-order scans the full package transaction history for the issuance.
+  // The object_type test leads so it narrows the transaction union to a
+  // security_id-bearing member before the other reads.
+  let dateOrdered = false;
+  transactions.forEach((ele) => {
     if (
-      ele.security_id === event.data.security_id &&
-      ele.object_type === 'TX_CONVERTIBLE_ISSUANCE'
+      ele.object_type === "TX_CONVERTIBLE_ISSUANCE" &&
+      ele.security_id === data.security_id &&
+      ele.date <= data.date
     ) {
-      if (ele.date <= event.data.date) {
-        incoming_date_validity = true;
-        report.incoming_date_validity = true;
-      }
+      dateOrdered = true;
     }
   });
-  if (!incoming_date_validity) {
-    report.incoming_date_validity = false;
+  if (!dateOrdered) {
+    findings.push({
+      severity: "error",
+      check: "date-order",
+      message: `The transaction is dated before the convertible issuance it references (security_id ${data.security_id}).`,
+      subject,
+    });
   }
 
-  let only_transaction_validity = true;
-  transactions.map((ele: any) => {
+  // no-other-transactions emits one finding per transaction on this security_id,
+  // exempting the issuance, any convertible acceptance, and this cancellation itself.
+  // This scan keeps every transaction type in play, so it narrows by property
+  // presence rather than by discriminant: a transaction that carries no
+  // security_id can never reference this one.
+  transactions.forEach((ele) => {
     if (
-      ele.security_id === event.data.security_id &&
-      ele.object_type !== 'TX_CONVERTIBLE_ISSUANCE' &&
-      ele.object_type !== 'TX_CONVERTIBLE_ACCEPTANCE' &&
-      !(ele.object_type === 'TX_CONVERTIBLE_CANCELLATION' && ele.id === event.data.id)
+      "security_id" in ele &&
+      ele.security_id === data.security_id &&
+      ele.object_type !== "TX_CONVERTIBLE_ISSUANCE" &&
+      ele.object_type !== "TX_CONVERTIBLE_ACCEPTANCE" &&
+      !(ele.object_type === "TX_CONVERTIBLE_CANCELLATION" && ele.id === data.id)
     ) {
-      only_transaction_validity = false;
-      report.only_transaction_validity = false;
+      findings.push({
+        severity: "error",
+        check: "no-other-transactions",
+        message: `Another transaction (${ele.id}) references the transaction's security_id.`,
+        subject,
+      });
     }
   });
-  if (only_transaction_validity) {
-    report.only_transaction_validity = true;
-  }
 
-  if (
-    incoming_convertibleIssuance_validity &&
-    incoming_date_validity &&
-    only_transaction_validity
-  ) {
-    validity = true;
-  }
-
-  const result = isGuard ? validity : report;
-  
-  return result;
+  return findings;
 };
 
-export default valid_tx_convertible_cancellation;
+export const TX_CONVERTIBLE_CANCELLATION = {
+  effect: "remove",
+  collection: "convertibleIssuances",
+  validate,
+  checks,
+} satisfies Descriptor;

--- a/ocf_validator/validators/convertible/tx_convertible_cancellation.ts
+++ b/ocf_validator/validators/convertible/tx_convertible_cancellation.ts
@@ -65,7 +65,7 @@ const validate: GradedValidator<Cancellation> = (context, data) => {
     findings.push({
       severity: "error",
       check: "date-order",
-      message: `The transaction is dated before the convertible issuance it references (security_id ${data.security_id}).`,
+      message: `The transaction is not dated on or after a convertible issuance with security_id ${data.security_id}.`,
       subject,
     });
   }

--- a/ocf_validator/validators/convertible/tx_convertible_issuance.ts
+++ b/ocf_validator/validators/convertible/tx_convertible_issuance.ts
@@ -1,27 +1,40 @@
-const valid_tx_convertible_issuance = (context: any, event: any, isGuard: any) => {
-  let validity = false;
+import type { OCFConvertibleIssuance } from "@opencaptablecoalition/ocf-types";
+import type { Check, GradedValidator } from "../../../types/validator";
+import type { Finding } from "../../../types/finding";
+import type { Descriptor } from "../../ocfMachine";
+
+const checks: readonly Check[] = [
+  {
+    id: "stakeholder-exists",
+    severity: "error",
+    description:
+      "The stakeholder referenced by the transaction exists in the stakeholder file.",
+  },
+];
+
+const validate: GradedValidator<OCFConvertibleIssuance> = (context, data) => {
+  const findings: Finding[] = [];
   const { stakeholders } = context.ocfPackageContent;
-  let report: any = {transaction_type: "TX_CONVERTIBLE_ISSUANCE", transaction_id: event.data.id, transaction_date: event.data.date};
-  
-  // Check if the stakeholder referenced by the transaction exists in the stakeholder file.
-  let stakeholder_validity = false;
+
+  let stakeholderExists = false;
   stakeholders.forEach((ele: any) => {
-    if (ele.id === event.data.stakeholder_id) {
-      stakeholder_validity = true;
-      report.stakeholder_validity = true
-    }
+    if (ele.id === data.stakeholder_id) stakeholderExists = true;
   });
-  if (!stakeholder_validity) {
-    report.stakeholder_validity = false
+  if (!stakeholderExists) {
+    findings.push({
+      severity: "error",
+      check: "stakeholder-exists",
+      message: `The stakeholder ${data.stakeholder_id} referenced by the transaction was not found in the stakeholder file.`,
+      subject: { object_type: data.object_type, id: data.id },
+    });
   }
 
-  if (stakeholder_validity) {
-    validity = true;
-  }
-
-  const result = isGuard ? validity : report;
-  
-  return result;
+  return findings;
 };
 
-export default valid_tx_convertible_issuance;
+export const TX_CONVERTIBLE_ISSUANCE = {
+  effect: "append",
+  collection: "convertibleIssuances",
+  validate,
+  checks,
+} satisfies Descriptor;

--- a/ocf_validator/validators/convertible/tx_convertible_retraction.ts
+++ b/ocf_validator/validators/convertible/tx_convertible_retraction.ts
@@ -63,7 +63,7 @@ const validate: GradedValidator<Retraction> = (context, data) => {
     findings.push({
       severity: "error",
       check: "date-order",
-      message: `The transaction is dated before the convertible issuance it references (security_id ${data.security_id}).`,
+      message: `The transaction is not dated on or after a convertible issuance with security_id ${data.security_id}.`,
       subject,
     });
   }

--- a/ocf_validator/validators/convertible/tx_convertible_retraction.ts
+++ b/ocf_validator/validators/convertible/tx_convertible_retraction.ts
@@ -1,75 +1,91 @@
-const valid_tx_convertible_retraction = (context: any, event: any, isGuard: Boolean = false) => {
-  let validity = false;
+import type { TransactionFor } from "../../../types/ocf-input";
+import type { Check, GradedValidator } from "../../../types/validator";
+import type { Finding } from "../../../types/finding";
+import type { Descriptor } from "../../ocfMachine";
 
-  let report: any = {transaction_type: "TX_CONVERTIBLE_RETRACTION", transaction_id: event.data.id, transaction_date: event.data.date};
+type Retraction = TransactionFor<"TX_CONVERTIBLE_RETRACTION">;
 
-  // TBC: validation of tx_convertible_retraction
-  const {transactions} = context.ocfPackageContent;
-  // Check that convertible issuance in incoming security_id referenced by transaction exists in current state.
-  let incoming_convertibleIssuance_validity = false;
-  context.convertibleIssuances.forEach((ele: any) => {
-    if (
-      ele.security_id === event.data.security_id &&
-      ele.object_type === 'TX_CONVERTIBLE_ISSUANCE'
-    ) {
-      incoming_convertibleIssuance_validity = true;
-      report.incoming_convertibleIssuance_validity = true
+const checks: readonly Check[] = [
+  {
+    id: "issuance-exists",
+    severity: "error",
+    description:
+      "The convertible issuance referenced by the transaction's security_id exists in the current cap-table state.",
+  },
+  {
+    id: "date-order",
+    severity: "error",
+    description:
+      "The transaction is dated on or after the convertible issuance it references.",
+  },
+  {
+    id: "no-acceptance",
+    severity: "error",
+    description: "No convertible acceptance references the transaction's security_id.",
+  },
+];
+
+const validate: GradedValidator<Retraction> = (context, data) => {
+  const findings: Finding[] = [];
+  const subject = { object_type: data.object_type, id: data.id };
+  const { transactions } = context.ocfPackageContent;
+
+  // issuance-exists scans the live convertible collection.
+  let issuanceExists = false;
+  context.convertibleIssuances.forEach((ele) => {
+    if (ele.security_id === data.security_id && ele.object_type === "TX_CONVERTIBLE_ISSUANCE") {
+      issuanceExists = true;
     }
   });
-  if (!incoming_convertibleIssuance_validity) {
-    report.incoming_convertibleIssuance_validity = false
-
+  if (!issuanceExists) {
+    findings.push({
+      severity: "error",
+      check: "issuance-exists",
+      message: `No convertible issuance with security_id ${data.security_id} exists in the current cap-table state.`,
+      subject,
+    });
   }
 
-  // Check to ensure that the date of transaction is the same day or after the date of the incoming convertible issuance.
-  let incoming_date_validity = false;
-  transactions.forEach((ele: any) => {
+  // date-order scans the full package transaction history for the issuance.
+  // The object_type test leads so it narrows the transaction union to a
+  // security_id-bearing member before the other reads.
+  let dateOrdered = false;
+  transactions.forEach((ele) => {
     if (
-      ele.security_id === event.data.security_id &&
-      ele.object_type === 'TX_CONVERTIBLE_ISSUANCE'
+      ele.object_type === "TX_CONVERTIBLE_ISSUANCE" &&
+      ele.security_id === data.security_id &&
+      ele.date <= data.date
     ) {
-      if (ele.date <= event.data.date) {
-        incoming_date_validity = true;
-        report.incoming_date_validity = true;
-      }
+      dateOrdered = true;
     }
   });
-  if (!incoming_date_validity) {
-    report.incoming_date_validity = false;
-
+  if (!dateOrdered) {
+    findings.push({
+      severity: "error",
+      check: "date-order",
+      message: `The transaction is dated before the convertible issuance it references (security_id ${data.security_id}).`,
+      subject,
+    });
   }
 
-  // Check that convertible issuance in incoming security_id does not have a convertible acceptance transaction associated with it.
-  let no_convertible_acceptance_validity = false;
-  let convertible_acceptance_exists = false;
-  transactions.forEach((ele: any) => {
-    if (
-      ele.security_id === event.data.security_id &&
-      ele.object_type === 'TX_CONVERTIBLE_ACCEPTANCE'
-    ) {
-      convertible_acceptance_exists = true;
+  // no-acceptance emits one finding per convertible acceptance on this security_id.
+  transactions.forEach((ele) => {
+    if (ele.object_type === "TX_CONVERTIBLE_ACCEPTANCE" && ele.security_id === data.security_id) {
+      findings.push({
+        severity: "error",
+        check: "no-acceptance",
+        message: `A convertible acceptance (${ele.id}) references the transaction's security_id.`,
+        subject,
+      });
     }
   });
 
-  if (!convertible_acceptance_exists) {
-    no_convertible_acceptance_validity = true;
-    report.no_convertible_acceptance_validity = true;
-  }
-  if (!no_convertible_acceptance_validity) {
-    report.no_convertible_acceptance_validity = false;
-  }
-
-  if (
-    incoming_convertibleIssuance_validity &&
-    incoming_date_validity &&
-    no_convertible_acceptance_validity
-  ) {
-    validity = true;
-  }
-
-  const result = isGuard ? validity : report;
-  
-  return result;
+  return findings;
 };
 
-export default valid_tx_convertible_retraction;
+export const TX_CONVERTIBLE_RETRACTION = {
+  effect: "remove",
+  collection: "convertibleIssuances",
+  validate,
+  checks,
+} satisfies Descriptor;

--- a/ocf_validator/validators/convertible/tx_convertible_transfer.ts
+++ b/ocf_validator/validators/convertible/tx_convertible_transfer.ts
@@ -65,7 +65,7 @@ const validate: GradedValidator<Transfer> = (context, data) => {
     findings.push({
       severity: "error",
       check: "date-order",
-      message: `The transaction is dated before the convertible issuance it references (security_id ${data.security_id}).`,
+      message: `The transaction is not dated on or after a convertible issuance with security_id ${data.security_id}.`,
       subject,
     });
   }

--- a/ocf_validator/validators/convertible/tx_convertible_transfer.ts
+++ b/ocf_validator/validators/convertible/tx_convertible_transfer.ts
@@ -1,63 +1,81 @@
-import {OcfMachineContext} from '../../ocfMachine';
-// Reference for tx_convertible_transfer transaction: https://open-cap-table-coalition.github.io/Open-Cap-Format-OCF/schema_markdown/schema/objects/transactions/transfer/StockTransfer/
+import type { TransactionFor } from "../../../types/ocf-input";
+import type { Check, GradedValidator } from "../../../types/validator";
+import type { Finding } from "../../../types/finding";
+import type { Descriptor } from "../../ocfMachine";
 
-/*
-  CURRENT CHECKS:
-    1. Does the incoming security_id referenced by transaction exist in current cap table state?
-    2. Is the date of transaction the same day or after the date of the incoming issuance?
- MISSING CHECKS:
-    1. The security_id of the convertible issuance referred to in the security_id variable must not be the security_id related to any other transactions with the exception of a convertible acceptance transaction.
-*/
+type Transfer = TransactionFor<"TX_CONVERTIBLE_TRANSFER">;
 
-const valid_tx_convertible_transfer = (context: OcfMachineContext, event: any, isGuard: Boolean) => {
-  let validity = false;
-  const {transactions} = context.ocfPackageContent;
-  let report: any = {transaction_type: "TX_CONVERTIBLE_TRANSFER", transaction_id: event.data.id, transaction_date: event.data.date};
+const checks: readonly Check[] = [
+  {
+    id: "issuance-exists",
+    severity: "error",
+    description:
+      "The convertible issuance referenced by the transaction's security_id exists in the current cap-table state.",
+  },
+  {
+    id: "date-order",
+    severity: "error",
+    description:
+      "The transaction is dated on or after the convertible issuance it references.",
+  },
+  {
+    id: "no-other-transactions",
+    severity: "error",
+    description:
+      "No other transaction references the transaction's security_id, other than a convertible acceptance.",
+    implemented: false,
+  },
+];
 
-  // Check that convertible issuance in incoming security_id referenced by transaction exists in current state.
-  let incoming_convertibleIssuance_validity = false;
-  context.convertibleIssuances.map((ele: any) => {
-    if (
-      ele.security_id === event.data.security_id &&
-      ele.object_type === 'TX_CONVERTIBLE_ISSUANCE'
-    ) {
-      incoming_convertibleIssuance_validity = true;
-      report.incoming_convertibleIssuance_validity = true;
+const validate: GradedValidator<Transfer> = (context, data) => {
+  const findings: Finding[] = [];
+  const subject = { object_type: data.object_type, id: data.id };
+  const { transactions } = context.ocfPackageContent;
+
+  // issuance-exists scans the live convertible collection.
+  let issuanceExists = false;
+  context.convertibleIssuances.forEach((ele) => {
+    if (ele.security_id === data.security_id && ele.object_type === "TX_CONVERTIBLE_ISSUANCE") {
+      issuanceExists = true;
     }
   });
-  if (!incoming_convertibleIssuance_validity) {
-    report.incoming_convertibleIssuance_validity = false;
+  if (!issuanceExists) {
+    findings.push({
+      severity: "error",
+      check: "issuance-exists",
+      message: `No convertible issuance with security_id ${data.security_id} exists in the current cap-table state.`,
+      subject,
+    });
   }
 
-  // Check to ensure that the date of transaction is the same day or after the date of the incoming convertible issuance.
-  let incoming_date_validity = false;
-  transactions.map((ele: any) => {
+  // date-order scans the full package transaction history for the issuance.
+  // The object_type test leads so it narrows the transaction union to a
+  // security_id-bearing member before the other reads.
+  let dateOrdered = false;
+  transactions.forEach((ele) => {
     if (
-      ele.security_id === event.data.security_id &&
-      ele.object_type === 'TX_CONVERTIBLE_ISSUANCE'
+      ele.object_type === "TX_CONVERTIBLE_ISSUANCE" &&
+      ele.security_id === data.security_id &&
+      ele.date <= data.date
     ) {
-      if (ele.date <= event.data.date) {
-        incoming_date_validity = true;
-        report.incoming_date_validity = true;
-      }
+      dateOrdered = true;
     }
   });
-  if (!incoming_date_validity) {
-    report.incoming_date_validity = false;
+  if (!dateOrdered) {
+    findings.push({
+      severity: "error",
+      check: "date-order",
+      message: `The transaction is dated before the convertible issuance it references (security_id ${data.security_id}).`,
+      subject,
+    });
   }
 
- 
-
-  if (
-    incoming_convertibleIssuance_validity &&
-    incoming_date_validity
-  ) {
-    validity = true;
-  }
-
-  const result = isGuard ? validity : report;
-  
-  return result;
+  return findings;
 };
 
-export default valid_tx_convertible_transfer;
+export const TX_CONVERTIBLE_TRANSFER = {
+  effect: "remove",
+  collection: "convertibleIssuances",
+  validate,
+  checks,
+} satisfies Descriptor;

--- a/ocf_validator/validators/index.ts
+++ b/ocf_validator/validators/index.ts
@@ -6,11 +6,6 @@ import valid_tx_stock_conversion from './stock/tx_stock_conversion';
 import valid_tx_stock_reissuance from './stock/tx_stock_reissuance';
 import valid_tx_stock_repurchase from './stock/tx_stock_repurchase';
 import valid_tx_stock_transfer from './stock/tx_stock_transfer';
-import valid_tx_convertible_issuance from './convertible/tx_convertible_issuance';
-import valid_tx_convertible_retraction from './convertible/tx_convertible_retraction';
-import valid_tx_convertible_acceptance from './convertible/tx_convertible_acceptance';
-import valid_tx_convertible_cancellation from './convertible/tx_convertible_cancellation';
-import valid_tx_convertible_transfer from './convertible/tx_convertible_transfer';
 import valid_tx_convertible_conversion from './convertible/tx_convertible_conversion';
 import valid_tx_warrant_issuance from './warrant/tx_warrant_issuance';
 import valid_tx_warrant_retraction from './warrant/tx_warrant_retraction';
@@ -50,11 +45,6 @@ const validators = {
   valid_tx_stock_reissuance,
   valid_tx_stock_repurchase,
   valid_tx_stock_transfer,
-  valid_tx_convertible_issuance,
-  valid_tx_convertible_retraction,
-  valid_tx_convertible_acceptance,
-  valid_tx_convertible_cancellation,
-  valid_tx_convertible_transfer,
   valid_tx_convertible_conversion,
   valid_tx_warrant_issuance,
   valid_tx_warrant_retraction,

--- a/tests/checkMetadata.test.ts
+++ b/tests/checkMetadata.test.ts
@@ -11,7 +11,8 @@ import { TX_DESCRIPTORS } from "../ocf_validator/ocfMachine";
 // therefore only a duplicate within one descriptor's own `checks`. The detector
 // below scans a descriptor map and returns structured diagnostics rather than
 // throwing, so the guard test can assert on its return value — and so synthetic
-// maps can exercise it while the real table declares no graded checks yet.
+// maps can exercise it directly. The real table now declares graded checks (the
+// convertible family), which the final case guards for duplicate ids.
 
 /** A single check id a descriptor declares more than once. */
 type DuplicateCheckId = { key: string; id: string };

--- a/tests/convertibleValidators.test.ts
+++ b/tests/convertibleValidators.test.ts
@@ -1,0 +1,540 @@
+import { describe, it, expect } from "vitest";
+import { TX_DESCRIPTORS } from "../ocf_validator/ocfMachine";
+import type { Finding } from "../types/finding";
+import type { GradedValidator, OcfMachineContext } from "../types/validator";
+import { baseContext, startSeeded, ev } from "./helpers";
+
+/** A context whose package `transactions` list is `transactions`. */
+const contextWith = (
+  overrides: Partial<OcfMachineContext> & { transactions?: any[] } = {},
+): OcfMachineContext => {
+  const { transactions = [], ...rest } = overrides;
+  return baseContext({
+    ...rest,
+    ocfPackageContent: {
+      ...baseContext().ocfPackageContent,
+      transactions,
+    } as OcfMachineContext["ocfPackageContent"],
+  });
+};
+
+const MIGRATED_KEYS = [
+  "TX_CONVERTIBLE_ISSUANCE",
+  "TX_CONVERTIBLE_ACCEPTANCE",
+  "TX_CONVERTIBLE_RETRACTION",
+  "TX_CONVERTIBLE_CANCELLATION",
+  "TX_CONVERTIBLE_TRANSFER",
+] as const;
+type MigratedKey = (typeof MIGRATED_KEYS)[number];
+
+/** Invoke the graded validator a migrated descriptor carries. */
+const runValidator = (
+  key: MigratedKey,
+  context: OcfMachineContext,
+  data: Record<string, unknown>,
+): Finding[] => {
+  const descriptor = TX_DESCRIPTORS[key] as { validate?: GradedValidator<any> };
+  if (!descriptor.validate) throw new Error(`${key} carries no graded validate`);
+  return descriptor.validate(context, data);
+};
+
+/** The check ids a descriptor declares as implemented (drops `implemented: false`). */
+const implementedCheckIds = (key: MigratedKey): string[] => {
+  const descriptor = TX_DESCRIPTORS[key] as { checks?: readonly { id: string; implemented?: false }[] };
+  return (descriptor.checks ?? []).filter((c) => c.implemented !== false).map((c) => c.id);
+};
+
+/** Assert a finding carries the declared id, error severity, and the transaction as subject. */
+const expectFindingShape = (
+  finding: Finding,
+  check: string,
+  subject: { object_type: string; id: string },
+) => {
+  expect(finding.check).toBe(check);
+  expect(finding.severity).toBe("error");
+  expect(finding.subject).toEqual(subject);
+};
+
+// A single convertible issuance, in the shape both the live collection and the
+// package transaction history hold it. `date` lets a scenario push the issuance
+// after the transaction under validation to trip the date-order check.
+const issuanceRecord = (security_id: string, date = "2020-01-01") => ({
+  id: `ci-${security_id}`,
+  object_type: "TX_CONVERTIBLE_ISSUANCE",
+  security_id,
+  date,
+});
+
+// ---------------------------------------------------------------------------
+// Issuance: stakeholder-exists
+// ---------------------------------------------------------------------------
+
+describe("convertible issuance validity", () => {
+  const withStakeholder = (id: string) =>
+    baseContext({
+      ocfPackageContent: {
+        ...baseContext().ocfPackageContent,
+        stakeholders: [{ id }],
+      } as OcfMachineContext["ocfPackageContent"],
+    });
+
+  const issuance = (overrides: Record<string, unknown> = {}) => ({
+    id: "conv1",
+    object_type: "TX_CONVERTIBLE_ISSUANCE",
+    security_id: "sec1",
+    stakeholder_id: "sh1",
+    date: "2021-01-01",
+    ...overrides,
+  });
+
+  it("returns no findings when the referenced stakeholder exists", () => {
+    const findings = runValidator("TX_CONVERTIBLE_ISSUANCE", withStakeholder("sh1"), issuance());
+    expect(findings).toEqual([]);
+  });
+
+  it("flags a missing stakeholder with an error naming the stakeholder_id", () => {
+    const findings = runValidator("TX_CONVERTIBLE_ISSUANCE", withStakeholder("someone-else"), issuance());
+    expect(findings).toHaveLength(1);
+    expectFindingShape(findings[0], "stakeholder-exists", {
+      object_type: "TX_CONVERTIBLE_ISSUANCE",
+      id: "conv1",
+    });
+    expect(findings[0].message).toContain("sh1");
+  });
+
+  it("appends a valid issuance to convertibleIssuances and stays in capTable", () => {
+    const actor = startSeeded(withStakeholder("sh1"));
+    actor.send(ev("TX_CONVERTIBLE_ISSUANCE", issuance()));
+
+    const snapshot = actor.getSnapshot();
+    expect(snapshot.value).toBe("capTable");
+    expect(snapshot.context.convertibleIssuances).toHaveLength(1);
+    expect(snapshot.context.convertibleIssuances[0]).toMatchObject({ id: "conv1", security_id: "sec1" });
+    expect(snapshot.context.findings).toEqual([]);
+  });
+
+  it("halts an invalid issuance in validationError with the error finding recorded", () => {
+    const actor = startSeeded(withStakeholder("someone-else"));
+    actor.send(ev("TX_CONVERTIBLE_ISSUANCE", issuance()));
+
+    const snapshot = actor.getSnapshot();
+    expect(snapshot.value).toBe("validationError");
+    expect(snapshot.context.findings).toHaveLength(1);
+    expect(snapshot.context.findings[0].check).toBe("stakeholder-exists");
+    expect(snapshot.context.convertibleIssuances).toEqual([]);
+    expect(snapshot.context.result).toContain("stakeholder-exists");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Acceptance: issuance-exists, date-order, no-retraction
+// ---------------------------------------------------------------------------
+
+describe("convertible acceptance validity", () => {
+  const acceptance = (overrides: Record<string, unknown> = {}) => ({
+    id: "acc1",
+    object_type: "TX_CONVERTIBLE_ACCEPTANCE",
+    security_id: "sec1",
+    date: "2021-01-01",
+    ...overrides,
+  });
+  const subject = { object_type: "TX_CONVERTIBLE_ACCEPTANCE", id: "acc1" };
+
+  it("returns no findings when the issuance exists, dates order, and no retraction references it", () => {
+    const context = contextWith({
+      convertibleIssuances: [issuanceRecord("sec1")] as any,
+      transactions: [issuanceRecord("sec1")],
+    });
+    expect(runValidator("TX_CONVERTIBLE_ACCEPTANCE", context, acceptance())).toEqual([]);
+  });
+
+  it("leaves the machine in capTable without mutating collections on the valid branch", () => {
+    const seeded = contextWith({
+      convertibleIssuances: [issuanceRecord("sec1")] as any,
+      transactions: [issuanceRecord("sec1")],
+    });
+    const before = structuredClone(seeded.convertibleIssuances);
+
+    const actor = startSeeded(seeded);
+    actor.send(ev("TX_CONVERTIBLE_ACCEPTANCE", acceptance()));
+
+    const snapshot = actor.getSnapshot();
+    expect(snapshot.value).toBe("capTable");
+    expect(snapshot.context.convertibleIssuances).toEqual(before);
+    expect(snapshot.context.findings).toEqual([]);
+  });
+
+  it("flags a missing issuance with an error naming the security_id", () => {
+    // In the package history (date-order passes) but not the live collection.
+    const context = contextWith({ transactions: [issuanceRecord("sec1")] });
+    const findings = runValidator("TX_CONVERTIBLE_ACCEPTANCE", context, acceptance());
+    expect(findings).toHaveLength(1);
+    expectFindingShape(findings[0], "issuance-exists", subject);
+    expect(findings[0].message).toContain("sec1");
+  });
+
+  it("flags an out-of-order date with an error naming the security_id", () => {
+    // Issuance is live (issuance-exists passes) but dated after the acceptance.
+    const context = contextWith({
+      convertibleIssuances: [issuanceRecord("sec1", "2022-01-01")] as any,
+      transactions: [issuanceRecord("sec1", "2022-01-01")],
+    });
+    const findings = runValidator("TX_CONVERTIBLE_ACCEPTANCE", context, acceptance());
+    expect(findings).toHaveLength(1);
+    expectFindingShape(findings[0], "date-order", subject);
+    expect(findings[0].message).toContain("sec1");
+  });
+
+  it("emits one no-retraction finding per offending retraction, each naming that retraction", () => {
+    const context = contextWith({
+      convertibleIssuances: [issuanceRecord("sec1")] as any,
+      transactions: [
+        issuanceRecord("sec1"),
+        { id: "ret-a", object_type: "TX_CONVERTIBLE_RETRACTION", security_id: "sec1", date: "2021-06-01" },
+        { id: "ret-b", object_type: "TX_CONVERTIBLE_RETRACTION", security_id: "sec1", date: "2021-07-01" },
+      ],
+    });
+    const findings = runValidator("TX_CONVERTIBLE_ACCEPTANCE", context, acceptance());
+    expect(findings).toHaveLength(2);
+    for (const finding of findings) expectFindingShape(finding, "no-retraction", subject);
+    expect(findings.map((f) => f.message).join("\n")).toContain("ret-a");
+    expect(findings.map((f) => f.message).join("\n")).toContain("ret-b");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Retraction: issuance-exists, date-order, no-acceptance
+// ---------------------------------------------------------------------------
+
+describe("convertible retraction validity", () => {
+  const retraction = (overrides: Record<string, unknown> = {}) => ({
+    id: "ret1",
+    object_type: "TX_CONVERTIBLE_RETRACTION",
+    security_id: "sec1",
+    date: "2021-01-01",
+    ...overrides,
+  });
+  const subject = { object_type: "TX_CONVERTIBLE_RETRACTION", id: "ret1" };
+
+  it("returns no findings when the issuance exists, dates order, and no acceptance references it", () => {
+    const context = contextWith({
+      convertibleIssuances: [issuanceRecord("sec1")] as any,
+      transactions: [issuanceRecord("sec1")],
+    });
+    expect(runValidator("TX_CONVERTIBLE_RETRACTION", context, retraction())).toEqual([]);
+  });
+
+  it("removes the referenced security from convertibleIssuances on the valid branch", () => {
+    const seeded = contextWith({
+      convertibleIssuances: [issuanceRecord("sec1"), issuanceRecord("sec2")] as any,
+      transactions: [issuanceRecord("sec1"), issuanceRecord("sec2")],
+    });
+    const actor = startSeeded(seeded);
+    actor.send(ev("TX_CONVERTIBLE_RETRACTION", retraction()));
+
+    const snapshot = actor.getSnapshot();
+    expect(snapshot.value).toBe("capTable");
+    expect(snapshot.context.convertibleIssuances.some((c: any) => c.security_id === "sec1")).toBe(false);
+    expect(snapshot.context.convertibleIssuances.some((c: any) => c.security_id === "sec2")).toBe(true);
+    expect(snapshot.context.findings).toEqual([]);
+  });
+
+  it("flags a missing issuance with an error naming the security_id", () => {
+    const context = contextWith({ transactions: [issuanceRecord("sec1")] });
+    const findings = runValidator("TX_CONVERTIBLE_RETRACTION", context, retraction());
+    expect(findings).toHaveLength(1);
+    expectFindingShape(findings[0], "issuance-exists", subject);
+    expect(findings[0].message).toContain("sec1");
+  });
+
+  it("flags an out-of-order date with an error naming the security_id", () => {
+    const context = contextWith({
+      convertibleIssuances: [issuanceRecord("sec1", "2022-01-01")] as any,
+      transactions: [issuanceRecord("sec1", "2022-01-01")],
+    });
+    const findings = runValidator("TX_CONVERTIBLE_RETRACTION", context, retraction());
+    expect(findings).toHaveLength(1);
+    expectFindingShape(findings[0], "date-order", subject);
+    expect(findings[0].message).toContain("sec1");
+  });
+
+  it("emits one no-acceptance finding per offending acceptance, each naming that acceptance", () => {
+    const context = contextWith({
+      convertibleIssuances: [issuanceRecord("sec1")] as any,
+      transactions: [
+        issuanceRecord("sec1"),
+        { id: "acc-a", object_type: "TX_CONVERTIBLE_ACCEPTANCE", security_id: "sec1", date: "2021-06-01" },
+        { id: "acc-b", object_type: "TX_CONVERTIBLE_ACCEPTANCE", security_id: "sec1", date: "2021-07-01" },
+      ],
+    });
+    const findings = runValidator("TX_CONVERTIBLE_RETRACTION", context, retraction());
+    expect(findings).toHaveLength(2);
+    for (const finding of findings) expectFindingShape(finding, "no-acceptance", subject);
+    expect(findings.map((f) => f.message).join("\n")).toContain("acc-a");
+    expect(findings.map((f) => f.message).join("\n")).toContain("acc-b");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cancellation: issuance-exists, date-order, no-other-transactions
+// ---------------------------------------------------------------------------
+
+describe("convertible cancellation validity", () => {
+  const cancellation = (overrides: Record<string, unknown> = {}) => ({
+    id: "can1",
+    object_type: "TX_CONVERTIBLE_CANCELLATION",
+    security_id: "sec1",
+    date: "2021-01-01",
+    ...overrides,
+  });
+  const cancellationRecord = { id: "can1", object_type: "TX_CONVERTIBLE_CANCELLATION", security_id: "sec1", date: "2021-01-01" };
+  const acceptanceRecord = { id: "acc-x", object_type: "TX_CONVERTIBLE_ACCEPTANCE", security_id: "sec1", date: "2021-02-01" };
+  const subject = { object_type: "TX_CONVERTIBLE_CANCELLATION", id: "can1" };
+
+  it("returns no findings when only an issuance, a convertible acceptance, and the cancellation itself reference the security", () => {
+    const context = contextWith({
+      convertibleIssuances: [issuanceRecord("sec1")] as any,
+      transactions: [issuanceRecord("sec1"), acceptanceRecord, cancellationRecord],
+    });
+    expect(runValidator("TX_CONVERTIBLE_CANCELLATION", context, cancellation())).toEqual([]);
+  });
+
+  it("treats any live convertible record matched by security_id as the issuance, regardless of object_type", () => {
+    // The existence check matches on security_id alone; a non-issuance object_type
+    // in the live collection still satisfies it.
+    const context = contextWith({
+      convertibleIssuances: [{ id: "x", object_type: "SOMETHING_ELSE", security_id: "sec1", date: "2020-01-01" }] as any,
+      transactions: [issuanceRecord("sec1")],
+    });
+    expect(runValidator("TX_CONVERTIBLE_CANCELLATION", context, cancellation())).toEqual([]);
+  });
+
+  it("removes the referenced security from convertibleIssuances on the valid branch", () => {
+    const seeded = contextWith({
+      convertibleIssuances: [issuanceRecord("sec1"), issuanceRecord("sec2")] as any,
+      transactions: [issuanceRecord("sec1"), issuanceRecord("sec2")],
+    });
+    const actor = startSeeded(seeded);
+    actor.send(ev("TX_CONVERTIBLE_CANCELLATION", cancellation()));
+
+    const snapshot = actor.getSnapshot();
+    expect(snapshot.value).toBe("capTable");
+    expect(snapshot.context.convertibleIssuances.some((c: any) => c.security_id === "sec1")).toBe(false);
+    expect(snapshot.context.convertibleIssuances.some((c: any) => c.security_id === "sec2")).toBe(true);
+  });
+
+  it("flags a missing issuance with an error naming the security_id", () => {
+    const context = contextWith({ transactions: [issuanceRecord("sec1")] });
+    const findings = runValidator("TX_CONVERTIBLE_CANCELLATION", context, cancellation());
+    expect(findings).toHaveLength(1);
+    expectFindingShape(findings[0], "issuance-exists", subject);
+    expect(findings[0].message).toContain("sec1");
+  });
+
+  it("flags an out-of-order date with an error naming the security_id", () => {
+    const context = contextWith({
+      convertibleIssuances: [issuanceRecord("sec1", "2022-01-01")] as any,
+      transactions: [issuanceRecord("sec1", "2022-01-01")],
+    });
+    const findings = runValidator("TX_CONVERTIBLE_CANCELLATION", context, cancellation());
+    expect(findings).toHaveLength(1);
+    expectFindingShape(findings[0], "date-order", subject);
+    expect(findings[0].message).toContain("sec1");
+  });
+
+  it("emits one no-other-transactions finding per offender, exempting acceptances and itself", () => {
+    const context = contextWith({
+      convertibleIssuances: [issuanceRecord("sec1")] as any,
+      transactions: [
+        issuanceRecord("sec1"),
+        acceptanceRecord,
+        cancellationRecord,
+        { id: "xfer-a", object_type: "TX_CONVERTIBLE_TRANSFER", security_id: "sec1", date: "2021-06-01" },
+        { id: "xfer-b", object_type: "TX_CONVERTIBLE_TRANSFER", security_id: "sec1", date: "2021-07-01" },
+      ],
+    });
+    const findings = runValidator("TX_CONVERTIBLE_CANCELLATION", context, cancellation());
+    expect(findings).toHaveLength(2);
+    for (const finding of findings) expectFindingShape(finding, "no-other-transactions", subject);
+    const messages = findings.map((f) => f.message).join("\n");
+    expect(messages).toContain("xfer-a");
+    expect(messages).toContain("xfer-b");
+    // The exempt acceptance is never named as an offender.
+    expect(messages).not.toContain("acc-x");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Transfer: issuance-exists, date-order (no-other-transactions is a declared gap)
+// ---------------------------------------------------------------------------
+
+describe("convertible transfer validity", () => {
+  const transfer = (overrides: Record<string, unknown> = {}) => ({
+    id: "xfer1",
+    object_type: "TX_CONVERTIBLE_TRANSFER",
+    security_id: "sec1",
+    date: "2021-01-01",
+    ...overrides,
+  });
+  const subject = { object_type: "TX_CONVERTIBLE_TRANSFER", id: "xfer1" };
+
+  it("returns no findings when the issuance exists and dates order", () => {
+    const context = contextWith({
+      convertibleIssuances: [issuanceRecord("sec1")] as any,
+      transactions: [issuanceRecord("sec1")],
+    });
+    expect(runValidator("TX_CONVERTIBLE_TRANSFER", context, transfer())).toEqual([]);
+  });
+
+  it("removes the referenced security from convertibleIssuances on the valid branch", () => {
+    const seeded = contextWith({
+      convertibleIssuances: [issuanceRecord("sec1"), issuanceRecord("sec2")] as any,
+      transactions: [issuanceRecord("sec1"), issuanceRecord("sec2")],
+    });
+    const actor = startSeeded(seeded);
+    actor.send(ev("TX_CONVERTIBLE_TRANSFER", transfer()));
+
+    const snapshot = actor.getSnapshot();
+    expect(snapshot.value).toBe("capTable");
+    expect(snapshot.context.convertibleIssuances.some((c: any) => c.security_id === "sec1")).toBe(false);
+    expect(snapshot.context.convertibleIssuances.some((c: any) => c.security_id === "sec2")).toBe(true);
+  });
+
+  it("flags a missing issuance with an error naming the security_id", () => {
+    const context = contextWith({ transactions: [issuanceRecord("sec1")] });
+    const findings = runValidator("TX_CONVERTIBLE_TRANSFER", context, transfer());
+    expect(findings).toHaveLength(1);
+    expectFindingShape(findings[0], "issuance-exists", subject);
+    expect(findings[0].message).toContain("sec1");
+  });
+
+  it("flags an out-of-order date with an error naming the security_id", () => {
+    const context = contextWith({
+      convertibleIssuances: [issuanceRecord("sec1", "2022-01-01")] as any,
+      transactions: [issuanceRecord("sec1", "2022-01-01")],
+    });
+    const findings = runValidator("TX_CONVERTIBLE_TRANSFER", context, transfer());
+    expect(findings).toHaveLength(1);
+    expectFindingShape(findings[0], "date-order", subject);
+    expect(findings[0].message).toContain("sec1");
+  });
+
+  it("never emits no-other-transactions, even when other transactions reference the security", () => {
+    const context = contextWith({
+      convertibleIssuances: [issuanceRecord("sec1")] as any,
+      transactions: [
+        issuanceRecord("sec1"),
+        { id: "ret-x", object_type: "TX_CONVERTIBLE_RETRACTION", security_id: "sec1", date: "2021-06-01" },
+        { id: "can-x", object_type: "TX_CONVERTIBLE_CANCELLATION", security_id: "sec1", date: "2021-07-01" },
+      ],
+    });
+    const findings = runValidator("TX_CONVERTIBLE_TRANSFER", context, transfer());
+    // The declared gap is never checked, so the transaction stays valid here.
+    expect(findings).toEqual([]);
+    expect(findings.some((f) => f.check === "no-other-transactions")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Declared-vs-emitted consistency across the family
+// ---------------------------------------------------------------------------
+
+// A transaction record on `security_id` of the given kind; the offender/exempt
+// building block for the failing scenarios below.
+const txRecord = (object_type: string, id: string, security_id = "sec1", date = "2021-06-01") => ({
+  id,
+  object_type,
+  security_id,
+  date,
+});
+
+// For each migrated type, scenarios that each fail one implemented check. The
+// implemented ids a module declares should be exactly the ids these scenarios
+// emit; a module's declared gap (transfer's no-other-transactions) has no
+// failing scenario because no code path emits it.
+const failingScenarios: Record<MigratedKey, { context: OcfMachineContext; data: Record<string, unknown> }[]> = {
+  TX_CONVERTIBLE_ISSUANCE: [
+    {
+      context: baseContext(),
+      data: { id: "i1", object_type: "TX_CONVERTIBLE_ISSUANCE", security_id: "sec1", stakeholder_id: "nobody", date: "2021-01-01" },
+    },
+  ],
+  TX_CONVERTIBLE_ACCEPTANCE: [
+    { context: contextWith({ transactions: [issuanceRecord("sec1")] }), data: txRecord("TX_CONVERTIBLE_ACCEPTANCE", "a1", "sec1", "2021-01-01") },
+    { context: contextWith({ convertibleIssuances: [issuanceRecord("sec1", "2022-01-01")] as any, transactions: [issuanceRecord("sec1", "2022-01-01")] }), data: txRecord("TX_CONVERTIBLE_ACCEPTANCE", "a1", "sec1", "2021-01-01") },
+    { context: contextWith({ convertibleIssuances: [issuanceRecord("sec1")] as any, transactions: [issuanceRecord("sec1"), txRecord("TX_CONVERTIBLE_RETRACTION", "r1")] }), data: txRecord("TX_CONVERTIBLE_ACCEPTANCE", "a1", "sec1", "2021-01-01") },
+  ],
+  TX_CONVERTIBLE_RETRACTION: [
+    { context: contextWith({ transactions: [issuanceRecord("sec1")] }), data: txRecord("TX_CONVERTIBLE_RETRACTION", "r1", "sec1", "2021-01-01") },
+    { context: contextWith({ convertibleIssuances: [issuanceRecord("sec1", "2022-01-01")] as any, transactions: [issuanceRecord("sec1", "2022-01-01")] }), data: txRecord("TX_CONVERTIBLE_RETRACTION", "r1", "sec1", "2021-01-01") },
+    { context: contextWith({ convertibleIssuances: [issuanceRecord("sec1")] as any, transactions: [issuanceRecord("sec1"), txRecord("TX_CONVERTIBLE_ACCEPTANCE", "a1")] }), data: txRecord("TX_CONVERTIBLE_RETRACTION", "r1", "sec1", "2021-01-01") },
+  ],
+  TX_CONVERTIBLE_CANCELLATION: [
+    { context: contextWith({ transactions: [issuanceRecord("sec1")] }), data: txRecord("TX_CONVERTIBLE_CANCELLATION", "c1", "sec1", "2021-01-01") },
+    { context: contextWith({ convertibleIssuances: [issuanceRecord("sec1", "2022-01-01")] as any, transactions: [issuanceRecord("sec1", "2022-01-01")] }), data: txRecord("TX_CONVERTIBLE_CANCELLATION", "c1", "sec1", "2021-01-01") },
+    { context: contextWith({ convertibleIssuances: [issuanceRecord("sec1")] as any, transactions: [issuanceRecord("sec1"), txRecord("TX_CONVERTIBLE_TRANSFER", "x1")] }), data: txRecord("TX_CONVERTIBLE_CANCELLATION", "c1", "sec1", "2021-01-01") },
+  ],
+  TX_CONVERTIBLE_TRANSFER: [
+    { context: contextWith({ transactions: [issuanceRecord("sec1")] }), data: txRecord("TX_CONVERTIBLE_TRANSFER", "x1", "sec1", "2021-01-01") },
+    { context: contextWith({ convertibleIssuances: [issuanceRecord("sec1", "2022-01-01")] as any, transactions: [issuanceRecord("sec1", "2022-01-01")] }), data: txRecord("TX_CONVERTIBLE_TRANSFER", "x1", "sec1", "2021-01-01") },
+  ],
+};
+
+/** Every check id emitted across a module's failing scenarios. */
+const emittedCheckIds = (key: MigratedKey): Set<string> => {
+  const emitted = new Set<string>();
+  for (const { context, data } of failingScenarios[key]) {
+    for (const finding of runValidator(key, context, data)) emitted.add(finding.check);
+  }
+  return emitted;
+};
+
+describe("declared and emitted checks stay consistent across the family", () => {
+  // Exact set equality in both directions: no finding is emitted for a check the
+  // descriptor does not declare implemented, and every declared implemented check
+  // is emitted by at least one failing scenario.
+  it.each(MIGRATED_KEYS)("%s emits exactly the check ids its descriptor declares implemented", (key) => {
+    expect([...emittedCheckIds(key)].sort()).toEqual([...implementedCheckIds(key)].sort());
+  });
+
+  it("never emits transfer's declared-gap check", () => {
+    expect(emittedCheckIds("TX_CONVERTIBLE_TRANSFER").has("no-other-transactions")).toBe(false);
+    // The gap is declared on the descriptor with implemented: false.
+    const declared = (TX_DESCRIPTORS.TX_CONVERTIBLE_TRANSFER as { checks: readonly { id: string; implemented?: false }[] }).checks;
+    expect(declared.some((c) => c.id === "no-other-transactions" && c.implemented === false)).toBe(true);
+  });
+
+  it("leaves conversion on the legacy convention", () => {
+    expect("legacyValidate" in TX_DESCRIPTORS.TX_CONVERTIBLE_CONVERSION).toBe(true);
+    expect("validate" in TX_DESCRIPTORS.TX_CONVERTIBLE_CONVERSION).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Channel migration: findings, not report, for the convertible family
+// ---------------------------------------------------------------------------
+
+describe("convertible family findings migrate to the findings channel", () => {
+  it("routes an invalid convertible transaction to findings, leaves report clear, and serializes the errors in the failure result", () => {
+    const actor = startSeeded(baseContext());
+    // No stakeholder matches, so the issuance is invalid.
+    actor.send(ev("TX_CONVERTIBLE_ISSUANCE", {
+      id: "conv1",
+      object_type: "TX_CONVERTIBLE_ISSUANCE",
+      security_id: "sec1",
+      stakeholder_id: "nobody",
+      date: "2021-01-01",
+    }));
+
+    const { context, value } = actor.getSnapshot();
+    expect(value).toBe("validationError");
+    // The errors landed on findings…
+    expect(context.findings.length).toBeGreaterThan(0);
+    expect(context.findings.every((f) => f.severity === "error")).toBe(true);
+    // …no report entry was written for a migrated convertible type…
+    const migrated = MIGRATED_KEYS as readonly string[];
+    expect(context.report.some((entry: any) => migrated.includes(entry?.transaction_type))).toBe(false);
+    // …and the failure result serialized the error findings.
+    expect(context.result).toContain(JSON.stringify(context.findings, null, 2));
+  });
+});

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -1,0 +1,41 @@
+// Shared machine-test helpers: a full empty context, an actor seeded straight
+// into `capTable`, and the test-only event cast. Imported by every suite that
+// drives the machine, so each validator family's tests build on one definition.
+
+import { createActor } from "xstate";
+import { ocfMachine, type OcfMachineEvent } from "../ocf_validator/ocfMachine";
+import type { OcfMachineContext } from "../types/validator";
+
+/** A full, mostly-empty machine context; `overrides` replace top-level fields. */
+export const baseContext = (overrides: Partial<OcfMachineContext> = {}): OcfMachineContext => ({
+  stockIssuances: [],
+  convertibleIssuances: [],
+  warrantIssuances: [],
+  equityCompensation: [],
+  ocfPackageContent: {
+    manifest: { issuer: { legal_name: "Test Co" } },
+    stakeholders: [],
+    stockClasses: [],
+    transactions: [],
+    stockLegends: [],
+    stockPlans: [],
+    vestingTerms: [],
+    valuations: [],
+  } as OcfMachineContext["ocfPackageContent"],
+  report: [],
+  findings: [],
+  lastErrorFindings: [],
+  snapshots: [],
+  result: "Incomplete",
+  ...overrides,
+});
+
+/** Start an actor seeded into `capTable` with the given context. */
+export const startSeeded = (context: OcfMachineContext) =>
+  createActor(ocfMachine, {
+    snapshot: ocfMachine.resolveState({ value: "capTable", context }),
+  }).start();
+
+/** Cast a hand-built event to the typed event union (test-only boundary). */
+export const ev = (type: string, data: Record<string, unknown> = {}): OcfMachineEvent =>
+  ({ type, data } as unknown as OcfMachineEvent);

--- a/tests/ocfMachine.test.ts
+++ b/tests/ocfMachine.test.ts
@@ -1,7 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { createActor } from "xstate";
 import {
-  ocfMachine,
   collectionUpdate,
   isValidOutcome,
   outcomeUpdate,
@@ -13,44 +11,7 @@ import {
 } from "../ocf_validator/ocfMachine";
 import type { Finding } from "../types/finding";
 import type { GradedValidator, OcfMachineContext } from "../types/validator";
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-/** A full, mostly-empty machine context; `overrides` replace top-level fields. */
-const baseContext = (overrides: Partial<OcfMachineContext> = {}): OcfMachineContext => ({
-  stockIssuances: [],
-  convertibleIssuances: [],
-  warrantIssuances: [],
-  equityCompensation: [],
-  ocfPackageContent: {
-    manifest: { issuer: { legal_name: "Test Co" } },
-    stakeholders: [],
-    stockClasses: [],
-    transactions: [],
-    stockLegends: [],
-    stockPlans: [],
-    vestingTerms: [],
-    valuations: [],
-  } as OcfMachineContext["ocfPackageContent"],
-  report: [],
-  findings: [],
-  lastErrorFindings: [],
-  snapshots: [],
-  result: "Incomplete",
-  ...overrides,
-});
-
-/** Start an actor seeded into `capTable` with the given context. */
-const startSeeded = (context: OcfMachineContext) =>
-  createActor(ocfMachine, {
-    snapshot: ocfMachine.resolveState({ value: "capTable", context }),
-  }).start();
-
-/** Cast a hand-built event to the typed event union (test-only boundary). */
-const ev = (type: string, data: Record<string, unknown> = {}): OcfMachineEvent =>
-  ({ type, data } as unknown as OcfMachineEvent);
+import { baseContext, startSeeded, ev } from "./helpers";
 
 // ---------------------------------------------------------------------------
 // Unknown transaction types
@@ -289,9 +250,11 @@ describe("per-type collection placement", () => {
 // Graded validators through the dispatch helpers
 // ---------------------------------------------------------------------------
 
-// No table entry carries a graded `validate` yet, so these drive the exported
-// dispatch helpers directly with synthetic descriptors. The machine-actor
-// route stays legacy-only (next describe) until a validator family migrates.
+// These drive the exported dispatch helpers directly with synthetic descriptors,
+// isolating the graded dispatch shape from any single family's validator. The
+// convertible family now carries graded `validate` in the real table, with its
+// own machine-actor coverage; the legacy describe below still pins the report
+// convention the unmigrated families use.
 
 /** A synthetic `none` descriptor carrying a graded validator and (empty) checks. */
 const gradedDescriptor = (validate: GradedValidator<any>) =>


### PR DESCRIPTION
Part of #159. Stacked on #196 (`issue-191-check-metadata`); the base retargets as the stack merges.

## What this does

First family migration of the #159 series: the five formulaic convertible validators (issuance, acceptance, retraction, cancellation, transfer) move to the graded convention.

- Each validator becomes `(context, data) => Finding[]` with deep-readonly, typed inputs. The dual-mode `isGuard` flag and the untyped `event` are gone.
- Each module now exports its own descriptor (`effect`, `collection`, `validate`, `checks`), and the central table imports them. The free-text `CURRENT CHECKS` / `MISSING CHECKS` comment blocks become structured `Check` metadata; transfer's known-missing check is declared with `implemented: false`.
- Check ids are shared across modules where the check is the same thing (`issuance-exists`, `date-order`), with per-descriptor uniqueness guarded by the existing metadata test. Every check in this family blocks in the legacy code, so every check is declared and emitted as `error`.
- Shared machine-test helpers move to `tests/helpers.ts`, and a new suite covers the family: per-check validity scenarios, finding shape and message content, per-offender finding counts, machine-driven collection effects, and set-equality between declared and emitted check ids.

`tx_convertible_conversion` is excluded and stays on the legacy convention: it is outsized and carries the defects filed in #192 and #193, so it gets its own PR.

## Behavior changes

- For these five transaction types, findings replace `report` entries: per-check outcomes land on `context.findings`, and failure messages serialize the error findings. `context.report` no longer receives entries for them.
- Checks that scan for offending transactions (`no-retraction`, `no-acceptance`, `no-other-transactions`) now emit one finding per offender instead of collapsing to a single boolean. Validity is unchanged; only the finding granularity is finer.

Everything else is ported faithfully, including the legacy scan quirks (split data sources, whole-package scans that see future-dated transactions, cancellation's unfiltered existence predicate). Those are deliberately preserved, not endorsed; they are recorded in #198 so they keep a resolution path.

## Verification

`npm run build` and `npm run test:ci` are green (99 tests), a one-off `tsc --noEmit` pass that includes the test files is clean, and the characterization snapshot is byte-identical to the stacked base (the fixture contains no convertible transactions, so this migration cannot affect it).
