### PR TITLE
Migrate warrant validators to graded descriptors

### DIFF
--- a/ocf_validator/ocfMachine.ts
+++ b/ocf_validator/ocfMachine.ts
@@ -16,6 +16,11 @@ import { TX_CONVERTIBLE_ACCEPTANCE } from "./validators/convertible/tx_convertib
 import { TX_CONVERTIBLE_RETRACTION } from "./validators/convertible/tx_convertible_retraction";
 import { TX_CONVERTIBLE_CANCELLATION } from "./validators/convertible/tx_convertible_cancellation";
 import { TX_CONVERTIBLE_TRANSFER } from "./validators/convertible/tx_convertible_transfer";
+import { TX_WARRANT_ISSUANCE } from "./validators/warrant/tx_warrant_issuance";
+import { TX_WARRANT_ACCEPTANCE } from "./validators/warrant/tx_warrant_acceptance";
+import { TX_WARRANT_RETRACTION } from "./validators/warrant/tx_warrant_retraction";
+import { TX_WARRANT_CANCELLATION } from "./validators/warrant/tx_warrant_cancellation";
+import { TX_WARRANT_TRANSFER } from "./validators/warrant/tx_warrant_transfer";
 import run_EOD from "./eod";
 
 // The validator contract types are defined in types/validator.ts; re-exported
@@ -168,13 +173,13 @@ export const TX_DESCRIPTORS = {
   // --- append: issuance appended to its family collection -----------------
   TX_STOCK_ISSUANCE: { effect: "append", collection: "stockIssuances", legacyValidate: validators.valid_tx_stock_issuance },
   TX_CONVERTIBLE_ISSUANCE,
-  TX_WARRANT_ISSUANCE: { effect: "append", collection: "warrantIssuances", legacyValidate: validators.valid_tx_warrant_issuance },
+  TX_WARRANT_ISSUANCE,
   TX_EQUITY_COMPENSATION_ISSUANCE: { effect: "append", collection: "equityCompensation", legacyValidate: validators.valid_tx_equity_compensation_issuance },
 
   // --- none: validate + report, no collection mutation --------------------
   TX_STOCK_ACCEPTANCE: { effect: "none", legacyValidate: validators.valid_tx_stock_acceptance },
   TX_CONVERTIBLE_ACCEPTANCE,
-  TX_WARRANT_ACCEPTANCE: { effect: "none", legacyValidate: validators.valid_tx_warrant_acceptance },
+  TX_WARRANT_ACCEPTANCE,
   TX_EQUITY_COMPENSATION_ACCEPTANCE: { effect: "none", legacyValidate: validators.valid_tx_equity_compensation_acceptance },
   // TX_EQUITY_COMPENSATION_EXERCISE removes nothing today (its collection filter
   // is commented out in the legacy machine), asymmetric with TX_WARRANT_EXERCISE
@@ -192,9 +197,9 @@ export const TX_DESCRIPTORS = {
   TX_CONVERTIBLE_CANCELLATION,
   TX_CONVERTIBLE_TRANSFER,
   TX_CONVERTIBLE_CONVERSION: { effect: "remove", collection: "convertibleIssuances", legacyValidate: validators.valid_tx_convertible_conversion },
-  TX_WARRANT_RETRACTION: { effect: "remove", collection: "warrantIssuances", legacyValidate: validators.valid_tx_warrant_retraction },
-  TX_WARRANT_CANCELLATION: { effect: "remove", collection: "warrantIssuances", legacyValidate: validators.valid_tx_warrant_cancellation },
-  TX_WARRANT_TRANSFER: { effect: "remove", collection: "warrantIssuances", legacyValidate: validators.valid_tx_warrant_transfer },
+  TX_WARRANT_RETRACTION,
+  TX_WARRANT_CANCELLATION,
+  TX_WARRANT_TRANSFER,
   TX_WARRANT_EXERCISE: { effect: "remove", collection: "warrantIssuances", legacyValidate: validators.valid_tx_warrant_exercise },
   TX_EQUITY_COMPENSATION_RETRACTION: { effect: "remove", collection: "equityCompensation", legacyValidate: validators.valid_tx_equity_compensation_retraction },
   TX_EQUITY_COMPENSATION_CANCELLATION: { effect: "remove", collection: "equityCompensation", legacyValidate: validators.valid_tx_equity_compensation_cancellation },

--- a/ocf_validator/validators/index.ts
+++ b/ocf_validator/validators/index.ts
@@ -7,11 +7,6 @@ import valid_tx_stock_reissuance from './stock/tx_stock_reissuance';
 import valid_tx_stock_repurchase from './stock/tx_stock_repurchase';
 import valid_tx_stock_transfer from './stock/tx_stock_transfer';
 import valid_tx_convertible_conversion from './convertible/tx_convertible_conversion';
-import valid_tx_warrant_issuance from './warrant/tx_warrant_issuance';
-import valid_tx_warrant_retraction from './warrant/tx_warrant_retraction';
-import valid_tx_warrant_acceptance from './warrant/tx_warrant_acceptance';
-import valid_tx_warrant_cancellation from './warrant/tx_warrant_cancellation';
-import valid_tx_warrant_transfer from './warrant/tx_warrant_transfer';
 import valid_tx_warrant_exercise from './warrant/tx_warrant_exercise';
 import valid_tx_equity_compensation_issuance from './equity_compensation/tx_equity_compensation_issuance';
 import valid_tx_equity_compensation_retraction from './equity_compensation/tx_equity_compensation_retraction';
@@ -46,11 +41,6 @@ const validators = {
   valid_tx_stock_repurchase,
   valid_tx_stock_transfer,
   valid_tx_convertible_conversion,
-  valid_tx_warrant_issuance,
-  valid_tx_warrant_retraction,
-  valid_tx_warrant_acceptance,
-  valid_tx_warrant_cancellation,
-  valid_tx_warrant_transfer,
   valid_tx_warrant_exercise,
   valid_tx_equity_compensation_issuance,
   valid_tx_equity_compensation_retraction,

--- a/ocf_validator/validators/warrant/tx_warrant_acceptance.ts
+++ b/ocf_validator/validators/warrant/tx_warrant_acceptance.ts
@@ -63,7 +63,7 @@ const validate: GradedValidator<Acceptance> = (context, data) => {
     findings.push({
       severity: "error",
       check: "date-order",
-      message: `The transaction is dated before the warrant issuance it references (security_id ${data.security_id}).`,
+      message: `The transaction is not dated on or after a warrant issuance with security_id ${data.security_id}.`,
       subject,
     });
   }

--- a/ocf_validator/validators/warrant/tx_warrant_acceptance.ts
+++ b/ocf_validator/validators/warrant/tx_warrant_acceptance.ts
@@ -1,72 +1,90 @@
-const valid_tx_warrant_acceptance = (context: any, event: any, isGuard: Boolean) => {
-  const {transactions} = context.ocfPackageContent;
+import type { TransactionFor } from "../../../types/ocf-input";
+import type { Check, GradedValidator } from "../../../types/validator";
+import type { Finding } from "../../../types/finding";
+import type { Descriptor } from "../../ocfMachine";
 
-  let validity = false;
-  let report: any = {transaction_type: "TX_WARRANT_ACCEPTANCE", transaction_id: event.data.id, transaction_date: event.data.date};
+type Acceptance = TransactionFor<"TX_WARRANT_ACCEPTANCE">;
 
-  // Check that warrant issuance in incoming security_id referenced by transaction exists in current state.
-  let incoming_warrantIssuance_validity = false;
-  context.warrantIssuances.forEach((ele: any) => {
-    if (
-      ele.security_id === event.data.security_id &&
-      ele.object_type === 'TX_WARRANT_ISSUANCE'
-    ) {
-      incoming_warrantIssuance_validity = true;
-      report.incoming_warrantIssuance_validity = true;
+const checks: readonly Check[] = [
+  {
+    id: "issuance-exists",
+    severity: "error",
+    description:
+      "The warrant issuance referenced by the transaction's security_id exists in the current cap-table state.",
+  },
+  {
+    id: "date-order",
+    severity: "error",
+    description:
+      "The transaction is dated on or after the warrant issuance it references.",
+  },
+  {
+    id: "no-retraction",
+    severity: "error",
+    description: "No warrant retraction references the transaction's security_id.",
+  },
+];
+
+const validate: GradedValidator<Acceptance> = (context, data) => {
+  const findings: Finding[] = [];
+  const subject = { object_type: data.object_type, id: data.id };
+  const { transactions } = context.ocfPackageContent;
+
+  // issuance-exists scans the live warrant collection.
+  let issuanceExists = false;
+  context.warrantIssuances.forEach((ele) => {
+    if (ele.security_id === data.security_id && ele.object_type === "TX_WARRANT_ISSUANCE") {
+      issuanceExists = true;
     }
   });
-  if (!incoming_warrantIssuance_validity) {
-    report.incoming_warrantIssuance_validity = false;
+  if (!issuanceExists) {
+    findings.push({
+      severity: "error",
+      check: "issuance-exists",
+      message: `No warrant issuance with security_id ${data.security_id} exists in the current cap-table state.`,
+      subject,
+    });
   }
 
-  // Check to ensure that the date of transaction is the same day or after the date of the incoming warrant issuance.
-  let incoming_date_validity = false;
-  transactions.forEach((ele: any) => {
+  // date-order scans the full package transaction history for the issuance.
+  // The object_type test leads so it narrows the transaction union to a
+  // security_id-bearing member before the other reads.
+  let dateOrdered = false;
+  transactions.forEach((ele) => {
     if (
-      ele.security_id === event.data.security_id &&
-      ele.object_type === 'TX_WARRANT_ISSUANCE'
+      ele.object_type === "TX_WARRANT_ISSUANCE" &&
+      ele.security_id === data.security_id &&
+      ele.date <= data.date
     ) {
-      if (ele.date <= event.data.date) {
-        incoming_date_validity = true;
-        report.incoming_date_validity = true;
-      }
+      dateOrdered = true;
     }
   });
-  if (!incoming_date_validity) {
-    report.incoming_date_validity = false;
+  if (!dateOrdered) {
+    findings.push({
+      severity: "error",
+      check: "date-order",
+      message: `The transaction is dated before the warrant issuance it references (security_id ${data.security_id}).`,
+      subject,
+    });
   }
 
-  // Check that warrant issuance in incoming security_id does not have a warrant retraction transaction associated with it.
-  let no_warrant_retraction_validity = false;
-  let warrant_retraction_exists = false;
-  transactions.forEach((ele: any) => {
-    if (
-      ele.security_id === event.data.security_id &&
-      ele.object_type === 'TX_WARRANT_RETRACTION'
-    ) {
-      warrant_retraction_exists = true;
+  // no-retraction emits one finding per warrant retraction on this security_id.
+  transactions.forEach((ele) => {
+    if (ele.object_type === "TX_WARRANT_RETRACTION" && ele.security_id === data.security_id) {
+      findings.push({
+        severity: "error",
+        check: "no-retraction",
+        message: `A warrant retraction (${ele.id}) references the transaction's security_id.`,
+        subject,
+      });
     }
   });
 
-  if (!warrant_retraction_exists) {
-    no_warrant_retraction_validity = true;
-    report.no_warrant_retraction_validity = true;
-  }
-  if (!no_warrant_retraction_validity) {
-    report.no_warrant_retraction_validity = false;
-  }
-
-  if (
-    incoming_warrantIssuance_validity &&
-    incoming_date_validity &&
-    no_warrant_retraction_validity
-  ) {
-    validity = true;
-  }
-
-  const result = isGuard ? validity : report;
-  
-  return result;
+  return findings;
 };
 
-export default valid_tx_warrant_acceptance;
+export const TX_WARRANT_ACCEPTANCE = {
+  effect: "none",
+  validate,
+  checks,
+} satisfies Descriptor;

--- a/ocf_validator/validators/warrant/tx_warrant_cancellation.ts
+++ b/ocf_validator/validators/warrant/tx_warrant_cancellation.ts
@@ -65,7 +65,7 @@ const validate: GradedValidator<Cancellation> = (context, data) => {
     findings.push({
       severity: "error",
       check: "date-order",
-      message: `The transaction is dated before the warrant issuance it references (security_id ${data.security_id}).`,
+      message: `The transaction is not dated on or after a warrant issuance with security_id ${data.security_id}.`,
       subject,
     });
   }

--- a/ocf_validator/validators/warrant/tx_warrant_cancellation.ts
+++ b/ocf_validator/validators/warrant/tx_warrant_cancellation.ts
@@ -1,79 +1,103 @@
-// Reference for tx_warrant_cancellation: https://open-cap-table-coalition.github.io/Open-Cap-Format-OCF/schema_markdown/schema/objects/transactions/cancellation/StockCancellation/
-/*
-  CURRENT CHECKS:
-    1. Check that warrant issuance in incoming security_id reference by transaction exists in current state.
-    2. Check to ensure that the date of transaction is the same day or after the date of the incoming warrant issuance.
-    3. The security_id of the warrant issuance referred to in the security_id variable must not be the security_id related to any other transactions with the exception of a warrant acceptance transaction.
-*/
+import type { TransactionFor } from "../../../types/ocf-input";
+import type { Check, GradedValidator } from "../../../types/validator";
+import type { Finding } from "../../../types/finding";
+import type { Descriptor } from "../../ocfMachine";
 
-import {OcfMachineContext} from '../../ocfMachine';
+type Cancellation = TransactionFor<"TX_WARRANT_CANCELLATION">;
 
-const valid_tx_warrant_cancellation = (
-  context: OcfMachineContext,
-  event: any,
-  isGuard: Boolean = false
-) => {
-  let validity = false;
-  let report: any = {transaction_type: "TX_WARRANT_CANCELLATION", transaction_id: event.data.id, transaction_date: event.data.date};
+const checks: readonly Check[] = [
+  {
+    id: "issuance-exists",
+    severity: "error",
+    description:
+      "The warrant issuance referenced by the transaction's security_id exists in the current cap-table state.",
+  },
+  {
+    id: "date-order",
+    severity: "error",
+    description:
+      "The transaction is dated on or after the warrant issuance it references.",
+  },
+  {
+    id: "no-other-transactions",
+    severity: "error",
+    description:
+      "No other transaction references the transaction's security_id, other than a warrant acceptance.",
+  },
+];
 
-  const {transactions} = context.ocfPackageContent;
-  // 1. Check that warrant issuance in incoming security_id reference by transaction exists in current state.
-  let incoming_warrantIssuance_validity = false;
-  context.warrantIssuances.forEach((ele: any) => {
-    if (ele.security_id === event.data.security_id) {
-      incoming_warrantIssuance_validity = true;
-      report.incoming_warrantIssuance_validity = true;
+const validate: GradedValidator<Cancellation> = (context, data) => {
+  const findings: Finding[] = [];
+  const subject = { object_type: data.object_type, id: data.id };
+  const { transactions } = context.ocfPackageContent;
+
+  // issuance-exists here matches on security_id alone — unlike the sibling
+  // validators it does not also require object_type TX_WARRANT_ISSUANCE.
+  let issuanceExists = false;
+  context.warrantIssuances.forEach((ele) => {
+    if (ele.security_id === data.security_id) {
+      issuanceExists = true;
     }
   });
-
-  if (!incoming_warrantIssuance_validity) {
-    report.incoming_warrantIssuance_validity = false;
+  if (!issuanceExists) {
+    findings.push({
+      severity: "error",
+      check: "issuance-exists",
+      message: `No warrant issuance with security_id ${data.security_id} exists in the current cap-table state.`,
+      subject,
+    });
   }
 
-  // 2. Check to ensure that the date of transaction is the same day or after the date of the incoming warrant issuance.
-  let incoming_date_validity = false;
-  transactions.forEach((ele: any) => {
+  // date-order scans the full package transaction history for the issuance.
+  // The object_type test leads so it narrows the transaction union to a
+  // security_id-bearing member before the other reads.
+  let dateOrdered = false;
+  transactions.forEach((ele) => {
     if (
-      ele.security_id === event.data.security_id &&
-      ele.object_type === 'TX_WARRANT_ISSUANCE'
+      ele.object_type === "TX_WARRANT_ISSUANCE" &&
+      ele.security_id === data.security_id &&
+      ele.date <= data.date
     ) {
-      if (ele.date <= event.data.date) {
-        incoming_date_validity = true;
-        report.incoming_date_validity = true;
-      }
+      dateOrdered = true;
     }
   });
-  if (!incoming_date_validity) {
-    report.incoming_date_validity = false;
+  if (!dateOrdered) {
+    findings.push({
+      severity: "error",
+      check: "date-order",
+      message: `The transaction is dated before the warrant issuance it references (security_id ${data.security_id}).`,
+      subject,
+    });
   }
 
-  let only_transaction_validity = true;
-  transactions.map((ele: any) => {
+  // no-other-transactions emits one finding per transaction on this security_id,
+  // exempting the issuance, any warrant acceptance, and this cancellation itself.
+  // This scan keeps every transaction type in play, so it narrows by property
+  // presence rather than by discriminant: a transaction that carries no
+  // security_id can never reference this one.
+  transactions.forEach((ele) => {
     if (
-      ele.security_id === event.data.security_id &&
-      ele.object_type !== 'TX_WARRANT_ISSUANCE' &&
-      ele.object_type !== 'TX_WARRANT_ACCEPTANCE' &&
-      !(ele.object_type === 'TX_WARRANT_CANCELLATION' && ele.id === event.data.id)
+      "security_id" in ele &&
+      ele.security_id === data.security_id &&
+      ele.object_type !== "TX_WARRANT_ISSUANCE" &&
+      ele.object_type !== "TX_WARRANT_ACCEPTANCE" &&
+      !(ele.object_type === "TX_WARRANT_CANCELLATION" && ele.id === data.id)
     ) {
-      only_transaction_validity = false;
-      report.only_transaction_validity = false;
+      findings.push({
+        severity: "error",
+        check: "no-other-transactions",
+        message: `Another transaction (${ele.id}) references the transaction's security_id.`,
+        subject,
+      });
     }
   });
-  if (only_transaction_validity) {
-    report.only_transaction_validity = true;
-  }
 
-  if (
-    incoming_warrantIssuance_validity &&
-    incoming_date_validity &&
-    only_transaction_validity
-  ) {
-    validity = true;
-  }
-
-  const result = isGuard ? validity : report;
-  
-  return result;
+  return findings;
 };
 
-export default valid_tx_warrant_cancellation;
+export const TX_WARRANT_CANCELLATION = {
+  effect: "remove",
+  collection: "warrantIssuances",
+  validate,
+  checks,
+} satisfies Descriptor;

--- a/ocf_validator/validators/warrant/tx_warrant_issuance.ts
+++ b/ocf_validator/validators/warrant/tx_warrant_issuance.ts
@@ -1,27 +1,40 @@
-const valid_tx_warrant_issuance = (context: any, event: any, isGuard: any) => {
-  let validity = false;
+import type { OCFWarrantIssuance } from "@opencaptablecoalition/ocf-types";
+import type { Check, GradedValidator } from "../../../types/validator";
+import type { Finding } from "../../../types/finding";
+import type { Descriptor } from "../../ocfMachine";
+
+const checks: readonly Check[] = [
+  {
+    id: "stakeholder-exists",
+    severity: "error",
+    description:
+      "The stakeholder referenced by the transaction exists in the stakeholder file.",
+  },
+];
+
+const validate: GradedValidator<OCFWarrantIssuance> = (context, data) => {
+  const findings: Finding[] = [];
   const { stakeholders } = context.ocfPackageContent;
-  let report: any = {transaction_type: "TX_WARRANT_ISSUANCE", transaction_id: event.data.id, transaction_date: event.data.date};
-  
-  // Check if the stakeholder referenced by the transaction exists in the stakeholder file.
-  let stakeholder_validity = false;
+
+  let stakeholderExists = false;
   stakeholders.forEach((ele: any) => {
-    if (ele.id === event.data.stakeholder_id) {
-      stakeholder_validity = true;
-      report.stakeholder_validity = true
-    }
+    if (ele.id === data.stakeholder_id) stakeholderExists = true;
   });
-  if (!stakeholder_validity) {
-    report.stakeholder_validity = false
+  if (!stakeholderExists) {
+    findings.push({
+      severity: "error",
+      check: "stakeholder-exists",
+      message: `The stakeholder ${data.stakeholder_id} referenced by the transaction was not found in the stakeholder file.`,
+      subject: { object_type: data.object_type, id: data.id },
+    });
   }
 
-  if (stakeholder_validity) {
-    validity = true;
-  }
-
-  const result = isGuard ? validity : report;
-  
-  return result;
+  return findings;
 };
 
-export default valid_tx_warrant_issuance;
+export const TX_WARRANT_ISSUANCE = {
+  effect: "append",
+  collection: "warrantIssuances",
+  validate,
+  checks,
+} satisfies Descriptor;

--- a/ocf_validator/validators/warrant/tx_warrant_retraction.ts
+++ b/ocf_validator/validators/warrant/tx_warrant_retraction.ts
@@ -1,75 +1,91 @@
-const valid_tx_warrant_retraction = (context: any, event: any, isGuard: Boolean = false) => {
-  let validity = false;
+import type { TransactionFor } from "../../../types/ocf-input";
+import type { Check, GradedValidator } from "../../../types/validator";
+import type { Finding } from "../../../types/finding";
+import type { Descriptor } from "../../ocfMachine";
 
-  let report: any = {transaction_type: "TX_WARRANT_RETRACTION", transaction_id: event.data.id, transaction_date: event.data.date};
+type Retraction = TransactionFor<"TX_WARRANT_RETRACTION">;
 
-  // TBC: validation of tx_warrant_retraction
-  const {transactions} = context.ocfPackageContent;
-  // Check that warrant issuance in incoming security_id referenced by transaction exists in current state.
-  let incoming_warrantIssuance_validity = false;
-  context.warrantIssuances.forEach((ele: any) => {
-    if (
-      ele.security_id === event.data.security_id &&
-      ele.object_type === 'TX_WARRANT_ISSUANCE'
-    ) {
-      incoming_warrantIssuance_validity = true;
-      report.incoming_warrantIssuance_validity = true
+const checks: readonly Check[] = [
+  {
+    id: "issuance-exists",
+    severity: "error",
+    description:
+      "The warrant issuance referenced by the transaction's security_id exists in the current cap-table state.",
+  },
+  {
+    id: "date-order",
+    severity: "error",
+    description:
+      "The transaction is dated on or after the warrant issuance it references.",
+  },
+  {
+    id: "no-acceptance",
+    severity: "error",
+    description: "No warrant acceptance references the transaction's security_id.",
+  },
+];
+
+const validate: GradedValidator<Retraction> = (context, data) => {
+  const findings: Finding[] = [];
+  const subject = { object_type: data.object_type, id: data.id };
+  const { transactions } = context.ocfPackageContent;
+
+  // issuance-exists scans the live warrant collection.
+  let issuanceExists = false;
+  context.warrantIssuances.forEach((ele) => {
+    if (ele.security_id === data.security_id && ele.object_type === "TX_WARRANT_ISSUANCE") {
+      issuanceExists = true;
     }
   });
-  if (!incoming_warrantIssuance_validity) {
-    report.incoming_warrantIssuance_validity = false
-
+  if (!issuanceExists) {
+    findings.push({
+      severity: "error",
+      check: "issuance-exists",
+      message: `No warrant issuance with security_id ${data.security_id} exists in the current cap-table state.`,
+      subject,
+    });
   }
 
-  // Check to ensure that the date of transaction is the same day or after the date of the incoming warrant issuance.
-  let incoming_date_validity = false;
-  transactions.forEach((ele: any) => {
+  // date-order scans the full package transaction history for the issuance.
+  // The object_type test leads so it narrows the transaction union to a
+  // security_id-bearing member before the other reads.
+  let dateOrdered = false;
+  transactions.forEach((ele) => {
     if (
-      ele.security_id === event.data.security_id &&
-      ele.object_type === 'TX_WARRANT_ISSUANCE'
+      ele.object_type === "TX_WARRANT_ISSUANCE" &&
+      ele.security_id === data.security_id &&
+      ele.date <= data.date
     ) {
-      if (ele.date <= event.data.date) {
-        incoming_date_validity = true;
-        report.incoming_date_validity = true;
-      }
+      dateOrdered = true;
     }
   });
-  if (!incoming_date_validity) {
-    report.incoming_date_validity = false;
-
+  if (!dateOrdered) {
+    findings.push({
+      severity: "error",
+      check: "date-order",
+      message: `The transaction is dated before the warrant issuance it references (security_id ${data.security_id}).`,
+      subject,
+    });
   }
 
-  // Check that warrant issuance in incoming security_id does not have a warrant acceptance transaction associated with it.
-  let no_warrant_acceptance_validity = false;
-  let warrant_acceptance_exists = false;
-  transactions.forEach((ele: any) => {
-    if (
-      ele.security_id === event.data.security_id &&
-      ele.object_type === 'TX_WARRANT_ACCEPTANCE'
-    ) {
-      warrant_acceptance_exists = true;
+  // no-acceptance emits one finding per warrant acceptance on this security_id.
+  transactions.forEach((ele) => {
+    if (ele.object_type === "TX_WARRANT_ACCEPTANCE" && ele.security_id === data.security_id) {
+      findings.push({
+        severity: "error",
+        check: "no-acceptance",
+        message: `A warrant acceptance (${ele.id}) references the transaction's security_id.`,
+        subject,
+      });
     }
   });
 
-  if (!warrant_acceptance_exists) {
-    no_warrant_acceptance_validity = true;
-    report.no_warrant_acceptance_validity = true;
-  }
-  if (!no_warrant_acceptance_validity) {
-    report.no_warrant_acceptance_validity = false;
-  }
-
-  if (
-    incoming_warrantIssuance_validity &&
-    incoming_date_validity &&
-    no_warrant_acceptance_validity
-  ) {
-    validity = true;
-  }
-
-  const result = isGuard ? validity : report;
-  
-  return result;
+  return findings;
 };
 
-export default valid_tx_warrant_retraction;
+export const TX_WARRANT_RETRACTION = {
+  effect: "remove",
+  collection: "warrantIssuances",
+  validate,
+  checks,
+} satisfies Descriptor;

--- a/ocf_validator/validators/warrant/tx_warrant_retraction.ts
+++ b/ocf_validator/validators/warrant/tx_warrant_retraction.ts
@@ -63,7 +63,7 @@ const validate: GradedValidator<Retraction> = (context, data) => {
     findings.push({
       severity: "error",
       check: "date-order",
-      message: `The transaction is dated before the warrant issuance it references (security_id ${data.security_id}).`,
+      message: `The transaction is not dated on or after a warrant issuance with security_id ${data.security_id}.`,
       subject,
     });
   }

--- a/ocf_validator/validators/warrant/tx_warrant_transfer.ts
+++ b/ocf_validator/validators/warrant/tx_warrant_transfer.ts
@@ -65,7 +65,7 @@ const validate: GradedValidator<Transfer> = (context, data) => {
     findings.push({
       severity: "error",
       check: "date-order",
-      message: `The transaction is dated before the warrant issuance it references (security_id ${data.security_id}).`,
+      message: `The transaction is not dated on or after a warrant issuance with security_id ${data.security_id}.`,
       subject,
     });
   }

--- a/ocf_validator/validators/warrant/tx_warrant_transfer.ts
+++ b/ocf_validator/validators/warrant/tx_warrant_transfer.ts
@@ -1,63 +1,81 @@
-import {OcfMachineContext} from '../../ocfMachine';
-// Reference for tx_warrant_transfer transaction: https://open-cap-table-coalition.github.io/Open-Cap-Format-OCF/schema_markdown/schema/objects/transactions/transfer/StockTransfer/
+import type { TransactionFor } from "../../../types/ocf-input";
+import type { Check, GradedValidator } from "../../../types/validator";
+import type { Finding } from "../../../types/finding";
+import type { Descriptor } from "../../ocfMachine";
 
-/*
-  CURRENT CHECKS:
-    1. Does the incoming security_id referenced by transaction exist in current cap table state?
-    2. Is the date of transaction the same day or after the date of the incoming issuance?
- MISSING CHECKS:
-    1. The security_id of the warrant issuance referred to in the security_id variable must not be the security_id related to any other transactions with the exception of a warrant acceptance transaction.
-*/
+type Transfer = TransactionFor<"TX_WARRANT_TRANSFER">;
 
-const valid_tx_warrant_transfer = (context: OcfMachineContext, event: any, isGuard: Boolean) => {
-  let validity = false;
-  const {transactions} = context.ocfPackageContent;
-  let report: any = {transaction_type: "TX_WARRANT_TRANSFER", transaction_id: event.data.id, transaction_date: event.data.date};
+const checks: readonly Check[] = [
+  {
+    id: "issuance-exists",
+    severity: "error",
+    description:
+      "The warrant issuance referenced by the transaction's security_id exists in the current cap-table state.",
+  },
+  {
+    id: "date-order",
+    severity: "error",
+    description:
+      "The transaction is dated on or after the warrant issuance it references.",
+  },
+  {
+    id: "no-other-transactions",
+    severity: "error",
+    description:
+      "No other transaction references the transaction's security_id, other than a warrant acceptance.",
+    implemented: false,
+  },
+];
 
-  // Check that warrant issuance in incoming security_id referenced by transaction exists in current state.
-  let incoming_warrantIssuance_validity = false;
-  context.warrantIssuances.map((ele: any) => {
-    if (
-      ele.security_id === event.data.security_id &&
-      ele.object_type === 'TX_WARRANT_ISSUANCE'
-    ) {
-      incoming_warrantIssuance_validity = true;
-      report.incoming_warrantIssuance_validity = true;
+const validate: GradedValidator<Transfer> = (context, data) => {
+  const findings: Finding[] = [];
+  const subject = { object_type: data.object_type, id: data.id };
+  const { transactions } = context.ocfPackageContent;
+
+  // issuance-exists scans the live warrant collection.
+  let issuanceExists = false;
+  context.warrantIssuances.forEach((ele) => {
+    if (ele.security_id === data.security_id && ele.object_type === "TX_WARRANT_ISSUANCE") {
+      issuanceExists = true;
     }
   });
-  if (!incoming_warrantIssuance_validity) {
-    report.incoming_warrantIssuance_validity = false;
+  if (!issuanceExists) {
+    findings.push({
+      severity: "error",
+      check: "issuance-exists",
+      message: `No warrant issuance with security_id ${data.security_id} exists in the current cap-table state.`,
+      subject,
+    });
   }
 
-  // Check to ensure that the date of transaction is the same day or after the date of the incoming warrant issuance.
-  let incoming_date_validity = false;
-  transactions.map((ele: any) => {
+  // date-order scans the full package transaction history for the issuance.
+  // The object_type test leads so it narrows the transaction union to a
+  // security_id-bearing member before the other reads.
+  let dateOrdered = false;
+  transactions.forEach((ele) => {
     if (
-      ele.security_id === event.data.security_id &&
-      ele.object_type === 'TX_WARRANT_ISSUANCE'
+      ele.object_type === "TX_WARRANT_ISSUANCE" &&
+      ele.security_id === data.security_id &&
+      ele.date <= data.date
     ) {
-      if (ele.date <= event.data.date) {
-        incoming_date_validity = true;
-        report.incoming_date_validity = true;
-      }
+      dateOrdered = true;
     }
   });
-  if (!incoming_date_validity) {
-    report.incoming_date_validity = false;
+  if (!dateOrdered) {
+    findings.push({
+      severity: "error",
+      check: "date-order",
+      message: `The transaction is dated before the warrant issuance it references (security_id ${data.security_id}).`,
+      subject,
+    });
   }
 
- 
-
-  if (
-    incoming_warrantIssuance_validity &&
-    incoming_date_validity
-  ) {
-    validity = true;
-  }
-
-  const result = isGuard ? validity : report;
-  
-  return result;
+  return findings;
 };
 
-export default valid_tx_warrant_transfer;
+export const TX_WARRANT_TRANSFER = {
+  effect: "remove",
+  collection: "warrantIssuances",
+  validate,
+  checks,
+} satisfies Descriptor;

--- a/tests/ocfMachine.test.ts
+++ b/tests/ocfMachine.test.ts
@@ -371,14 +371,14 @@ describe("legacy validators through the machine", () => {
 
   it("records a validated transaction's report entry and leaves findings empty", () => {
     const actor = startSeeded(seededWithStakeholder());
-    actor.send(ev("TX_WARRANT_ISSUANCE", { id: "wi1", security_id: "war1", stakeholder_id: "sh1" }));
+    actor.send(ev("TX_EQUITY_COMPENSATION_ISSUANCE", { id: "ec1", security_id: "ec-sec1", stakeholder_id: "sh1" }));
 
     const snapshot = actor.getSnapshot();
     expect(snapshot.value).toBe("capTable");
     expect(snapshot.context.report).toHaveLength(1);
     expect(snapshot.context.report[0]).toMatchObject({
-      transaction_type: "TX_WARRANT_ISSUANCE",
-      transaction_id: "wi1",
+      transaction_type: "TX_EQUITY_COMPENSATION_ISSUANCE",
+      transaction_id: "ec1",
       stakeholder_validity: true,
     });
     expect(snapshot.context.findings).toEqual([]);
@@ -386,14 +386,14 @@ describe("legacy validators through the machine", () => {
 
   it("fails an invalid transaction with the report entry serialized in the result and findings still empty", () => {
     const actor = startSeeded(seededWithStakeholder());
-    // No such stakeholder — the warrant issuance validator rejects it.
-    actor.send(ev("TX_WARRANT_ISSUANCE", { id: "wi1", security_id: "war1", stakeholder_id: "nobody" }));
+    // No such stakeholder — the equity compensation issuance validator rejects it.
+    actor.send(ev("TX_EQUITY_COMPENSATION_ISSUANCE", { id: "ec1", security_id: "ec-sec1", stakeholder_id: "nobody" }));
 
     const snapshot = actor.getSnapshot();
     expect(snapshot.value).toBe("validationError");
     expect(snapshot.context.report).toHaveLength(1);
     expect(snapshot.context.result).toBe(
-      `The validation of the OCF package for Test Co failed on wi1: ${JSON.stringify(snapshot.context.report[0], null, 2)}`,
+      `The validation of the OCF package for Test Co failed on ec1: ${JSON.stringify(snapshot.context.report[0], null, 2)}`,
     );
     expect(snapshot.context.findings).toEqual([]);
   });

--- a/tests/warrantValidators.test.ts
+++ b/tests/warrantValidators.test.ts
@@ -1,0 +1,540 @@
+import { describe, it, expect } from "vitest";
+import { TX_DESCRIPTORS } from "../ocf_validator/ocfMachine";
+import type { Finding } from "../types/finding";
+import type { GradedValidator, OcfMachineContext } from "../types/validator";
+import { baseContext, startSeeded, ev } from "./helpers";
+
+/** A context whose package `transactions` list is `transactions`. */
+const contextWith = (
+  overrides: Partial<OcfMachineContext> & { transactions?: any[] } = {},
+): OcfMachineContext => {
+  const { transactions = [], ...rest } = overrides;
+  return baseContext({
+    ...rest,
+    ocfPackageContent: {
+      ...baseContext().ocfPackageContent,
+      transactions,
+    } as OcfMachineContext["ocfPackageContent"],
+  });
+};
+
+const MIGRATED_KEYS = [
+  "TX_WARRANT_ISSUANCE",
+  "TX_WARRANT_ACCEPTANCE",
+  "TX_WARRANT_RETRACTION",
+  "TX_WARRANT_CANCELLATION",
+  "TX_WARRANT_TRANSFER",
+] as const;
+type MigratedKey = (typeof MIGRATED_KEYS)[number];
+
+/** Invoke the graded validator a migrated descriptor carries. */
+const runValidator = (
+  key: MigratedKey,
+  context: OcfMachineContext,
+  data: Record<string, unknown>,
+): Finding[] => {
+  const descriptor = TX_DESCRIPTORS[key] as { validate?: GradedValidator<any> };
+  if (!descriptor.validate) throw new Error(`${key} carries no graded validate`);
+  return descriptor.validate(context, data);
+};
+
+/** The check ids a descriptor declares as implemented (drops `implemented: false`). */
+const implementedCheckIds = (key: MigratedKey): string[] => {
+  const descriptor = TX_DESCRIPTORS[key] as { checks?: readonly { id: string; implemented?: false }[] };
+  return (descriptor.checks ?? []).filter((c) => c.implemented !== false).map((c) => c.id);
+};
+
+/** Assert a finding carries the declared id, error severity, and the transaction as subject. */
+const expectFindingShape = (
+  finding: Finding,
+  check: string,
+  subject: { object_type: string; id: string },
+) => {
+  expect(finding.check).toBe(check);
+  expect(finding.severity).toBe("error");
+  expect(finding.subject).toEqual(subject);
+};
+
+// A single warrant issuance, in the shape both the live collection and the
+// package transaction history hold it. `date` lets a scenario push the issuance
+// after the transaction under validation to trip the date-order check.
+const issuanceRecord = (security_id: string, date = "2020-01-01") => ({
+  id: `wi-${security_id}`,
+  object_type: "TX_WARRANT_ISSUANCE",
+  security_id,
+  date,
+});
+
+// ---------------------------------------------------------------------------
+// Issuance: stakeholder-exists
+// ---------------------------------------------------------------------------
+
+describe("warrant issuance validity", () => {
+  const withStakeholder = (id: string) =>
+    baseContext({
+      ocfPackageContent: {
+        ...baseContext().ocfPackageContent,
+        stakeholders: [{ id }],
+      } as OcfMachineContext["ocfPackageContent"],
+    });
+
+  const issuance = (overrides: Record<string, unknown> = {}) => ({
+    id: "war1",
+    object_type: "TX_WARRANT_ISSUANCE",
+    security_id: "sec1",
+    stakeholder_id: "sh1",
+    date: "2021-01-01",
+    ...overrides,
+  });
+
+  it("returns no findings when the referenced stakeholder exists", () => {
+    const findings = runValidator("TX_WARRANT_ISSUANCE", withStakeholder("sh1"), issuance());
+    expect(findings).toEqual([]);
+  });
+
+  it("flags a missing stakeholder with an error naming the stakeholder_id", () => {
+    const findings = runValidator("TX_WARRANT_ISSUANCE", withStakeholder("someone-else"), issuance());
+    expect(findings).toHaveLength(1);
+    expectFindingShape(findings[0], "stakeholder-exists", {
+      object_type: "TX_WARRANT_ISSUANCE",
+      id: "war1",
+    });
+    expect(findings[0].message).toContain("sh1");
+  });
+
+  it("appends a valid issuance to warrantIssuances and stays in capTable", () => {
+    const actor = startSeeded(withStakeholder("sh1"));
+    actor.send(ev("TX_WARRANT_ISSUANCE", issuance()));
+
+    const snapshot = actor.getSnapshot();
+    expect(snapshot.value).toBe("capTable");
+    expect(snapshot.context.warrantIssuances).toHaveLength(1);
+    expect(snapshot.context.warrantIssuances[0]).toMatchObject({ id: "war1", security_id: "sec1" });
+    expect(snapshot.context.findings).toEqual([]);
+  });
+
+  it("halts an invalid issuance in validationError with the error finding recorded", () => {
+    const actor = startSeeded(withStakeholder("someone-else"));
+    actor.send(ev("TX_WARRANT_ISSUANCE", issuance()));
+
+    const snapshot = actor.getSnapshot();
+    expect(snapshot.value).toBe("validationError");
+    expect(snapshot.context.findings).toHaveLength(1);
+    expect(snapshot.context.findings[0].check).toBe("stakeholder-exists");
+    expect(snapshot.context.warrantIssuances).toEqual([]);
+    expect(snapshot.context.result).toContain("stakeholder-exists");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Acceptance: issuance-exists, date-order, no-retraction
+// ---------------------------------------------------------------------------
+
+describe("warrant acceptance validity", () => {
+  const acceptance = (overrides: Record<string, unknown> = {}) => ({
+    id: "acc1",
+    object_type: "TX_WARRANT_ACCEPTANCE",
+    security_id: "sec1",
+    date: "2021-01-01",
+    ...overrides,
+  });
+  const subject = { object_type: "TX_WARRANT_ACCEPTANCE", id: "acc1" };
+
+  it("returns no findings when the issuance exists, dates order, and no retraction references it", () => {
+    const context = contextWith({
+      warrantIssuances: [issuanceRecord("sec1")] as any,
+      transactions: [issuanceRecord("sec1")],
+    });
+    expect(runValidator("TX_WARRANT_ACCEPTANCE", context, acceptance())).toEqual([]);
+  });
+
+  it("leaves the machine in capTable without mutating collections on the valid branch", () => {
+    const seeded = contextWith({
+      warrantIssuances: [issuanceRecord("sec1")] as any,
+      transactions: [issuanceRecord("sec1")],
+    });
+    const before = structuredClone(seeded.warrantIssuances);
+
+    const actor = startSeeded(seeded);
+    actor.send(ev("TX_WARRANT_ACCEPTANCE", acceptance()));
+
+    const snapshot = actor.getSnapshot();
+    expect(snapshot.value).toBe("capTable");
+    expect(snapshot.context.warrantIssuances).toEqual(before);
+    expect(snapshot.context.findings).toEqual([]);
+  });
+
+  it("flags a missing issuance with an error naming the security_id", () => {
+    // In the package history (date-order passes) but not the live collection.
+    const context = contextWith({ transactions: [issuanceRecord("sec1")] });
+    const findings = runValidator("TX_WARRANT_ACCEPTANCE", context, acceptance());
+    expect(findings).toHaveLength(1);
+    expectFindingShape(findings[0], "issuance-exists", subject);
+    expect(findings[0].message).toContain("sec1");
+  });
+
+  it("flags an out-of-order date with an error naming the security_id", () => {
+    // Issuance is live (issuance-exists passes) but dated after the acceptance.
+    const context = contextWith({
+      warrantIssuances: [issuanceRecord("sec1", "2022-01-01")] as any,
+      transactions: [issuanceRecord("sec1", "2022-01-01")],
+    });
+    const findings = runValidator("TX_WARRANT_ACCEPTANCE", context, acceptance());
+    expect(findings).toHaveLength(1);
+    expectFindingShape(findings[0], "date-order", subject);
+    expect(findings[0].message).toContain("sec1");
+  });
+
+  it("emits one no-retraction finding per offending retraction, each naming that retraction", () => {
+    const context = contextWith({
+      warrantIssuances: [issuanceRecord("sec1")] as any,
+      transactions: [
+        issuanceRecord("sec1"),
+        { id: "ret-a", object_type: "TX_WARRANT_RETRACTION", security_id: "sec1", date: "2021-06-01" },
+        { id: "ret-b", object_type: "TX_WARRANT_RETRACTION", security_id: "sec1", date: "2021-07-01" },
+      ],
+    });
+    const findings = runValidator("TX_WARRANT_ACCEPTANCE", context, acceptance());
+    expect(findings).toHaveLength(2);
+    for (const finding of findings) expectFindingShape(finding, "no-retraction", subject);
+    expect(findings.map((f) => f.message).join("\n")).toContain("ret-a");
+    expect(findings.map((f) => f.message).join("\n")).toContain("ret-b");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Retraction: issuance-exists, date-order, no-acceptance
+// ---------------------------------------------------------------------------
+
+describe("warrant retraction validity", () => {
+  const retraction = (overrides: Record<string, unknown> = {}) => ({
+    id: "ret1",
+    object_type: "TX_WARRANT_RETRACTION",
+    security_id: "sec1",
+    date: "2021-01-01",
+    ...overrides,
+  });
+  const subject = { object_type: "TX_WARRANT_RETRACTION", id: "ret1" };
+
+  it("returns no findings when the issuance exists, dates order, and no acceptance references it", () => {
+    const context = contextWith({
+      warrantIssuances: [issuanceRecord("sec1")] as any,
+      transactions: [issuanceRecord("sec1")],
+    });
+    expect(runValidator("TX_WARRANT_RETRACTION", context, retraction())).toEqual([]);
+  });
+
+  it("removes the referenced security from warrantIssuances on the valid branch", () => {
+    const seeded = contextWith({
+      warrantIssuances: [issuanceRecord("sec1"), issuanceRecord("sec2")] as any,
+      transactions: [issuanceRecord("sec1"), issuanceRecord("sec2")],
+    });
+    const actor = startSeeded(seeded);
+    actor.send(ev("TX_WARRANT_RETRACTION", retraction()));
+
+    const snapshot = actor.getSnapshot();
+    expect(snapshot.value).toBe("capTable");
+    expect(snapshot.context.warrantIssuances.some((w: any) => w.security_id === "sec1")).toBe(false);
+    expect(snapshot.context.warrantIssuances.some((w: any) => w.security_id === "sec2")).toBe(true);
+    expect(snapshot.context.findings).toEqual([]);
+  });
+
+  it("flags a missing issuance with an error naming the security_id", () => {
+    const context = contextWith({ transactions: [issuanceRecord("sec1")] });
+    const findings = runValidator("TX_WARRANT_RETRACTION", context, retraction());
+    expect(findings).toHaveLength(1);
+    expectFindingShape(findings[0], "issuance-exists", subject);
+    expect(findings[0].message).toContain("sec1");
+  });
+
+  it("flags an out-of-order date with an error naming the security_id", () => {
+    const context = contextWith({
+      warrantIssuances: [issuanceRecord("sec1", "2022-01-01")] as any,
+      transactions: [issuanceRecord("sec1", "2022-01-01")],
+    });
+    const findings = runValidator("TX_WARRANT_RETRACTION", context, retraction());
+    expect(findings).toHaveLength(1);
+    expectFindingShape(findings[0], "date-order", subject);
+    expect(findings[0].message).toContain("sec1");
+  });
+
+  it("emits one no-acceptance finding per offending acceptance, each naming that acceptance", () => {
+    const context = contextWith({
+      warrantIssuances: [issuanceRecord("sec1")] as any,
+      transactions: [
+        issuanceRecord("sec1"),
+        { id: "acc-a", object_type: "TX_WARRANT_ACCEPTANCE", security_id: "sec1", date: "2021-06-01" },
+        { id: "acc-b", object_type: "TX_WARRANT_ACCEPTANCE", security_id: "sec1", date: "2021-07-01" },
+      ],
+    });
+    const findings = runValidator("TX_WARRANT_RETRACTION", context, retraction());
+    expect(findings).toHaveLength(2);
+    for (const finding of findings) expectFindingShape(finding, "no-acceptance", subject);
+    expect(findings.map((f) => f.message).join("\n")).toContain("acc-a");
+    expect(findings.map((f) => f.message).join("\n")).toContain("acc-b");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cancellation: issuance-exists, date-order, no-other-transactions
+// ---------------------------------------------------------------------------
+
+describe("warrant cancellation validity", () => {
+  const cancellation = (overrides: Record<string, unknown> = {}) => ({
+    id: "can1",
+    object_type: "TX_WARRANT_CANCELLATION",
+    security_id: "sec1",
+    date: "2021-01-01",
+    ...overrides,
+  });
+  const cancellationRecord = { id: "can1", object_type: "TX_WARRANT_CANCELLATION", security_id: "sec1", date: "2021-01-01" };
+  const acceptanceRecord = { id: "acc-x", object_type: "TX_WARRANT_ACCEPTANCE", security_id: "sec1", date: "2021-02-01" };
+  const subject = { object_type: "TX_WARRANT_CANCELLATION", id: "can1" };
+
+  it("returns no findings when only an issuance, a warrant acceptance, and the cancellation itself reference the security", () => {
+    const context = contextWith({
+      warrantIssuances: [issuanceRecord("sec1")] as any,
+      transactions: [issuanceRecord("sec1"), acceptanceRecord, cancellationRecord],
+    });
+    expect(runValidator("TX_WARRANT_CANCELLATION", context, cancellation())).toEqual([]);
+  });
+
+  it("treats any live warrant record matched by security_id as the issuance, regardless of object_type", () => {
+    // The existence check matches on security_id alone; a non-issuance object_type
+    // in the live collection still satisfies it.
+    const context = contextWith({
+      warrantIssuances: [{ id: "x", object_type: "SOMETHING_ELSE", security_id: "sec1", date: "2020-01-01" }] as any,
+      transactions: [issuanceRecord("sec1")],
+    });
+    expect(runValidator("TX_WARRANT_CANCELLATION", context, cancellation())).toEqual([]);
+  });
+
+  it("removes the referenced security from warrantIssuances on the valid branch", () => {
+    const seeded = contextWith({
+      warrantIssuances: [issuanceRecord("sec1"), issuanceRecord("sec2")] as any,
+      transactions: [issuanceRecord("sec1"), issuanceRecord("sec2")],
+    });
+    const actor = startSeeded(seeded);
+    actor.send(ev("TX_WARRANT_CANCELLATION", cancellation()));
+
+    const snapshot = actor.getSnapshot();
+    expect(snapshot.value).toBe("capTable");
+    expect(snapshot.context.warrantIssuances.some((w: any) => w.security_id === "sec1")).toBe(false);
+    expect(snapshot.context.warrantIssuances.some((w: any) => w.security_id === "sec2")).toBe(true);
+  });
+
+  it("flags a missing issuance with an error naming the security_id", () => {
+    const context = contextWith({ transactions: [issuanceRecord("sec1")] });
+    const findings = runValidator("TX_WARRANT_CANCELLATION", context, cancellation());
+    expect(findings).toHaveLength(1);
+    expectFindingShape(findings[0], "issuance-exists", subject);
+    expect(findings[0].message).toContain("sec1");
+  });
+
+  it("flags an out-of-order date with an error naming the security_id", () => {
+    const context = contextWith({
+      warrantIssuances: [issuanceRecord("sec1", "2022-01-01")] as any,
+      transactions: [issuanceRecord("sec1", "2022-01-01")],
+    });
+    const findings = runValidator("TX_WARRANT_CANCELLATION", context, cancellation());
+    expect(findings).toHaveLength(1);
+    expectFindingShape(findings[0], "date-order", subject);
+    expect(findings[0].message).toContain("sec1");
+  });
+
+  it("emits one no-other-transactions finding per offender, exempting acceptances and itself", () => {
+    const context = contextWith({
+      warrantIssuances: [issuanceRecord("sec1")] as any,
+      transactions: [
+        issuanceRecord("sec1"),
+        acceptanceRecord,
+        cancellationRecord,
+        { id: "xfer-a", object_type: "TX_WARRANT_TRANSFER", security_id: "sec1", date: "2021-06-01" },
+        { id: "xfer-b", object_type: "TX_WARRANT_TRANSFER", security_id: "sec1", date: "2021-07-01" },
+      ],
+    });
+    const findings = runValidator("TX_WARRANT_CANCELLATION", context, cancellation());
+    expect(findings).toHaveLength(2);
+    for (const finding of findings) expectFindingShape(finding, "no-other-transactions", subject);
+    const messages = findings.map((f) => f.message).join("\n");
+    expect(messages).toContain("xfer-a");
+    expect(messages).toContain("xfer-b");
+    // The exempt acceptance is never named as an offender.
+    expect(messages).not.toContain("acc-x");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Transfer: issuance-exists, date-order (no-other-transactions is a declared gap)
+// ---------------------------------------------------------------------------
+
+describe("warrant transfer validity", () => {
+  const transfer = (overrides: Record<string, unknown> = {}) => ({
+    id: "xfer1",
+    object_type: "TX_WARRANT_TRANSFER",
+    security_id: "sec1",
+    date: "2021-01-01",
+    ...overrides,
+  });
+  const subject = { object_type: "TX_WARRANT_TRANSFER", id: "xfer1" };
+
+  it("returns no findings when the issuance exists and dates order", () => {
+    const context = contextWith({
+      warrantIssuances: [issuanceRecord("sec1")] as any,
+      transactions: [issuanceRecord("sec1")],
+    });
+    expect(runValidator("TX_WARRANT_TRANSFER", context, transfer())).toEqual([]);
+  });
+
+  it("removes the referenced security from warrantIssuances on the valid branch", () => {
+    const seeded = contextWith({
+      warrantIssuances: [issuanceRecord("sec1"), issuanceRecord("sec2")] as any,
+      transactions: [issuanceRecord("sec1"), issuanceRecord("sec2")],
+    });
+    const actor = startSeeded(seeded);
+    actor.send(ev("TX_WARRANT_TRANSFER", transfer()));
+
+    const snapshot = actor.getSnapshot();
+    expect(snapshot.value).toBe("capTable");
+    expect(snapshot.context.warrantIssuances.some((w: any) => w.security_id === "sec1")).toBe(false);
+    expect(snapshot.context.warrantIssuances.some((w: any) => w.security_id === "sec2")).toBe(true);
+  });
+
+  it("flags a missing issuance with an error naming the security_id", () => {
+    const context = contextWith({ transactions: [issuanceRecord("sec1")] });
+    const findings = runValidator("TX_WARRANT_TRANSFER", context, transfer());
+    expect(findings).toHaveLength(1);
+    expectFindingShape(findings[0], "issuance-exists", subject);
+    expect(findings[0].message).toContain("sec1");
+  });
+
+  it("flags an out-of-order date with an error naming the security_id", () => {
+    const context = contextWith({
+      warrantIssuances: [issuanceRecord("sec1", "2022-01-01")] as any,
+      transactions: [issuanceRecord("sec1", "2022-01-01")],
+    });
+    const findings = runValidator("TX_WARRANT_TRANSFER", context, transfer());
+    expect(findings).toHaveLength(1);
+    expectFindingShape(findings[0], "date-order", subject);
+    expect(findings[0].message).toContain("sec1");
+  });
+
+  it("never emits no-other-transactions, even when other transactions reference the security", () => {
+    const context = contextWith({
+      warrantIssuances: [issuanceRecord("sec1")] as any,
+      transactions: [
+        issuanceRecord("sec1"),
+        { id: "ret-x", object_type: "TX_WARRANT_RETRACTION", security_id: "sec1", date: "2021-06-01" },
+        { id: "can-x", object_type: "TX_WARRANT_CANCELLATION", security_id: "sec1", date: "2021-07-01" },
+      ],
+    });
+    const findings = runValidator("TX_WARRANT_TRANSFER", context, transfer());
+    // The declared gap is never checked, so the transaction stays valid here.
+    expect(findings).toEqual([]);
+    expect(findings.some((f) => f.check === "no-other-transactions")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Declared-vs-emitted consistency across the family
+// ---------------------------------------------------------------------------
+
+// A transaction record on `security_id` of the given kind; the offender/exempt
+// building block for the failing scenarios below.
+const txRecord = (object_type: string, id: string, security_id = "sec1", date = "2021-06-01") => ({
+  id,
+  object_type,
+  security_id,
+  date,
+});
+
+// For each migrated type, scenarios that each fail one implemented check. The
+// implemented ids a module declares should be exactly the ids these scenarios
+// emit; a module's declared gap (transfer's no-other-transactions) has no
+// failing scenario because no code path emits it.
+const failingScenarios: Record<MigratedKey, { context: OcfMachineContext; data: Record<string, unknown> }[]> = {
+  TX_WARRANT_ISSUANCE: [
+    {
+      context: baseContext(),
+      data: { id: "i1", object_type: "TX_WARRANT_ISSUANCE", security_id: "sec1", stakeholder_id: "nobody", date: "2021-01-01" },
+    },
+  ],
+  TX_WARRANT_ACCEPTANCE: [
+    { context: contextWith({ transactions: [issuanceRecord("sec1")] }), data: txRecord("TX_WARRANT_ACCEPTANCE", "a1", "sec1", "2021-01-01") },
+    { context: contextWith({ warrantIssuances: [issuanceRecord("sec1", "2022-01-01")] as any, transactions: [issuanceRecord("sec1", "2022-01-01")] }), data: txRecord("TX_WARRANT_ACCEPTANCE", "a1", "sec1", "2021-01-01") },
+    { context: contextWith({ warrantIssuances: [issuanceRecord("sec1")] as any, transactions: [issuanceRecord("sec1"), txRecord("TX_WARRANT_RETRACTION", "r1")] }), data: txRecord("TX_WARRANT_ACCEPTANCE", "a1", "sec1", "2021-01-01") },
+  ],
+  TX_WARRANT_RETRACTION: [
+    { context: contextWith({ transactions: [issuanceRecord("sec1")] }), data: txRecord("TX_WARRANT_RETRACTION", "r1", "sec1", "2021-01-01") },
+    { context: contextWith({ warrantIssuances: [issuanceRecord("sec1", "2022-01-01")] as any, transactions: [issuanceRecord("sec1", "2022-01-01")] }), data: txRecord("TX_WARRANT_RETRACTION", "r1", "sec1", "2021-01-01") },
+    { context: contextWith({ warrantIssuances: [issuanceRecord("sec1")] as any, transactions: [issuanceRecord("sec1"), txRecord("TX_WARRANT_ACCEPTANCE", "a1")] }), data: txRecord("TX_WARRANT_RETRACTION", "r1", "sec1", "2021-01-01") },
+  ],
+  TX_WARRANT_CANCELLATION: [
+    { context: contextWith({ transactions: [issuanceRecord("sec1")] }), data: txRecord("TX_WARRANT_CANCELLATION", "c1", "sec1", "2021-01-01") },
+    { context: contextWith({ warrantIssuances: [issuanceRecord("sec1", "2022-01-01")] as any, transactions: [issuanceRecord("sec1", "2022-01-01")] }), data: txRecord("TX_WARRANT_CANCELLATION", "c1", "sec1", "2021-01-01") },
+    { context: contextWith({ warrantIssuances: [issuanceRecord("sec1")] as any, transactions: [issuanceRecord("sec1"), txRecord("TX_WARRANT_TRANSFER", "x1")] }), data: txRecord("TX_WARRANT_CANCELLATION", "c1", "sec1", "2021-01-01") },
+  ],
+  TX_WARRANT_TRANSFER: [
+    { context: contextWith({ transactions: [issuanceRecord("sec1")] }), data: txRecord("TX_WARRANT_TRANSFER", "x1", "sec1", "2021-01-01") },
+    { context: contextWith({ warrantIssuances: [issuanceRecord("sec1", "2022-01-01")] as any, transactions: [issuanceRecord("sec1", "2022-01-01")] }), data: txRecord("TX_WARRANT_TRANSFER", "x1", "sec1", "2021-01-01") },
+  ],
+};
+
+/** Every check id emitted across a module's failing scenarios. */
+const emittedCheckIds = (key: MigratedKey): Set<string> => {
+  const emitted = new Set<string>();
+  for (const { context, data } of failingScenarios[key]) {
+    for (const finding of runValidator(key, context, data)) emitted.add(finding.check);
+  }
+  return emitted;
+};
+
+describe("declared and emitted checks stay consistent across the family", () => {
+  // Exact set equality in both directions: no finding is emitted for a check the
+  // descriptor does not declare implemented, and every declared implemented check
+  // is emitted by at least one failing scenario.
+  it.each(MIGRATED_KEYS)("%s emits exactly the check ids its descriptor declares implemented", (key) => {
+    expect([...emittedCheckIds(key)].sort()).toEqual([...implementedCheckIds(key)].sort());
+  });
+
+  it("never emits transfer's declared-gap check", () => {
+    expect(emittedCheckIds("TX_WARRANT_TRANSFER").has("no-other-transactions")).toBe(false);
+    // The gap is declared on the descriptor with implemented: false.
+    const declared = (TX_DESCRIPTORS.TX_WARRANT_TRANSFER as { checks: readonly { id: string; implemented?: false }[] }).checks;
+    expect(declared.some((c) => c.id === "no-other-transactions" && c.implemented === false)).toBe(true);
+  });
+
+  it("leaves warrant exercise on the legacy convention", () => {
+    expect("legacyValidate" in TX_DESCRIPTORS.TX_WARRANT_EXERCISE).toBe(true);
+    expect("validate" in TX_DESCRIPTORS.TX_WARRANT_EXERCISE).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Channel migration: findings, not report, for the warrant family
+// ---------------------------------------------------------------------------
+
+describe("warrant family findings migrate to the findings channel", () => {
+  it("routes an invalid warrant transaction to findings, leaves report clear, and serializes the errors in the failure result", () => {
+    const actor = startSeeded(baseContext());
+    // No stakeholder matches, so the issuance is invalid.
+    actor.send(ev("TX_WARRANT_ISSUANCE", {
+      id: "war1",
+      object_type: "TX_WARRANT_ISSUANCE",
+      security_id: "sec1",
+      stakeholder_id: "nobody",
+      date: "2021-01-01",
+    }));
+
+    const { context, value } = actor.getSnapshot();
+    expect(value).toBe("validationError");
+    // The errors landed on findings…
+    expect(context.findings.length).toBeGreaterThan(0);
+    expect(context.findings.every((f) => f.severity === "error")).toBe(true);
+    // …no report entry was written for a migrated warrant type…
+    const migrated = MIGRATED_KEYS as readonly string[];
+    expect(context.report.some((entry: any) => migrated.includes(entry?.transaction_type))).toBe(false);
+    // …and the failure result serialized the error findings.
+    expect(context.result).toContain(JSON.stringify(context.findings, null, 2));
+  });
+});


### PR DESCRIPTION
Part of #159. Stacked on #199 (`issue-159-convertible-family`); the base retargets as the stack merges.

## What this does

Second family migration of the #159 series: the five formulaic warrant validators (issuance, acceptance, retraction, cancellation, transfer) move to the graded convention, mirroring the convertible family (#199) module for module.

- Each validator becomes `(context, data) => Finding[]` with deep-readonly, typed inputs. The dual-mode `isGuard` flag and the untyped `event` are gone.
- Each module exports its own descriptor (`effect`, `collection`, `validate`, `checks`), and the central table imports them. The free-text `CURRENT CHECKS` / `MISSING CHECKS` comment blocks become structured `Check` metadata; transfer's known-missing check is declared with `implemented: false`.
- Check ids reuse the shared vocabulary established in #199 (`stakeholder-exists`, `issuance-exists`, `date-order`, `no-retraction`, `no-acceptance`, `no-other-transactions`), with per-descriptor uniqueness guarded by the existing metadata test. Severity is read from the legacy behavior: a check that blocks validity grades as `error`; a continue-but-report check would grade as `warning`. Every check in this family blocks in the legacy code, so every check is `error`.
- A new suite (`tests/warrantValidators.test.ts`) covers the family the same way the convertible suite does: per-check validity scenarios, finding shape and message content, per-offender finding counts, machine-driven collection effects, and set-equality between declared and emitted check ids.
- The two machine tests that used a warrant issuance as their example of a legacy-convention validator now use an equity compensation issuance instead (its legacy validator performs the same single stakeholder check). This re-point recurs at each family migration until the legacy test block is deleted along with `legacyValidate`.

`tx_warrant_exercise` is excluded and stays on the legacy convention: it carries the defects filed in #192 and #193, so it gets its own PR.

## Behavior changes

- For these five transaction types, findings replace `report` entries: per-check outcomes land on `context.findings`, and failure messages serialize the error findings. `context.report` no longer receives entries for them.
- Checks that scan for offending transactions (`no-retraction`, `no-acceptance`, `no-other-transactions`) now emit one finding per offender instead of collapsing to a single boolean. Validity is unchanged; only the finding granularity is finer.

Everything else is ported faithfully, including the legacy scan quirks (split data sources, whole-package scans that see future-dated transactions, cancellation's unfiltered existence predicate). Those are deliberately preserved, not endorsed; they are recorded in #198, which also schedules their fix once the shared checks are extracted.

## Port fidelity

The test fixture contains no warrant transactions and this PR deletes the legacy validator bodies, so the suite cannot itself prove the port is faithful: the new tests encode the intended semantics. The map below pairs each legacy predicate with its graded replacement so the port can be reviewed side by side with the deleted code.

Two normalizations are applied uniformly and preserve validity in every module:

- The date-order scan reorders its conjuncts: the graded scan leads with the `object_type` discriminant, then `security_id`, then the date comparison, in one condition. That changes evaluation order on an AND; the set of matching rows is identical.
- Offender scans emit one finding per offending row instead of setting a single boolean (the behavior change named above).

Existence checks read the live family collection (`context.warrantIssuances`); date-order and offender scans read the full package transaction list, including transactions dated after the one under validation. This split is preserved exactly from the legacy code.

<details>
<summary>Per-module predicate map</summary>

### tx_warrant_issuance (append to `warrantIssuances`)

Legacy validity: `stakeholder_validity`.

| Legacy predicate | Source | Match condition | Graded check |
| --- | --- | --- | --- |
| `stakeholder_validity` | `stakeholders` file | `ele.id === stakeholder_id` | `stakeholder-exists` (error); message names the `stakeholder_id` |

### tx_warrant_acceptance (no collection effect)

Legacy validity: `incoming_warrantIssuance_validity && incoming_date_validity && no_warrant_retraction_validity`.

| Legacy predicate | Source | Match condition | Graded check |
| --- | --- | --- | --- |
| `incoming_warrantIssuance_validity` | live `warrantIssuances` | `security_id` match and `object_type === 'TX_WARRANT_ISSUANCE'` | `issuance-exists` (error); message names the `security_id` |
| `incoming_date_validity` | full `transactions` | `security_id` match, `object_type === 'TX_WARRANT_ISSUANCE'`, then `date <=` | `date-order` (error); message names the `security_id` |
| `no_warrant_retraction_validity` | full `transactions` | offender: `security_id` match and `object_type === 'TX_WARRANT_RETRACTION'` | `no-retraction` (error); one finding per offender, naming its `id` |

No exemptions on the offender scan.

### tx_warrant_retraction (remove from `warrantIssuances`)

Legacy validity: `incoming_warrantIssuance_validity && incoming_date_validity && no_warrant_acceptance_validity`. The stray `TBC` note in the legacy file is deleted.

| Legacy predicate | Source | Match condition | Graded check |
| --- | --- | --- | --- |
| `incoming_warrantIssuance_validity` | live `warrantIssuances` | `security_id` match and `object_type === 'TX_WARRANT_ISSUANCE'` | `issuance-exists` (error); message names the `security_id` |
| `incoming_date_validity` | full `transactions` | `security_id` match, `object_type === 'TX_WARRANT_ISSUANCE'`, then `date <=` | `date-order` (error); message names the `security_id` |
| `no_warrant_acceptance_validity` | full `transactions` | offender: `security_id` match and `object_type === 'TX_WARRANT_ACCEPTANCE'` | `no-acceptance` (error); one finding per offender, naming its `id` |

No exemptions on the offender scan.

### tx_warrant_cancellation (remove from `warrantIssuances`)

Legacy validity: `incoming_warrantIssuance_validity && incoming_date_validity && only_transaction_validity`.

| Legacy predicate | Source | Match condition | Graded check |
| --- | --- | --- | --- |
| `incoming_warrantIssuance_validity` | live `warrantIssuances` | `security_id` match alone, with no `object_type` filter (unlike the sibling validators) | `issuance-exists` (error); message names the `security_id` |
| `incoming_date_validity` | full `transactions` | `security_id` match, `object_type === 'TX_WARRANT_ISSUANCE'`, then `date <=` | `date-order` (error); message names the `security_id` |
| `only_transaction_validity` | full `transactions` | offender: `security_id` match, excluding warrant issuances, warrant acceptances, and the cancellation itself (matched by `id`) | `no-other-transactions` (error); one finding per offender, naming its `id` |

The three-way exemption is ported verbatim: warrant issuances, warrant acceptances, and the cancellation transaction itself are exempt; every other transaction on the `security_id` is an offender. The issuance exemption is required for the check to ever pass, since a valid cancellation always coexists with its issuance. The graded scan narrows by property presence (`"security_id" in ele`) so it can keep every transaction type in play. This is the only module whose existence check omits the `object_type` filter.

### tx_warrant_transfer (remove from `warrantIssuances`)

Legacy validity: `incoming_warrantIssuance_validity && incoming_date_validity`.

| Legacy predicate | Source | Match condition | Graded check |
| --- | --- | --- | --- |
| `incoming_warrantIssuance_validity` | live `warrantIssuances` | `security_id` match and `object_type === 'TX_WARRANT_ISSUANCE'` | `issuance-exists` (error); message names the `security_id` |
| `incoming_date_validity` | full `transactions` | `security_id` match, `object_type === 'TX_WARRANT_ISSUANCE'`, then `date <=` | `date-order` (error); message names the `security_id` |
| (absent; the legacy `MISSING CHECKS` note) | (none) | (none) | `no-other-transactions` declared with `implemented: false`; never emitted |

Transfer's third check is a declared gap only. Implementing it would be a behavior change beyond migration scope; the legacy `MISSING CHECKS` prose becomes the `implemented: false` metadata.

</details>

## Verification

`npm run build` and `npm run test:ci` are green (132 tests), a one-off `tsc --noEmit` pass that includes the test files is clean, and the characterization snapshot is byte-identical to the stacked base (the fixture contains no warrant transactions, so this migration cannot affect it).
