### PR TITLE
Define migrated validators declaratively via check objects

### DIFF
--- a/ocf_validator/validators/checkKit.ts
+++ b/ocf_validator/validators/checkKit.ts
@@ -1,0 +1,105 @@
+import type { TransactionFor } from "../../types/ocf-input";
+import type { Finding } from "../../types/finding";
+import type {
+  Check,
+  DeepReadonly,
+  GradedValidator,
+  OcfMachineContext,
+} from "../../types/validator";
+import type { CollectionKey, TxKey } from "../ocfMachine";
+
+/**
+ * A declared check as executable data: the public `Check` metadata plus an
+ * optional `run`. A check with a `run` is performed; a check with none is a
+ * declared gap. `run` returns only the failure MESSAGES — one string per
+ * failure — because the factory stamps every finding's severity, check id, and
+ * subject; a check body never writes those. `run`'s `data` is `any` because one
+ * check object serves modules with different transaction payloads: each concrete
+ * check narrows `data` structurally in its own body, so the `any` lives only at
+ * this seam. Declaring a check `satisfies CheckObject` lets the compiler enforce
+ * this shape — including the `string[]` return — contextually.
+ */
+export type CheckObject = Pick<Check, "id" | "severity" | "description"> & {
+  run?: (context: DeepReadonly<OcfMachineContext>, data: any) => string[];
+};
+
+/**
+ * A validator declaration: the transaction key (which fixes the payload type of
+ * the derived validator), the collection effect, and the check objects. An
+ * effect-none transaction mutates no collection, so it carries no `collection`;
+ * an append or remove transaction names the family collection it touches.
+ */
+type Spec =
+  | { transaction: TxKey; effect: "none"; collection?: never; checks: readonly CheckObject[] }
+  | { transaction: TxKey; effect: "append" | "remove"; collection: CollectionKey; checks: readonly CheckObject[] };
+
+/**
+ * Projects the check objects to their public `Check` metadata: drops `run` and
+ * marks a runless check `implemented: false`. The key order — `id`, `severity`,
+ * `description`, `implemented` — is fixed because the coverage report serializes
+ * it verbatim.
+ */
+const toMetadata = (checks: readonly CheckObject[]): readonly Check[] =>
+  checks.map((check) => {
+    const metadata: Check = {
+      id: check.id,
+      severity: check.severity,
+      description: check.description,
+    };
+    if (!check.run) metadata.implemented = false;
+    return metadata;
+  });
+
+/**
+ * Composes the check objects into a validator. The finding subject is built once
+ * from the transaction under validation; then each check that has a `run` is
+ * executed in list order and every message it returns is completed into a
+ * `Finding` field by field — severity and check id from the check declaration,
+ * subject from the transaction — so the stamping is authoritative and a check
+ * body only ever supplies the message text. `data` is `any` here for the same
+ * reason it is on `CheckObject.run`: the payload's family is the declaration's
+ * concern, not the composer's.
+ */
+const toValidate =
+  (checks: readonly CheckObject[]): GradedValidator<any> =>
+  (context, data: any) => {
+    const subject = { object_type: data.object_type, id: data.id };
+    const findings: Finding[] = [];
+    for (const check of checks) {
+      if (!check.run) continue;
+      for (const message of check.run(context, data)) {
+        findings.push({
+          severity: check.severity,
+          check: check.id,
+          message,
+          subject,
+        });
+      }
+    }
+    return findings;
+  };
+
+/**
+ * Builds a transaction descriptor from a declaration. `transaction` fixes the
+ * validator's payload type and is dropped from the emitted descriptor, which
+ * carries only `effect`, `collection` (where the declaration has one), the
+ * composed `validate`, and the projected `checks` metadata. The result is
+ * checked against the machine's `Descriptor` type where the table assembles it,
+ * so a payload wired to the wrong family collection fails there.
+ */
+export function defineValidator<const S extends Spec>(
+  spec: S,
+): Omit<S, "transaction" | "checks"> & {
+  validate: GradedValidator<TransactionFor<S["transaction"]>>;
+  checks: readonly Check[];
+} {
+  const { transaction, checks, ...rest } = spec;
+  return {
+    ...rest,
+    validate: toValidate(checks),
+    checks: toMetadata(checks),
+  } as Omit<S, "transaction" | "checks"> & {
+    validate: GradedValidator<TransactionFor<S["transaction"]>>;
+    checks: readonly Check[];
+  };
+}

--- a/ocf_validator/validators/convertible/checks.ts
+++ b/ocf_validator/validators/convertible/checks.ts
@@ -1,0 +1,65 @@
+import type { CheckObject } from "../checkKit";
+
+/**
+ * The convertible issuance referenced by the transaction's security_id exists in
+ * the current cap-table state. Matches on security_id alone against the live
+ * convertible collection, which holds only issuances.
+ */
+export const issuanceExists = {
+  id: "issuance-exists",
+  severity: "error",
+  description:
+    "The convertible issuance referenced by the transaction's security_id exists in the current cap-table state.",
+  run: (context, data: { security_id: string }) => {
+    const messages: string[] = [];
+
+    let issuanceExists = false;
+    context.convertibleIssuances.forEach((ele) => {
+      if (ele.security_id === data.security_id) {
+        issuanceExists = true;
+      }
+    });
+    if (!issuanceExists) {
+      messages.push(
+        `No convertible issuance with security_id ${data.security_id} exists in the current cap-table state.`,
+      );
+    }
+
+    return messages;
+  },
+} satisfies CheckObject;
+
+/**
+ * The transaction is dated on or after the convertible issuance it references.
+ */
+export const dateOrder = {
+  id: "date-order",
+  severity: "error",
+  description:
+    "The transaction is dated on or after the convertible issuance it references.",
+  run: (context, data: { security_id: string; date: string }) => {
+    const messages: string[] = [];
+    const { transactions } = context.ocfPackageContent;
+
+    // date-order scans the full package transaction history for the issuance.
+    // The object_type test leads so it narrows the transaction union to a
+    // security_id-bearing member before the other reads.
+    let dateOrdered = false;
+    transactions.forEach((ele) => {
+      if (
+        ele.object_type === "TX_CONVERTIBLE_ISSUANCE" &&
+        ele.security_id === data.security_id &&
+        ele.date <= data.date
+      ) {
+        dateOrdered = true;
+      }
+    });
+    if (!dateOrdered) {
+      messages.push(
+        `The transaction is not dated on or after a convertible issuance with security_id ${data.security_id}.`,
+      );
+    }
+
+    return messages;
+  },
+} satisfies CheckObject;

--- a/ocf_validator/validators/convertible/tx_convertible_acceptance.ts
+++ b/ocf_validator/validators/convertible/tx_convertible_acceptance.ts
@@ -1,90 +1,29 @@
-import type { TransactionFor } from "../../../types/ocf-input";
-import type { Check, GradedValidator } from "../../../types/validator";
-import type { Finding } from "../../../types/finding";
-import type { Descriptor } from "../../ocfMachine";
+import { defineValidator, type CheckObject } from "../checkKit";
+import { issuanceExists, dateOrder } from "./checks";
 
-type Acceptance = TransactionFor<"TX_CONVERTIBLE_ACCEPTANCE">;
+const noRetraction = {
+  id: "no-retraction",
+  severity: "error",
+  description: "No convertible retraction references the transaction's security_id.",
+  run: (context, data: { security_id: string }) => {
+    const messages: string[] = [];
+    const { transactions } = context.ocfPackageContent;
 
-const checks: readonly Check[] = [
-  {
-    id: "issuance-exists",
-    severity: "error",
-    description:
-      "The convertible issuance referenced by the transaction's security_id exists in the current cap-table state.",
-  },
-  {
-    id: "date-order",
-    severity: "error",
-    description:
-      "The transaction is dated on or after the convertible issuance it references.",
-  },
-  {
-    id: "no-retraction",
-    severity: "error",
-    description: "No convertible retraction references the transaction's security_id.",
-  },
-];
-
-const validate: GradedValidator<Acceptance> = (context, data) => {
-  const findings: Finding[] = [];
-  const subject = { object_type: data.object_type, id: data.id };
-  const { transactions } = context.ocfPackageContent;
-
-  // issuance-exists scans the live convertible collection.
-  let issuanceExists = false;
-  context.convertibleIssuances.forEach((ele) => {
-    if (ele.security_id === data.security_id && ele.object_type === "TX_CONVERTIBLE_ISSUANCE") {
-      issuanceExists = true;
-    }
-  });
-  if (!issuanceExists) {
-    findings.push({
-      severity: "error",
-      check: "issuance-exists",
-      message: `No convertible issuance with security_id ${data.security_id} exists in the current cap-table state.`,
-      subject,
+    // no-retraction emits one finding per convertible retraction on this security_id.
+    transactions.forEach((ele) => {
+      if (ele.object_type === "TX_CONVERTIBLE_RETRACTION" && ele.security_id === data.security_id) {
+        messages.push(
+          `A convertible retraction (${ele.id}) references the transaction's security_id.`,
+        );
+      }
     });
-  }
 
-  // date-order scans the full package transaction history for the issuance.
-  // The object_type test leads so it narrows the transaction union to a
-  // security_id-bearing member before the other reads.
-  let dateOrdered = false;
-  transactions.forEach((ele) => {
-    if (
-      ele.object_type === "TX_CONVERTIBLE_ISSUANCE" &&
-      ele.security_id === data.security_id &&
-      ele.date <= data.date
-    ) {
-      dateOrdered = true;
-    }
-  });
-  if (!dateOrdered) {
-    findings.push({
-      severity: "error",
-      check: "date-order",
-      message: `The transaction is not dated on or after a convertible issuance with security_id ${data.security_id}.`,
-      subject,
-    });
-  }
+    return messages;
+  },
+} satisfies CheckObject;
 
-  // no-retraction emits one finding per convertible retraction on this security_id.
-  transactions.forEach((ele) => {
-    if (ele.object_type === "TX_CONVERTIBLE_RETRACTION" && ele.security_id === data.security_id) {
-      findings.push({
-        severity: "error",
-        check: "no-retraction",
-        message: `A convertible retraction (${ele.id}) references the transaction's security_id.`,
-        subject,
-      });
-    }
-  });
-
-  return findings;
-};
-
-export const TX_CONVERTIBLE_ACCEPTANCE = {
+export const TX_CONVERTIBLE_ACCEPTANCE = defineValidator({
+  transaction: "TX_CONVERTIBLE_ACCEPTANCE",
   effect: "none",
-  validate,
-  checks,
-} satisfies Descriptor;
+  checks: [issuanceExists, dateOrder, noRetraction],
+});

--- a/ocf_validator/validators/convertible/tx_convertible_cancellation.ts
+++ b/ocf_validator/validators/convertible/tx_convertible_cancellation.ts
@@ -1,103 +1,41 @@
-import type { TransactionFor } from "../../../types/ocf-input";
-import type { Check, GradedValidator } from "../../../types/validator";
-import type { Finding } from "../../../types/finding";
-import type { Descriptor } from "../../ocfMachine";
+import { defineValidator, type CheckObject } from "../checkKit";
+import { issuanceExists, dateOrder } from "./checks";
 
-type Cancellation = TransactionFor<"TX_CONVERTIBLE_CANCELLATION">;
+const noOtherTransactions = {
+  id: "no-other-transactions",
+  severity: "error",
+  description:
+    "No other transaction references the transaction's security_id, other than a convertible acceptance.",
+  run: (context, data: { id: string; security_id: string }) => {
+    const messages: string[] = [];
+    const { transactions } = context.ocfPackageContent;
 
-const checks: readonly Check[] = [
-  {
-    id: "issuance-exists",
-    severity: "error",
-    description:
-      "The convertible issuance referenced by the transaction's security_id exists in the current cap-table state.",
-  },
-  {
-    id: "date-order",
-    severity: "error",
-    description:
-      "The transaction is dated on or after the convertible issuance it references.",
-  },
-  {
-    id: "no-other-transactions",
-    severity: "error",
-    description:
-      "No other transaction references the transaction's security_id, other than a convertible acceptance.",
-  },
-];
-
-const validate: GradedValidator<Cancellation> = (context, data) => {
-  const findings: Finding[] = [];
-  const subject = { object_type: data.object_type, id: data.id };
-  const { transactions } = context.ocfPackageContent;
-
-  // issuance-exists here matches on security_id alone — unlike the sibling
-  // validators it does not also require object_type TX_CONVERTIBLE_ISSUANCE.
-  let issuanceExists = false;
-  context.convertibleIssuances.forEach((ele) => {
-    if (ele.security_id === data.security_id) {
-      issuanceExists = true;
-    }
-  });
-  if (!issuanceExists) {
-    findings.push({
-      severity: "error",
-      check: "issuance-exists",
-      message: `No convertible issuance with security_id ${data.security_id} exists in the current cap-table state.`,
-      subject,
+    // no-other-transactions emits one finding per transaction on this security_id,
+    // exempting the issuance, any convertible acceptance, and this cancellation itself.
+    // This scan keeps every transaction type in play, so it narrows by property
+    // presence rather than by discriminant: a transaction that carries no
+    // security_id can never reference this one.
+    transactions.forEach((ele) => {
+      if (
+        "security_id" in ele &&
+        ele.security_id === data.security_id &&
+        ele.object_type !== "TX_CONVERTIBLE_ISSUANCE" &&
+        ele.object_type !== "TX_CONVERTIBLE_ACCEPTANCE" &&
+        !(ele.object_type === "TX_CONVERTIBLE_CANCELLATION" && ele.id === data.id)
+      ) {
+        messages.push(
+          `Another transaction (${ele.id}) references the transaction's security_id.`,
+        );
+      }
     });
-  }
 
-  // date-order scans the full package transaction history for the issuance.
-  // The object_type test leads so it narrows the transaction union to a
-  // security_id-bearing member before the other reads.
-  let dateOrdered = false;
-  transactions.forEach((ele) => {
-    if (
-      ele.object_type === "TX_CONVERTIBLE_ISSUANCE" &&
-      ele.security_id === data.security_id &&
-      ele.date <= data.date
-    ) {
-      dateOrdered = true;
-    }
-  });
-  if (!dateOrdered) {
-    findings.push({
-      severity: "error",
-      check: "date-order",
-      message: `The transaction is not dated on or after a convertible issuance with security_id ${data.security_id}.`,
-      subject,
-    });
-  }
+    return messages;
+  },
+} satisfies CheckObject;
 
-  // no-other-transactions emits one finding per transaction on this security_id,
-  // exempting the issuance, any convertible acceptance, and this cancellation itself.
-  // This scan keeps every transaction type in play, so it narrows by property
-  // presence rather than by discriminant: a transaction that carries no
-  // security_id can never reference this one.
-  transactions.forEach((ele) => {
-    if (
-      "security_id" in ele &&
-      ele.security_id === data.security_id &&
-      ele.object_type !== "TX_CONVERTIBLE_ISSUANCE" &&
-      ele.object_type !== "TX_CONVERTIBLE_ACCEPTANCE" &&
-      !(ele.object_type === "TX_CONVERTIBLE_CANCELLATION" && ele.id === data.id)
-    ) {
-      findings.push({
-        severity: "error",
-        check: "no-other-transactions",
-        message: `Another transaction (${ele.id}) references the transaction's security_id.`,
-        subject,
-      });
-    }
-  });
-
-  return findings;
-};
-
-export const TX_CONVERTIBLE_CANCELLATION = {
+export const TX_CONVERTIBLE_CANCELLATION = defineValidator({
+  transaction: "TX_CONVERTIBLE_CANCELLATION",
   effect: "remove",
   collection: "convertibleIssuances",
-  validate,
-  checks,
-} satisfies Descriptor;
+  checks: [issuanceExists, dateOrder, noOtherTransactions],
+});

--- a/ocf_validator/validators/convertible/tx_convertible_issuance.ts
+++ b/ocf_validator/validators/convertible/tx_convertible_issuance.ts
@@ -1,40 +1,31 @@
-import type { OCFConvertibleIssuance } from "@opencaptablecoalition/ocf-types";
-import type { Check, GradedValidator } from "../../../types/validator";
-import type { Finding } from "../../../types/finding";
-import type { Descriptor } from "../../ocfMachine";
+import { defineValidator, type CheckObject } from "../checkKit";
 
-const checks: readonly Check[] = [
-  {
-    id: "stakeholder-exists",
-    severity: "error",
-    description:
-      "The stakeholder referenced by the transaction exists in the stakeholder file.",
-  },
-];
+const stakeholderExists = {
+  id: "stakeholder-exists",
+  severity: "error",
+  description:
+    "The stakeholder referenced by the transaction exists in the stakeholder file.",
+  run: (context, data: { stakeholder_id: string }) => {
+    const messages: string[] = [];
+    const { stakeholders } = context.ocfPackageContent;
 
-const validate: GradedValidator<OCFConvertibleIssuance> = (context, data) => {
-  const findings: Finding[] = [];
-  const { stakeholders } = context.ocfPackageContent;
-
-  let stakeholderExists = false;
-  stakeholders.forEach((ele: any) => {
-    if (ele.id === data.stakeholder_id) stakeholderExists = true;
-  });
-  if (!stakeholderExists) {
-    findings.push({
-      severity: "error",
-      check: "stakeholder-exists",
-      message: `The stakeholder ${data.stakeholder_id} referenced by the transaction was not found in the stakeholder file.`,
-      subject: { object_type: data.object_type, id: data.id },
+    let stakeholderExists = false;
+    stakeholders.forEach((ele: any) => {
+      if (ele.id === data.stakeholder_id) stakeholderExists = true;
     });
-  }
+    if (!stakeholderExists) {
+      messages.push(
+        `The stakeholder ${data.stakeholder_id} referenced by the transaction was not found in the stakeholder file.`,
+      );
+    }
 
-  return findings;
-};
+    return messages;
+  },
+} satisfies CheckObject;
 
-export const TX_CONVERTIBLE_ISSUANCE = {
+export const TX_CONVERTIBLE_ISSUANCE = defineValidator({
+  transaction: "TX_CONVERTIBLE_ISSUANCE",
   effect: "append",
   collection: "convertibleIssuances",
-  validate,
-  checks,
-} satisfies Descriptor;
+  checks: [stakeholderExists],
+});

--- a/ocf_validator/validators/convertible/tx_convertible_retraction.ts
+++ b/ocf_validator/validators/convertible/tx_convertible_retraction.ts
@@ -1,91 +1,30 @@
-import type { TransactionFor } from "../../../types/ocf-input";
-import type { Check, GradedValidator } from "../../../types/validator";
-import type { Finding } from "../../../types/finding";
-import type { Descriptor } from "../../ocfMachine";
+import { defineValidator, type CheckObject } from "../checkKit";
+import { issuanceExists, dateOrder } from "./checks";
 
-type Retraction = TransactionFor<"TX_CONVERTIBLE_RETRACTION">;
+const noAcceptance = {
+  id: "no-acceptance",
+  severity: "error",
+  description: "No convertible acceptance references the transaction's security_id.",
+  run: (context, data: { security_id: string }) => {
+    const messages: string[] = [];
+    const { transactions } = context.ocfPackageContent;
 
-const checks: readonly Check[] = [
-  {
-    id: "issuance-exists",
-    severity: "error",
-    description:
-      "The convertible issuance referenced by the transaction's security_id exists in the current cap-table state.",
-  },
-  {
-    id: "date-order",
-    severity: "error",
-    description:
-      "The transaction is dated on or after the convertible issuance it references.",
-  },
-  {
-    id: "no-acceptance",
-    severity: "error",
-    description: "No convertible acceptance references the transaction's security_id.",
-  },
-];
-
-const validate: GradedValidator<Retraction> = (context, data) => {
-  const findings: Finding[] = [];
-  const subject = { object_type: data.object_type, id: data.id };
-  const { transactions } = context.ocfPackageContent;
-
-  // issuance-exists scans the live convertible collection.
-  let issuanceExists = false;
-  context.convertibleIssuances.forEach((ele) => {
-    if (ele.security_id === data.security_id && ele.object_type === "TX_CONVERTIBLE_ISSUANCE") {
-      issuanceExists = true;
-    }
-  });
-  if (!issuanceExists) {
-    findings.push({
-      severity: "error",
-      check: "issuance-exists",
-      message: `No convertible issuance with security_id ${data.security_id} exists in the current cap-table state.`,
-      subject,
+    // no-acceptance emits one finding per convertible acceptance on this security_id.
+    transactions.forEach((ele) => {
+      if (ele.object_type === "TX_CONVERTIBLE_ACCEPTANCE" && ele.security_id === data.security_id) {
+        messages.push(
+          `A convertible acceptance (${ele.id}) references the transaction's security_id.`,
+        );
+      }
     });
-  }
 
-  // date-order scans the full package transaction history for the issuance.
-  // The object_type test leads so it narrows the transaction union to a
-  // security_id-bearing member before the other reads.
-  let dateOrdered = false;
-  transactions.forEach((ele) => {
-    if (
-      ele.object_type === "TX_CONVERTIBLE_ISSUANCE" &&
-      ele.security_id === data.security_id &&
-      ele.date <= data.date
-    ) {
-      dateOrdered = true;
-    }
-  });
-  if (!dateOrdered) {
-    findings.push({
-      severity: "error",
-      check: "date-order",
-      message: `The transaction is not dated on or after a convertible issuance with security_id ${data.security_id}.`,
-      subject,
-    });
-  }
+    return messages;
+  },
+} satisfies CheckObject;
 
-  // no-acceptance emits one finding per convertible acceptance on this security_id.
-  transactions.forEach((ele) => {
-    if (ele.object_type === "TX_CONVERTIBLE_ACCEPTANCE" && ele.security_id === data.security_id) {
-      findings.push({
-        severity: "error",
-        check: "no-acceptance",
-        message: `A convertible acceptance (${ele.id}) references the transaction's security_id.`,
-        subject,
-      });
-    }
-  });
-
-  return findings;
-};
-
-export const TX_CONVERTIBLE_RETRACTION = {
+export const TX_CONVERTIBLE_RETRACTION = defineValidator({
+  transaction: "TX_CONVERTIBLE_RETRACTION",
   effect: "remove",
   collection: "convertibleIssuances",
-  validate,
-  checks,
-} satisfies Descriptor;
+  checks: [issuanceExists, dateOrder, noAcceptance],
+});

--- a/ocf_validator/validators/convertible/tx_convertible_transfer.ts
+++ b/ocf_validator/validators/convertible/tx_convertible_transfer.ts
@@ -1,81 +1,18 @@
-import type { TransactionFor } from "../../../types/ocf-input";
-import type { Check, GradedValidator } from "../../../types/validator";
-import type { Finding } from "../../../types/finding";
-import type { Descriptor } from "../../ocfMachine";
+import { defineValidator, type CheckObject } from "../checkKit";
+import { issuanceExists, dateOrder } from "./checks";
 
-type Transfer = TransactionFor<"TX_CONVERTIBLE_TRANSFER">;
+// The transfer module declares this check but does not implement it: the same
+// metadata with no run, so it reports as a gap and contributes no findings.
+const noOtherTransactions = {
+  id: "no-other-transactions",
+  severity: "error",
+  description:
+    "No other transaction references the transaction's security_id, other than a convertible acceptance.",
+} satisfies CheckObject;
 
-const checks: readonly Check[] = [
-  {
-    id: "issuance-exists",
-    severity: "error",
-    description:
-      "The convertible issuance referenced by the transaction's security_id exists in the current cap-table state.",
-  },
-  {
-    id: "date-order",
-    severity: "error",
-    description:
-      "The transaction is dated on or after the convertible issuance it references.",
-  },
-  {
-    id: "no-other-transactions",
-    severity: "error",
-    description:
-      "No other transaction references the transaction's security_id, other than a convertible acceptance.",
-    implemented: false,
-  },
-];
-
-const validate: GradedValidator<Transfer> = (context, data) => {
-  const findings: Finding[] = [];
-  const subject = { object_type: data.object_type, id: data.id };
-  const { transactions } = context.ocfPackageContent;
-
-  // issuance-exists scans the live convertible collection.
-  let issuanceExists = false;
-  context.convertibleIssuances.forEach((ele) => {
-    if (ele.security_id === data.security_id && ele.object_type === "TX_CONVERTIBLE_ISSUANCE") {
-      issuanceExists = true;
-    }
-  });
-  if (!issuanceExists) {
-    findings.push({
-      severity: "error",
-      check: "issuance-exists",
-      message: `No convertible issuance with security_id ${data.security_id} exists in the current cap-table state.`,
-      subject,
-    });
-  }
-
-  // date-order scans the full package transaction history for the issuance.
-  // The object_type test leads so it narrows the transaction union to a
-  // security_id-bearing member before the other reads.
-  let dateOrdered = false;
-  transactions.forEach((ele) => {
-    if (
-      ele.object_type === "TX_CONVERTIBLE_ISSUANCE" &&
-      ele.security_id === data.security_id &&
-      ele.date <= data.date
-    ) {
-      dateOrdered = true;
-    }
-  });
-  if (!dateOrdered) {
-    findings.push({
-      severity: "error",
-      check: "date-order",
-      message: `The transaction is not dated on or after a convertible issuance with security_id ${data.security_id}.`,
-      subject,
-    });
-  }
-
-  return findings;
-};
-
-export const TX_CONVERTIBLE_TRANSFER = {
+export const TX_CONVERTIBLE_TRANSFER = defineValidator({
+  transaction: "TX_CONVERTIBLE_TRANSFER",
   effect: "remove",
   collection: "convertibleIssuances",
-  validate,
-  checks,
-} satisfies Descriptor;
+  checks: [issuanceExists, dateOrder, noOtherTransactions],
+});

--- a/ocf_validator/validators/warrant/checks.ts
+++ b/ocf_validator/validators/warrant/checks.ts
@@ -1,0 +1,65 @@
+import type { CheckObject } from "../checkKit";
+
+/**
+ * The warrant issuance referenced by the transaction's security_id exists in
+ * the current cap-table state. Matches on security_id alone against the live
+ * warrant collection, which holds only issuances.
+ */
+export const issuanceExists = {
+  id: "issuance-exists",
+  severity: "error",
+  description:
+    "The warrant issuance referenced by the transaction's security_id exists in the current cap-table state.",
+  run: (context, data: { security_id: string }) => {
+    const messages: string[] = [];
+
+    let issuanceExists = false;
+    context.warrantIssuances.forEach((ele) => {
+      if (ele.security_id === data.security_id) {
+        issuanceExists = true;
+      }
+    });
+    if (!issuanceExists) {
+      messages.push(
+        `No warrant issuance with security_id ${data.security_id} exists in the current cap-table state.`,
+      );
+    }
+
+    return messages;
+  },
+} satisfies CheckObject;
+
+/**
+ * The transaction is dated on or after the warrant issuance it references.
+ */
+export const dateOrder = {
+  id: "date-order",
+  severity: "error",
+  description:
+    "The transaction is dated on or after the warrant issuance it references.",
+  run: (context, data: { security_id: string; date: string }) => {
+    const messages: string[] = [];
+    const { transactions } = context.ocfPackageContent;
+
+    // date-order scans the full package transaction history for the issuance.
+    // The object_type test leads so it narrows the transaction union to a
+    // security_id-bearing member before the other reads.
+    let dateOrdered = false;
+    transactions.forEach((ele) => {
+      if (
+        ele.object_type === "TX_WARRANT_ISSUANCE" &&
+        ele.security_id === data.security_id &&
+        ele.date <= data.date
+      ) {
+        dateOrdered = true;
+      }
+    });
+    if (!dateOrdered) {
+      messages.push(
+        `The transaction is not dated on or after a warrant issuance with security_id ${data.security_id}.`,
+      );
+    }
+
+    return messages;
+  },
+} satisfies CheckObject;

--- a/ocf_validator/validators/warrant/tx_warrant_acceptance.ts
+++ b/ocf_validator/validators/warrant/tx_warrant_acceptance.ts
@@ -1,90 +1,29 @@
-import type { TransactionFor } from "../../../types/ocf-input";
-import type { Check, GradedValidator } from "../../../types/validator";
-import type { Finding } from "../../../types/finding";
-import type { Descriptor } from "../../ocfMachine";
+import { defineValidator, type CheckObject } from "../checkKit";
+import { issuanceExists, dateOrder } from "./checks";
 
-type Acceptance = TransactionFor<"TX_WARRANT_ACCEPTANCE">;
+const noRetraction = {
+  id: "no-retraction",
+  severity: "error",
+  description: "No warrant retraction references the transaction's security_id.",
+  run: (context, data: { security_id: string }) => {
+    const messages: string[] = [];
+    const { transactions } = context.ocfPackageContent;
 
-const checks: readonly Check[] = [
-  {
-    id: "issuance-exists",
-    severity: "error",
-    description:
-      "The warrant issuance referenced by the transaction's security_id exists in the current cap-table state.",
-  },
-  {
-    id: "date-order",
-    severity: "error",
-    description:
-      "The transaction is dated on or after the warrant issuance it references.",
-  },
-  {
-    id: "no-retraction",
-    severity: "error",
-    description: "No warrant retraction references the transaction's security_id.",
-  },
-];
-
-const validate: GradedValidator<Acceptance> = (context, data) => {
-  const findings: Finding[] = [];
-  const subject = { object_type: data.object_type, id: data.id };
-  const { transactions } = context.ocfPackageContent;
-
-  // issuance-exists scans the live warrant collection.
-  let issuanceExists = false;
-  context.warrantIssuances.forEach((ele) => {
-    if (ele.security_id === data.security_id && ele.object_type === "TX_WARRANT_ISSUANCE") {
-      issuanceExists = true;
-    }
-  });
-  if (!issuanceExists) {
-    findings.push({
-      severity: "error",
-      check: "issuance-exists",
-      message: `No warrant issuance with security_id ${data.security_id} exists in the current cap-table state.`,
-      subject,
+    // no-retraction emits one finding per warrant retraction on this security_id.
+    transactions.forEach((ele) => {
+      if (ele.object_type === "TX_WARRANT_RETRACTION" && ele.security_id === data.security_id) {
+        messages.push(
+          `A warrant retraction (${ele.id}) references the transaction's security_id.`,
+        );
+      }
     });
-  }
 
-  // date-order scans the full package transaction history for the issuance.
-  // The object_type test leads so it narrows the transaction union to a
-  // security_id-bearing member before the other reads.
-  let dateOrdered = false;
-  transactions.forEach((ele) => {
-    if (
-      ele.object_type === "TX_WARRANT_ISSUANCE" &&
-      ele.security_id === data.security_id &&
-      ele.date <= data.date
-    ) {
-      dateOrdered = true;
-    }
-  });
-  if (!dateOrdered) {
-    findings.push({
-      severity: "error",
-      check: "date-order",
-      message: `The transaction is not dated on or after a warrant issuance with security_id ${data.security_id}.`,
-      subject,
-    });
-  }
+    return messages;
+  },
+} satisfies CheckObject;
 
-  // no-retraction emits one finding per warrant retraction on this security_id.
-  transactions.forEach((ele) => {
-    if (ele.object_type === "TX_WARRANT_RETRACTION" && ele.security_id === data.security_id) {
-      findings.push({
-        severity: "error",
-        check: "no-retraction",
-        message: `A warrant retraction (${ele.id}) references the transaction's security_id.`,
-        subject,
-      });
-    }
-  });
-
-  return findings;
-};
-
-export const TX_WARRANT_ACCEPTANCE = {
+export const TX_WARRANT_ACCEPTANCE = defineValidator({
+  transaction: "TX_WARRANT_ACCEPTANCE",
   effect: "none",
-  validate,
-  checks,
-} satisfies Descriptor;
+  checks: [issuanceExists, dateOrder, noRetraction],
+});

--- a/ocf_validator/validators/warrant/tx_warrant_cancellation.ts
+++ b/ocf_validator/validators/warrant/tx_warrant_cancellation.ts
@@ -1,103 +1,41 @@
-import type { TransactionFor } from "../../../types/ocf-input";
-import type { Check, GradedValidator } from "../../../types/validator";
-import type { Finding } from "../../../types/finding";
-import type { Descriptor } from "../../ocfMachine";
+import { defineValidator, type CheckObject } from "../checkKit";
+import { issuanceExists, dateOrder } from "./checks";
 
-type Cancellation = TransactionFor<"TX_WARRANT_CANCELLATION">;
+const noOtherTransactions = {
+  id: "no-other-transactions",
+  severity: "error",
+  description:
+    "No other transaction references the transaction's security_id, other than a warrant acceptance.",
+  run: (context, data: { id: string; security_id: string }) => {
+    const messages: string[] = [];
+    const { transactions } = context.ocfPackageContent;
 
-const checks: readonly Check[] = [
-  {
-    id: "issuance-exists",
-    severity: "error",
-    description:
-      "The warrant issuance referenced by the transaction's security_id exists in the current cap-table state.",
-  },
-  {
-    id: "date-order",
-    severity: "error",
-    description:
-      "The transaction is dated on or after the warrant issuance it references.",
-  },
-  {
-    id: "no-other-transactions",
-    severity: "error",
-    description:
-      "No other transaction references the transaction's security_id, other than a warrant acceptance.",
-  },
-];
-
-const validate: GradedValidator<Cancellation> = (context, data) => {
-  const findings: Finding[] = [];
-  const subject = { object_type: data.object_type, id: data.id };
-  const { transactions } = context.ocfPackageContent;
-
-  // issuance-exists here matches on security_id alone — unlike the sibling
-  // validators it does not also require object_type TX_WARRANT_ISSUANCE.
-  let issuanceExists = false;
-  context.warrantIssuances.forEach((ele) => {
-    if (ele.security_id === data.security_id) {
-      issuanceExists = true;
-    }
-  });
-  if (!issuanceExists) {
-    findings.push({
-      severity: "error",
-      check: "issuance-exists",
-      message: `No warrant issuance with security_id ${data.security_id} exists in the current cap-table state.`,
-      subject,
+    // no-other-transactions emits one finding per transaction on this security_id,
+    // exempting the issuance, any warrant acceptance, and this cancellation itself.
+    // This scan keeps every transaction type in play, so it narrows by property
+    // presence rather than by discriminant: a transaction that carries no
+    // security_id can never reference this one.
+    transactions.forEach((ele) => {
+      if (
+        "security_id" in ele &&
+        ele.security_id === data.security_id &&
+        ele.object_type !== "TX_WARRANT_ISSUANCE" &&
+        ele.object_type !== "TX_WARRANT_ACCEPTANCE" &&
+        !(ele.object_type === "TX_WARRANT_CANCELLATION" && ele.id === data.id)
+      ) {
+        messages.push(
+          `Another transaction (${ele.id}) references the transaction's security_id.`,
+        );
+      }
     });
-  }
 
-  // date-order scans the full package transaction history for the issuance.
-  // The object_type test leads so it narrows the transaction union to a
-  // security_id-bearing member before the other reads.
-  let dateOrdered = false;
-  transactions.forEach((ele) => {
-    if (
-      ele.object_type === "TX_WARRANT_ISSUANCE" &&
-      ele.security_id === data.security_id &&
-      ele.date <= data.date
-    ) {
-      dateOrdered = true;
-    }
-  });
-  if (!dateOrdered) {
-    findings.push({
-      severity: "error",
-      check: "date-order",
-      message: `The transaction is not dated on or after a warrant issuance with security_id ${data.security_id}.`,
-      subject,
-    });
-  }
+    return messages;
+  },
+} satisfies CheckObject;
 
-  // no-other-transactions emits one finding per transaction on this security_id,
-  // exempting the issuance, any warrant acceptance, and this cancellation itself.
-  // This scan keeps every transaction type in play, so it narrows by property
-  // presence rather than by discriminant: a transaction that carries no
-  // security_id can never reference this one.
-  transactions.forEach((ele) => {
-    if (
-      "security_id" in ele &&
-      ele.security_id === data.security_id &&
-      ele.object_type !== "TX_WARRANT_ISSUANCE" &&
-      ele.object_type !== "TX_WARRANT_ACCEPTANCE" &&
-      !(ele.object_type === "TX_WARRANT_CANCELLATION" && ele.id === data.id)
-    ) {
-      findings.push({
-        severity: "error",
-        check: "no-other-transactions",
-        message: `Another transaction (${ele.id}) references the transaction's security_id.`,
-        subject,
-      });
-    }
-  });
-
-  return findings;
-};
-
-export const TX_WARRANT_CANCELLATION = {
+export const TX_WARRANT_CANCELLATION = defineValidator({
+  transaction: "TX_WARRANT_CANCELLATION",
   effect: "remove",
   collection: "warrantIssuances",
-  validate,
-  checks,
-} satisfies Descriptor;
+  checks: [issuanceExists, dateOrder, noOtherTransactions],
+});

--- a/ocf_validator/validators/warrant/tx_warrant_issuance.ts
+++ b/ocf_validator/validators/warrant/tx_warrant_issuance.ts
@@ -1,40 +1,31 @@
-import type { OCFWarrantIssuance } from "@opencaptablecoalition/ocf-types";
-import type { Check, GradedValidator } from "../../../types/validator";
-import type { Finding } from "../../../types/finding";
-import type { Descriptor } from "../../ocfMachine";
+import { defineValidator, type CheckObject } from "../checkKit";
 
-const checks: readonly Check[] = [
-  {
-    id: "stakeholder-exists",
-    severity: "error",
-    description:
-      "The stakeholder referenced by the transaction exists in the stakeholder file.",
-  },
-];
+const stakeholderExists = {
+  id: "stakeholder-exists",
+  severity: "error",
+  description:
+    "The stakeholder referenced by the transaction exists in the stakeholder file.",
+  run: (context, data: { stakeholder_id: string }) => {
+    const messages: string[] = [];
+    const { stakeholders } = context.ocfPackageContent;
 
-const validate: GradedValidator<OCFWarrantIssuance> = (context, data) => {
-  const findings: Finding[] = [];
-  const { stakeholders } = context.ocfPackageContent;
-
-  let stakeholderExists = false;
-  stakeholders.forEach((ele: any) => {
-    if (ele.id === data.stakeholder_id) stakeholderExists = true;
-  });
-  if (!stakeholderExists) {
-    findings.push({
-      severity: "error",
-      check: "stakeholder-exists",
-      message: `The stakeholder ${data.stakeholder_id} referenced by the transaction was not found in the stakeholder file.`,
-      subject: { object_type: data.object_type, id: data.id },
+    let stakeholderExists = false;
+    stakeholders.forEach((ele: any) => {
+      if (ele.id === data.stakeholder_id) stakeholderExists = true;
     });
-  }
+    if (!stakeholderExists) {
+      messages.push(
+        `The stakeholder ${data.stakeholder_id} referenced by the transaction was not found in the stakeholder file.`,
+      );
+    }
 
-  return findings;
-};
+    return messages;
+  },
+} satisfies CheckObject;
 
-export const TX_WARRANT_ISSUANCE = {
+export const TX_WARRANT_ISSUANCE = defineValidator({
+  transaction: "TX_WARRANT_ISSUANCE",
   effect: "append",
   collection: "warrantIssuances",
-  validate,
-  checks,
-} satisfies Descriptor;
+  checks: [stakeholderExists],
+});

--- a/ocf_validator/validators/warrant/tx_warrant_retraction.ts
+++ b/ocf_validator/validators/warrant/tx_warrant_retraction.ts
@@ -1,91 +1,30 @@
-import type { TransactionFor } from "../../../types/ocf-input";
-import type { Check, GradedValidator } from "../../../types/validator";
-import type { Finding } from "../../../types/finding";
-import type { Descriptor } from "../../ocfMachine";
+import { defineValidator, type CheckObject } from "../checkKit";
+import { issuanceExists, dateOrder } from "./checks";
 
-type Retraction = TransactionFor<"TX_WARRANT_RETRACTION">;
+const noAcceptance = {
+  id: "no-acceptance",
+  severity: "error",
+  description: "No warrant acceptance references the transaction's security_id.",
+  run: (context, data: { security_id: string }) => {
+    const messages: string[] = [];
+    const { transactions } = context.ocfPackageContent;
 
-const checks: readonly Check[] = [
-  {
-    id: "issuance-exists",
-    severity: "error",
-    description:
-      "The warrant issuance referenced by the transaction's security_id exists in the current cap-table state.",
-  },
-  {
-    id: "date-order",
-    severity: "error",
-    description:
-      "The transaction is dated on or after the warrant issuance it references.",
-  },
-  {
-    id: "no-acceptance",
-    severity: "error",
-    description: "No warrant acceptance references the transaction's security_id.",
-  },
-];
-
-const validate: GradedValidator<Retraction> = (context, data) => {
-  const findings: Finding[] = [];
-  const subject = { object_type: data.object_type, id: data.id };
-  const { transactions } = context.ocfPackageContent;
-
-  // issuance-exists scans the live warrant collection.
-  let issuanceExists = false;
-  context.warrantIssuances.forEach((ele) => {
-    if (ele.security_id === data.security_id && ele.object_type === "TX_WARRANT_ISSUANCE") {
-      issuanceExists = true;
-    }
-  });
-  if (!issuanceExists) {
-    findings.push({
-      severity: "error",
-      check: "issuance-exists",
-      message: `No warrant issuance with security_id ${data.security_id} exists in the current cap-table state.`,
-      subject,
+    // no-acceptance emits one finding per warrant acceptance on this security_id.
+    transactions.forEach((ele) => {
+      if (ele.object_type === "TX_WARRANT_ACCEPTANCE" && ele.security_id === data.security_id) {
+        messages.push(
+          `A warrant acceptance (${ele.id}) references the transaction's security_id.`,
+        );
+      }
     });
-  }
 
-  // date-order scans the full package transaction history for the issuance.
-  // The object_type test leads so it narrows the transaction union to a
-  // security_id-bearing member before the other reads.
-  let dateOrdered = false;
-  transactions.forEach((ele) => {
-    if (
-      ele.object_type === "TX_WARRANT_ISSUANCE" &&
-      ele.security_id === data.security_id &&
-      ele.date <= data.date
-    ) {
-      dateOrdered = true;
-    }
-  });
-  if (!dateOrdered) {
-    findings.push({
-      severity: "error",
-      check: "date-order",
-      message: `The transaction is not dated on or after a warrant issuance with security_id ${data.security_id}.`,
-      subject,
-    });
-  }
+    return messages;
+  },
+} satisfies CheckObject;
 
-  // no-acceptance emits one finding per warrant acceptance on this security_id.
-  transactions.forEach((ele) => {
-    if (ele.object_type === "TX_WARRANT_ACCEPTANCE" && ele.security_id === data.security_id) {
-      findings.push({
-        severity: "error",
-        check: "no-acceptance",
-        message: `A warrant acceptance (${ele.id}) references the transaction's security_id.`,
-        subject,
-      });
-    }
-  });
-
-  return findings;
-};
-
-export const TX_WARRANT_RETRACTION = {
+export const TX_WARRANT_RETRACTION = defineValidator({
+  transaction: "TX_WARRANT_RETRACTION",
   effect: "remove",
   collection: "warrantIssuances",
-  validate,
-  checks,
-} satisfies Descriptor;
+  checks: [issuanceExists, dateOrder, noAcceptance],
+});

--- a/ocf_validator/validators/warrant/tx_warrant_transfer.ts
+++ b/ocf_validator/validators/warrant/tx_warrant_transfer.ts
@@ -1,81 +1,18 @@
-import type { TransactionFor } from "../../../types/ocf-input";
-import type { Check, GradedValidator } from "../../../types/validator";
-import type { Finding } from "../../../types/finding";
-import type { Descriptor } from "../../ocfMachine";
+import { defineValidator, type CheckObject } from "../checkKit";
+import { issuanceExists, dateOrder } from "./checks";
 
-type Transfer = TransactionFor<"TX_WARRANT_TRANSFER">;
+// The transfer module declares this check but does not implement it: the same
+// metadata with no run, so it reports as a gap and contributes no findings.
+const noOtherTransactions = {
+  id: "no-other-transactions",
+  severity: "error",
+  description:
+    "No other transaction references the transaction's security_id, other than a warrant acceptance.",
+} satisfies CheckObject;
 
-const checks: readonly Check[] = [
-  {
-    id: "issuance-exists",
-    severity: "error",
-    description:
-      "The warrant issuance referenced by the transaction's security_id exists in the current cap-table state.",
-  },
-  {
-    id: "date-order",
-    severity: "error",
-    description:
-      "The transaction is dated on or after the warrant issuance it references.",
-  },
-  {
-    id: "no-other-transactions",
-    severity: "error",
-    description:
-      "No other transaction references the transaction's security_id, other than a warrant acceptance.",
-    implemented: false,
-  },
-];
-
-const validate: GradedValidator<Transfer> = (context, data) => {
-  const findings: Finding[] = [];
-  const subject = { object_type: data.object_type, id: data.id };
-  const { transactions } = context.ocfPackageContent;
-
-  // issuance-exists scans the live warrant collection.
-  let issuanceExists = false;
-  context.warrantIssuances.forEach((ele) => {
-    if (ele.security_id === data.security_id && ele.object_type === "TX_WARRANT_ISSUANCE") {
-      issuanceExists = true;
-    }
-  });
-  if (!issuanceExists) {
-    findings.push({
-      severity: "error",
-      check: "issuance-exists",
-      message: `No warrant issuance with security_id ${data.security_id} exists in the current cap-table state.`,
-      subject,
-    });
-  }
-
-  // date-order scans the full package transaction history for the issuance.
-  // The object_type test leads so it narrows the transaction union to a
-  // security_id-bearing member before the other reads.
-  let dateOrdered = false;
-  transactions.forEach((ele) => {
-    if (
-      ele.object_type === "TX_WARRANT_ISSUANCE" &&
-      ele.security_id === data.security_id &&
-      ele.date <= data.date
-    ) {
-      dateOrdered = true;
-    }
-  });
-  if (!dateOrdered) {
-    findings.push({
-      severity: "error",
-      check: "date-order",
-      message: `The transaction is not dated on or after a warrant issuance with security_id ${data.security_id}.`,
-      subject,
-    });
-  }
-
-  return findings;
-};
-
-export const TX_WARRANT_TRANSFER = {
+export const TX_WARRANT_TRANSFER = defineValidator({
+  transaction: "TX_WARRANT_TRANSFER",
   effect: "remove",
   collection: "warrantIssuances",
-  validate,
-  checks,
-} satisfies Descriptor;
+  checks: [issuanceExists, dateOrder, noOtherTransactions],
+});


### PR DESCRIPTION
Part of #159, implementing the extraction step planned on #198. Originally stacked on #200; the stack below has merged and this PR is now based on `main`.

## What this does

Both migrated families' validator modules become declarative: each module now contains only its transaction's substance, and all derivation machinery lives behind one factory.

- New `ocf_validator/validators/checkKit.ts`, exporting exactly two names. `CheckObject` is a check as one self-contained object: id, severity, description, and an optional `run` function that returns the failure messages. `defineValidator({ transaction, effect, collection?, checks })` builds a machine descriptor from an ordered list of check objects: the declared `checks` metadata and the `validate` function both derive from the same list, and each finding is completed by the factory — severity and check id stamped from the declaration, subject stamped from the transaction under validation. A finding with a mistyped check id, wrong severity, or wrong subject is no longer possible to write. A check without a `run` is declared but not implemented, and its `implemented: false` flag is derived from that absence.
- The transaction key also determines the validator's payload type, and the factory's typing was verified in both directions against the repo's compiler: a validator wired to the wrong family's collection is rejected, as is a collection on an effect that takes none.
- New `convertible/checks.ts` and `warrant/checks.ts` each hold the two checks that are genuinely reused within their family (`issuance-exists`, `date-order`). Single-use checks are defined in the module that uses them. After normalizing family vocabulary, the two families' files are token-for-token identical.
- Each of the ten migrated modules shrinks to: imports, its own check definitions, and one exported `defineValidator` call with four fields.

`tx_convertible_conversion` and `tx_warrant_exercise` stay on the legacy convention; their PRs come separately.

## Behavior change

One deliberate change rides along, recorded as decision 3 on #198: the `issuance-exists` check now matches the live collection on `security_id` alone in every module, adopting the form the cancellation validators already used. The dropped `object_type` condition could never change a result, because the machine only ever appends issuances to these collections: elements enter only through the per-type issuance cases, the collections initialize empty, and removal only filters. That invariant is currently enforced by the machine's shape rather than by a test; a guard test pinning it is a tracked obligation of the semantics work on #198.

Everything else is output-identical, mechanically proven (below).

## Verification

Zero edits under `tests/` (all 132 tests pass unchanged, run with snapshot writes disallowed), the characterization snapshot is byte-identical to the base branch, and a `tsc` pass that includes the test files is clean.

The stronger proof: before any refactoring, two golden recordings were captured at this PR's base commit — every migrated descriptor's declared `checks` array, and the complete findings output (exact messages, order, counts, and key order) of a fixed failing-scenario battery run through all ten validators. After each of the two commits, both recordings reproduce byte for byte.

After the stack below merged, the branch was rebased onto `main`: the date-order rewording from the #199/#200 reviews is preserved (that message now lives in the two family checks files), and both recordings were recaptured at the new base commit and reproduce byte for byte at this head.

<details>
<summary>Battery scenarios and reproduction procedure</summary>

Scenario battery per family (scenario name, expected finding count at both heads):

- issuance: valid (0), missing-stakeholder (1)
- acceptance: valid (0), missing-issuance (1), out-of-order-date (1), two-retractions (2, one per offender), all-checks-fail (4)
- retraction: valid (0), missing-issuance (1), out-of-order-date (1), two-acceptances (2), all-checks-fail (4)
- cancellation: valid (0), valid-with-exempt-others (0, pins the issuance/acceptance/self exemptions), live-record-of-other-type (0, pins the bare match), missing-issuance (1), out-of-order-date (1), two-offenders (2), all-checks-fail (4)
- transfer: valid (0), would-be-offender-ignored (0, pins the declared gap emitting nothing), missing-issuance (1), out-of-order-date (1), all-checks-fail (2)

To reproduce: this PR's base commit is the pre-refactor state, so the whole proof runs from the PR alone. Save the two scripts below outside the repo, then from a checkout of the base commit and again from this branch head run

```
npx ts-node --transpile-only --compilerOptions '{"module":"commonjs","moduleResolution":"node"}' <script> <repoRoot> <out.json>
```

and diff the outputs pairwise; they are byte-identical.

**Metadata dump** (serializes every graded descriptor's `checks` array):

```ts
/**
 * Golden metadata dump: serializes every migrated (graded) descriptor's checks
 * array. Lives OUTSIDE the repo tree so no repo tsconfig ever sweeps it.
 *
 * Run from a worktree root (so ts-node and module resolution use that
 * worktree): npx ts-node --transpile-only <this script> <repoRoot> <outPath>
 */
import { writeFileSync } from "fs";
import { join, resolve } from "path";

const repoRoot = resolve(process.argv[2]);
const outPath = process.argv[3];
// eslint-disable-next-line @typescript-eslint/no-var-requires
const { TX_DESCRIPTORS } = require(join(repoRoot, "ocf_validator", "ocfMachine"));

const out: Record<string, unknown> = {};
for (const [key, desc] of Object.entries(TX_DESCRIPTORS as Record<string, object>)) {
  if ("checks" in desc) {
    out[key] = (desc as { checks: unknown }).checks;
  }
}
writeFileSync(outPath, JSON.stringify(out, null, 2) + "\n");
console.log(`wrote ${Object.keys(out).length} descriptors to ${outPath}`);
```

**Findings battery** (builds the scenarios above as plain object contexts and runs each descriptor's `validate` directly):

```ts
/**
 * Golden findings battery: runs a fixed scenario set through every migrated
 * (graded) descriptor's validate and dumps the complete Finding[] per scenario,
 * in emission order. Byte-identical output before and after the refactor is
 * the proof of no behavior change.
 *
 * Run from a worktree root: npx ts-node --transpile-only <script> <repoRoot> <outPath>
 * Descriptors without a graded validate (legacy families) are skipped.
 */
import { writeFileSync } from "fs";
import { join, resolve } from "path";

const repoRoot = resolve(process.argv[2]);
const outPath = process.argv[3];
// eslint-disable-next-line @typescript-eslint/no-var-requires
const { TX_DESCRIPTORS } = require(join(repoRoot, "ocf_validator", "ocfMachine"));

type Rec = Record<string, unknown>;

interface FamilyConfig {
  prefix: string;
  collection: string;
  issuance: string;
  acceptance: string;
  retraction: string;
  cancellation: string;
  transfer: string;
}

const FAMILIES: FamilyConfig[] = [
  {
    prefix: "TX_CONVERTIBLE",
    collection: "convertibleIssuances",
    issuance: "TX_CONVERTIBLE_ISSUANCE",
    acceptance: "TX_CONVERTIBLE_ACCEPTANCE",
    retraction: "TX_CONVERTIBLE_RETRACTION",
    cancellation: "TX_CONVERTIBLE_CANCELLATION",
    transfer: "TX_CONVERTIBLE_TRANSFER",
  },
  {
    prefix: "TX_WARRANT",
    collection: "warrantIssuances",
    issuance: "TX_WARRANT_ISSUANCE",
    acceptance: "TX_WARRANT_ACCEPTANCE",
    retraction: "TX_WARRANT_RETRACTION",
    cancellation: "TX_WARRANT_CANCELLATION",
    transfer: "TX_WARRANT_TRANSFER",
  },
];

function ctx(f: FamilyConfig, live: Rec[], transactions: Rec[], stakeholders: Rec[] = []): Rec {
  return {
    ocfPackageContent: { transactions, stakeholders },
    stockIssuances: [],
    convertibleIssuances: [],
    warrantIssuances: [],
    equityCompensation: [],
    [f.collection]: live,
  };
}

function iss(f: FamilyConfig, secId: string, date = "2020-01-01"): Rec {
  return { id: `iss-${secId}`, object_type: f.issuance, security_id: secId, date };
}

function scenariosFor(f: FamilyConfig): Record<string, Record<string, { context: Rec; data: Rec }>> {
  const accData = { id: "a1", object_type: f.acceptance, security_id: "sec1", date: "2021-01-01" };
  const retData = { id: "r1", object_type: f.retraction, security_id: "sec1", date: "2021-01-01" };
  const canData = { id: "c1", object_type: f.cancellation, security_id: "sec1", date: "2021-01-01" };
  const xferData = { id: "t1", object_type: f.transfer, security_id: "sec1", date: "2021-01-01" };
  const retA = { id: "ret-a", object_type: f.retraction, security_id: "sec1", date: "2021-06-01" };
  const retB = { id: "ret-b", object_type: f.retraction, security_id: "sec1", date: "2021-07-01" };
  const accA = { id: "acc-a", object_type: f.acceptance, security_id: "sec1", date: "2021-06-01" };
  const accB = { id: "acc-b", object_type: f.acceptance, security_id: "sec1", date: "2021-07-01" };
  const xferA = { id: "xfer-a", object_type: f.transfer, security_id: "sec1", date: "2021-06-01" };
  const xferB = { id: "xfer-b", object_type: f.transfer, security_id: "sec1", date: "2021-07-01" };

  return {
    [f.issuance]: {
      "valid": {
        context: ctx(f, [], [], [{ id: "sh1" }]),
        data: { id: "i1", object_type: f.issuance, security_id: "sec1", stakeholder_id: "sh1", date: "2021-01-01" },
      },
      "missing-stakeholder": {
        context: ctx(f, [], [], [{ id: "sh1" }]),
        data: { id: "i1", object_type: f.issuance, security_id: "sec1", stakeholder_id: "nobody", date: "2021-01-01" },
      },
    },
    [f.acceptance]: {
      "valid": { context: ctx(f, [iss(f, "sec1")], [iss(f, "sec1")]), data: accData },
      "missing-issuance": { context: ctx(f, [], [iss(f, "sec1")]), data: accData },
      "out-of-order-date": { context: ctx(f, [iss(f, "sec1", "2022-01-01")], [iss(f, "sec1", "2022-01-01")]), data: accData },
      "two-retractions": { context: ctx(f, [iss(f, "sec1")], [iss(f, "sec1"), retA, retB]), data: accData },
      "all-checks-fail": { context: ctx(f, [], [retA, retB]), data: accData },
    },
    [f.retraction]: {
      "valid": { context: ctx(f, [iss(f, "sec1")], [iss(f, "sec1")]), data: retData },
      "missing-issuance": { context: ctx(f, [], [iss(f, "sec1")]), data: retData },
      "out-of-order-date": { context: ctx(f, [iss(f, "sec1", "2022-01-01")], [iss(f, "sec1", "2022-01-01")]), data: retData },
      "two-acceptances": { context: ctx(f, [iss(f, "sec1")], [iss(f, "sec1"), accA, accB]), data: retData },
      "all-checks-fail": { context: ctx(f, [], [accA, accB]), data: retData },
    },
    [f.cancellation]: {
      "valid": { context: ctx(f, [iss(f, "sec1")], [iss(f, "sec1")]), data: canData },
      "valid-with-exempt-others": {
        context: ctx(f, [iss(f, "sec1")], [
          iss(f, "sec1"),
          { id: "acc-x", object_type: f.acceptance, security_id: "sec1", date: "2021-02-01" },
          { id: "c1", object_type: f.cancellation, security_id: "sec1", date: "2021-01-01" },
        ]),
        data: canData,
      },
      "live-record-of-other-type": {
        context: ctx(f, [{ id: "x", object_type: "SOMETHING_ELSE", security_id: "sec1", date: "2020-01-01" }], [iss(f, "sec1")]),
        data: canData,
      },
      "missing-issuance": { context: ctx(f, [], [iss(f, "sec1")]), data: canData },
      "out-of-order-date": { context: ctx(f, [iss(f, "sec1", "2022-01-01")], [iss(f, "sec1", "2022-01-01")]), data: canData },
      "two-offenders": { context: ctx(f, [iss(f, "sec1")], [iss(f, "sec1"), xferA, xferB]), data: canData },
      "all-checks-fail": { context: ctx(f, [], [xferA, xferB]), data: canData },
    },
    [f.transfer]: {
      "valid": { context: ctx(f, [iss(f, "sec1")], [iss(f, "sec1")]), data: xferData },
      "would-be-offender-ignored": { context: ctx(f, [iss(f, "sec1")], [iss(f, "sec1"), retA]), data: xferData },
      "missing-issuance": { context: ctx(f, [], [iss(f, "sec1")]), data: xferData },
      "out-of-order-date": { context: ctx(f, [iss(f, "sec1", "2022-01-01")], [iss(f, "sec1", "2022-01-01")]), data: xferData },
      "all-checks-fail": { context: ctx(f, [], []), data: xferData },
    },
  };
}

const out: Record<string, unknown> = {};
let modules = 0;
for (const family of FAMILIES) {
  const scenarios = scenariosFor(family);
  for (const [txKey, cases] of Object.entries(scenarios)) {
    const descriptor = (TX_DESCRIPTORS as Rec)[txKey] as Rec | undefined;
    if (!descriptor || typeof descriptor.validate !== "function") continue;
    modules += 1;
    const results: Record<string, unknown> = {};
    for (const [name, { context, data }] of Object.entries(cases)) {
      results[name] = (descriptor.validate as (c: unknown, d: unknown) => unknown)(context, data);
    }
    out[txKey] = results;
  }
}

writeFileSync(outPath, JSON.stringify(out, null, 2) + "\n");
console.log(`wrote findings for ${modules} descriptors to ${outPath}`);
```

</details>

