### PR TITLE
Judge convertible and warrant checks against history up to each transaction's date

### DIFF
--- a/ocf_validator/validators/convertible/checks.ts
+++ b/ocf_validator/validators/convertible/checks.ts
@@ -1,16 +1,22 @@
 import type { CheckObject } from "../checkKit";
 
 /**
- * The convertible issuance referenced by the transaction's security_id exists in
- * the current cap-table state. Matches on security_id alone against the live
- * convertible collection, which holds only issuances.
+ * The convertible issuance referenced by the transaction's security_id is
+ * outstanding as of the transaction's date. Passes on a bare security_id match
+ * against the live convertible collection, which holds only issuances. When the
+ * live match fails, the message consults the full package transaction history
+ * and states one of three causes by elimination: the security was never issued,
+ * it is issued only later, or it was issued on or before this date but is no
+ * longer outstanding. The cause and any date it displays come from a single
+ * history record — a match dated on or before the transaction is preferred over
+ * a later-dated one.
  */
 export const issuanceExists = {
   id: "issuance-exists",
   severity: "error",
   description:
-    "The convertible issuance referenced by the transaction's security_id exists in the current cap-table state.",
-  run: (context, data: { security_id: string }) => {
+    "The convertible issuance referenced by the transaction's security_id is outstanding as of the transaction's date.",
+  run: (context, data: { security_id: string; date: string }) => {
     const messages: string[] = [];
 
     let issuanceExists = false;
@@ -19,44 +25,34 @@ export const issuanceExists = {
         issuanceExists = true;
       }
     });
-    if (!issuanceExists) {
-      messages.push(
-        `No convertible issuance with security_id ${data.security_id} exists in the current cap-table state.`,
-      );
-    }
+    if (issuanceExists) return messages;
 
-    return messages;
-  },
-} satisfies CheckObject;
-
-/**
- * The transaction is dated on or after the convertible issuance it references.
- */
-export const dateOrder = {
-  id: "date-order",
-  severity: "error",
-  description:
-    "The transaction is dated on or after the convertible issuance it references.",
-  run: (context, data: { security_id: string; date: string }) => {
-    const messages: string[] = [];
     const { transactions } = context.ocfPackageContent;
-
-    // date-order scans the full package transaction history for the issuance.
-    // The object_type test leads so it narrows the transaction union to a
-    // security_id-bearing member before the other reads.
-    let dateOrdered = false;
+    let firstIssuanceDate: string | undefined;
+    let onOrBeforeDate: string | undefined;
     transactions.forEach((ele) => {
       if (
         ele.object_type === "TX_CONVERTIBLE_ISSUANCE" &&
-        ele.security_id === data.security_id &&
-        ele.date <= data.date
+        ele.security_id === data.security_id
       ) {
-        dateOrdered = true;
+        if (firstIssuanceDate === undefined) firstIssuanceDate = ele.date;
+        if (onOrBeforeDate === undefined && ele.date <= data.date) {
+          onOrBeforeDate = ele.date;
+        }
       }
     });
-    if (!dateOrdered) {
+
+    if (firstIssuanceDate === undefined) {
       messages.push(
-        `The transaction is not dated on or after a convertible issuance with security_id ${data.security_id}.`,
+        `No convertible issuance with security_id ${data.security_id} appears in the package.`,
+      );
+    } else if (onOrBeforeDate === undefined) {
+      messages.push(
+        `The convertible issuance referenced by security_id ${data.security_id} is dated ${firstIssuanceDate}, after this transaction (${data.date}).`,
+      );
+    } else {
+      messages.push(
+        `The convertible issuance referenced by security_id ${data.security_id} (dated ${onOrBeforeDate}) is not outstanding as of this transaction's date.`,
       );
     }
 

--- a/ocf_validator/validators/convertible/tx_convertible_acceptance.ts
+++ b/ocf_validator/validators/convertible/tx_convertible_acceptance.ts
@@ -1,17 +1,22 @@
 import { defineValidator, type CheckObject } from "../checkKit";
-import { issuanceExists, dateOrder } from "./checks";
+import { issuanceExists } from "./checks";
 
 const noRetraction = {
   id: "no-retraction",
   severity: "error",
-  description: "No convertible retraction references the transaction's security_id.",
-  run: (context, data: { security_id: string }) => {
+  description: "No convertible retraction dated on or before this transaction references its security_id.",
+  run: (context, data: { security_id: string; date: string }) => {
     const messages: string[] = [];
     const { transactions } = context.ocfPackageContent;
 
-    // no-retraction emits one finding per convertible retraction on this security_id.
+    // no-retraction emits one finding per convertible retraction on this security_id
+    // dated on or before this transaction; a later retraction cannot invalidate it.
     transactions.forEach((ele) => {
-      if (ele.object_type === "TX_CONVERTIBLE_RETRACTION" && ele.security_id === data.security_id) {
+      if (
+        ele.object_type === "TX_CONVERTIBLE_RETRACTION" &&
+        ele.security_id === data.security_id &&
+        ele.date <= data.date
+      ) {
         messages.push(
           `A convertible retraction (${ele.id}) references the transaction's security_id.`,
         );
@@ -25,5 +30,5 @@ const noRetraction = {
 export const TX_CONVERTIBLE_ACCEPTANCE = defineValidator({
   transaction: "TX_CONVERTIBLE_ACCEPTANCE",
   effect: "none",
-  checks: [issuanceExists, dateOrder, noRetraction],
+  checks: [issuanceExists, noRetraction],
 });

--- a/ocf_validator/validators/convertible/tx_convertible_cancellation.ts
+++ b/ocf_validator/validators/convertible/tx_convertible_cancellation.ts
@@ -1,24 +1,25 @@
 import { defineValidator, type CheckObject } from "../checkKit";
-import { issuanceExists, dateOrder } from "./checks";
+import { issuanceExists } from "./checks";
 
 const noOtherTransactions = {
   id: "no-other-transactions",
   severity: "error",
   description:
-    "No other transaction references the transaction's security_id, other than a convertible acceptance.",
-  run: (context, data: { id: string; security_id: string }) => {
+    "No other transaction dated on or before this transaction references its security_id, other than a convertible acceptance.",
+  run: (context, data: { id: string; security_id: string; date: string }) => {
     const messages: string[] = [];
     const { transactions } = context.ocfPackageContent;
 
-    // no-other-transactions emits one finding per transaction on this security_id,
-    // exempting the issuance, any convertible acceptance, and this cancellation itself.
-    // This scan keeps every transaction type in play, so it narrows by property
-    // presence rather than by discriminant: a transaction that carries no
-    // security_id can never reference this one.
+    // no-other-transactions emits one finding per transaction on this security_id
+    // dated on or before this cancellation, exempting the issuance, any convertible
+    // acceptance, and this cancellation itself. This scan keeps every transaction
+    // type in play, so it narrows by property presence rather than by discriminant:
+    // a transaction that carries no security_id can never reference this one.
     transactions.forEach((ele) => {
       if (
         "security_id" in ele &&
         ele.security_id === data.security_id &&
+        ele.date <= data.date &&
         ele.object_type !== "TX_CONVERTIBLE_ISSUANCE" &&
         ele.object_type !== "TX_CONVERTIBLE_ACCEPTANCE" &&
         !(ele.object_type === "TX_CONVERTIBLE_CANCELLATION" && ele.id === data.id)
@@ -37,5 +38,5 @@ export const TX_CONVERTIBLE_CANCELLATION = defineValidator({
   transaction: "TX_CONVERTIBLE_CANCELLATION",
   effect: "remove",
   collection: "convertibleIssuances",
-  checks: [issuanceExists, dateOrder, noOtherTransactions],
+  checks: [issuanceExists, noOtherTransactions],
 });

--- a/ocf_validator/validators/convertible/tx_convertible_retraction.ts
+++ b/ocf_validator/validators/convertible/tx_convertible_retraction.ts
@@ -1,17 +1,22 @@
 import { defineValidator, type CheckObject } from "../checkKit";
-import { issuanceExists, dateOrder } from "./checks";
+import { issuanceExists } from "./checks";
 
 const noAcceptance = {
   id: "no-acceptance",
   severity: "error",
-  description: "No convertible acceptance references the transaction's security_id.",
-  run: (context, data: { security_id: string }) => {
+  description: "No convertible acceptance dated on or before this transaction references its security_id.",
+  run: (context, data: { security_id: string; date: string }) => {
     const messages: string[] = [];
     const { transactions } = context.ocfPackageContent;
 
-    // no-acceptance emits one finding per convertible acceptance on this security_id.
+    // no-acceptance emits one finding per convertible acceptance on this security_id
+    // dated on or before this transaction; a later acceptance cannot invalidate it.
     transactions.forEach((ele) => {
-      if (ele.object_type === "TX_CONVERTIBLE_ACCEPTANCE" && ele.security_id === data.security_id) {
+      if (
+        ele.object_type === "TX_CONVERTIBLE_ACCEPTANCE" &&
+        ele.security_id === data.security_id &&
+        ele.date <= data.date
+      ) {
         messages.push(
           `A convertible acceptance (${ele.id}) references the transaction's security_id.`,
         );
@@ -26,5 +31,5 @@ export const TX_CONVERTIBLE_RETRACTION = defineValidator({
   transaction: "TX_CONVERTIBLE_RETRACTION",
   effect: "remove",
   collection: "convertibleIssuances",
-  checks: [issuanceExists, dateOrder, noAcceptance],
+  checks: [issuanceExists, noAcceptance],
 });

--- a/ocf_validator/validators/convertible/tx_convertible_transfer.ts
+++ b/ocf_validator/validators/convertible/tx_convertible_transfer.ts
@@ -1,5 +1,5 @@
 import { defineValidator, type CheckObject } from "../checkKit";
-import { issuanceExists, dateOrder } from "./checks";
+import { issuanceExists } from "./checks";
 
 // The transfer module declares this check but does not implement it: the same
 // metadata with no run, so it reports as a gap and contributes no findings.
@@ -7,12 +7,12 @@ const noOtherTransactions = {
   id: "no-other-transactions",
   severity: "error",
   description:
-    "No other transaction references the transaction's security_id, other than a convertible acceptance.",
+    "No other transaction dated on or before this transaction references its security_id, other than a convertible acceptance.",
 } satisfies CheckObject;
 
 export const TX_CONVERTIBLE_TRANSFER = defineValidator({
   transaction: "TX_CONVERTIBLE_TRANSFER",
   effect: "remove",
   collection: "convertibleIssuances",
-  checks: [issuanceExists, dateOrder, noOtherTransactions],
+  checks: [issuanceExists, noOtherTransactions],
 });

--- a/ocf_validator/validators/warrant/checks.ts
+++ b/ocf_validator/validators/warrant/checks.ts
@@ -1,16 +1,22 @@
 import type { CheckObject } from "../checkKit";
 
 /**
- * The warrant issuance referenced by the transaction's security_id exists in
- * the current cap-table state. Matches on security_id alone against the live
- * warrant collection, which holds only issuances.
+ * The warrant issuance referenced by the transaction's security_id is
+ * outstanding as of the transaction's date. Passes on a bare security_id match
+ * against the live warrant collection, which holds only issuances. When the
+ * live match fails, the message consults the full package transaction history
+ * and states one of three causes by elimination: the security was never issued,
+ * it is issued only later, or it was issued on or before this date but is no
+ * longer outstanding. The cause and any date it displays come from a single
+ * history record — a match dated on or before the transaction is preferred over
+ * a later-dated one.
  */
 export const issuanceExists = {
   id: "issuance-exists",
   severity: "error",
   description:
-    "The warrant issuance referenced by the transaction's security_id exists in the current cap-table state.",
-  run: (context, data: { security_id: string }) => {
+    "The warrant issuance referenced by the transaction's security_id is outstanding as of the transaction's date.",
+  run: (context, data: { security_id: string; date: string }) => {
     const messages: string[] = [];
 
     let issuanceExists = false;
@@ -19,44 +25,34 @@ export const issuanceExists = {
         issuanceExists = true;
       }
     });
-    if (!issuanceExists) {
-      messages.push(
-        `No warrant issuance with security_id ${data.security_id} exists in the current cap-table state.`,
-      );
-    }
+    if (issuanceExists) return messages;
 
-    return messages;
-  },
-} satisfies CheckObject;
-
-/**
- * The transaction is dated on or after the warrant issuance it references.
- */
-export const dateOrder = {
-  id: "date-order",
-  severity: "error",
-  description:
-    "The transaction is dated on or after the warrant issuance it references.",
-  run: (context, data: { security_id: string; date: string }) => {
-    const messages: string[] = [];
     const { transactions } = context.ocfPackageContent;
-
-    // date-order scans the full package transaction history for the issuance.
-    // The object_type test leads so it narrows the transaction union to a
-    // security_id-bearing member before the other reads.
-    let dateOrdered = false;
+    let firstIssuanceDate: string | undefined;
+    let onOrBeforeDate: string | undefined;
     transactions.forEach((ele) => {
       if (
         ele.object_type === "TX_WARRANT_ISSUANCE" &&
-        ele.security_id === data.security_id &&
-        ele.date <= data.date
+        ele.security_id === data.security_id
       ) {
-        dateOrdered = true;
+        if (firstIssuanceDate === undefined) firstIssuanceDate = ele.date;
+        if (onOrBeforeDate === undefined && ele.date <= data.date) {
+          onOrBeforeDate = ele.date;
+        }
       }
     });
-    if (!dateOrdered) {
+
+    if (firstIssuanceDate === undefined) {
       messages.push(
-        `The transaction is not dated on or after a warrant issuance with security_id ${data.security_id}.`,
+        `No warrant issuance with security_id ${data.security_id} appears in the package.`,
+      );
+    } else if (onOrBeforeDate === undefined) {
+      messages.push(
+        `The warrant issuance referenced by security_id ${data.security_id} is dated ${firstIssuanceDate}, after this transaction (${data.date}).`,
+      );
+    } else {
+      messages.push(
+        `The warrant issuance referenced by security_id ${data.security_id} (dated ${onOrBeforeDate}) is not outstanding as of this transaction's date.`,
       );
     }
 

--- a/ocf_validator/validators/warrant/tx_warrant_acceptance.ts
+++ b/ocf_validator/validators/warrant/tx_warrant_acceptance.ts
@@ -1,17 +1,22 @@
 import { defineValidator, type CheckObject } from "../checkKit";
-import { issuanceExists, dateOrder } from "./checks";
+import { issuanceExists } from "./checks";
 
 const noRetraction = {
   id: "no-retraction",
   severity: "error",
-  description: "No warrant retraction references the transaction's security_id.",
-  run: (context, data: { security_id: string }) => {
+  description: "No warrant retraction dated on or before this transaction references its security_id.",
+  run: (context, data: { security_id: string; date: string }) => {
     const messages: string[] = [];
     const { transactions } = context.ocfPackageContent;
 
-    // no-retraction emits one finding per warrant retraction on this security_id.
+    // no-retraction emits one finding per warrant retraction on this security_id
+    // dated on or before this transaction; a later retraction cannot invalidate it.
     transactions.forEach((ele) => {
-      if (ele.object_type === "TX_WARRANT_RETRACTION" && ele.security_id === data.security_id) {
+      if (
+        ele.object_type === "TX_WARRANT_RETRACTION" &&
+        ele.security_id === data.security_id &&
+        ele.date <= data.date
+      ) {
         messages.push(
           `A warrant retraction (${ele.id}) references the transaction's security_id.`,
         );
@@ -25,5 +30,5 @@ const noRetraction = {
 export const TX_WARRANT_ACCEPTANCE = defineValidator({
   transaction: "TX_WARRANT_ACCEPTANCE",
   effect: "none",
-  checks: [issuanceExists, dateOrder, noRetraction],
+  checks: [issuanceExists, noRetraction],
 });

--- a/ocf_validator/validators/warrant/tx_warrant_cancellation.ts
+++ b/ocf_validator/validators/warrant/tx_warrant_cancellation.ts
@@ -1,24 +1,25 @@
 import { defineValidator, type CheckObject } from "../checkKit";
-import { issuanceExists, dateOrder } from "./checks";
+import { issuanceExists } from "./checks";
 
 const noOtherTransactions = {
   id: "no-other-transactions",
   severity: "error",
   description:
-    "No other transaction references the transaction's security_id, other than a warrant acceptance.",
-  run: (context, data: { id: string; security_id: string }) => {
+    "No other transaction dated on or before this transaction references its security_id, other than a warrant acceptance.",
+  run: (context, data: { id: string; security_id: string; date: string }) => {
     const messages: string[] = [];
     const { transactions } = context.ocfPackageContent;
 
-    // no-other-transactions emits one finding per transaction on this security_id,
-    // exempting the issuance, any warrant acceptance, and this cancellation itself.
-    // This scan keeps every transaction type in play, so it narrows by property
-    // presence rather than by discriminant: a transaction that carries no
-    // security_id can never reference this one.
+    // no-other-transactions emits one finding per transaction on this security_id
+    // dated on or before this cancellation, exempting the issuance, any warrant
+    // acceptance, and this cancellation itself. This scan keeps every transaction
+    // type in play, so it narrows by property presence rather than by discriminant:
+    // a transaction that carries no security_id can never reference this one.
     transactions.forEach((ele) => {
       if (
         "security_id" in ele &&
         ele.security_id === data.security_id &&
+        ele.date <= data.date &&
         ele.object_type !== "TX_WARRANT_ISSUANCE" &&
         ele.object_type !== "TX_WARRANT_ACCEPTANCE" &&
         !(ele.object_type === "TX_WARRANT_CANCELLATION" && ele.id === data.id)
@@ -37,5 +38,5 @@ export const TX_WARRANT_CANCELLATION = defineValidator({
   transaction: "TX_WARRANT_CANCELLATION",
   effect: "remove",
   collection: "warrantIssuances",
-  checks: [issuanceExists, dateOrder, noOtherTransactions],
+  checks: [issuanceExists, noOtherTransactions],
 });

--- a/ocf_validator/validators/warrant/tx_warrant_retraction.ts
+++ b/ocf_validator/validators/warrant/tx_warrant_retraction.ts
@@ -1,17 +1,22 @@
 import { defineValidator, type CheckObject } from "../checkKit";
-import { issuanceExists, dateOrder } from "./checks";
+import { issuanceExists } from "./checks";
 
 const noAcceptance = {
   id: "no-acceptance",
   severity: "error",
-  description: "No warrant acceptance references the transaction's security_id.",
-  run: (context, data: { security_id: string }) => {
+  description: "No warrant acceptance dated on or before this transaction references its security_id.",
+  run: (context, data: { security_id: string; date: string }) => {
     const messages: string[] = [];
     const { transactions } = context.ocfPackageContent;
 
-    // no-acceptance emits one finding per warrant acceptance on this security_id.
+    // no-acceptance emits one finding per warrant acceptance on this security_id
+    // dated on or before this transaction; a later acceptance cannot invalidate it.
     transactions.forEach((ele) => {
-      if (ele.object_type === "TX_WARRANT_ACCEPTANCE" && ele.security_id === data.security_id) {
+      if (
+        ele.object_type === "TX_WARRANT_ACCEPTANCE" &&
+        ele.security_id === data.security_id &&
+        ele.date <= data.date
+      ) {
         messages.push(
           `A warrant acceptance (${ele.id}) references the transaction's security_id.`,
         );
@@ -26,5 +31,5 @@ export const TX_WARRANT_RETRACTION = defineValidator({
   transaction: "TX_WARRANT_RETRACTION",
   effect: "remove",
   collection: "warrantIssuances",
-  checks: [issuanceExists, dateOrder, noAcceptance],
+  checks: [issuanceExists, noAcceptance],
 });

--- a/ocf_validator/validators/warrant/tx_warrant_transfer.ts
+++ b/ocf_validator/validators/warrant/tx_warrant_transfer.ts
@@ -1,5 +1,5 @@
 import { defineValidator, type CheckObject } from "../checkKit";
-import { issuanceExists, dateOrder } from "./checks";
+import { issuanceExists } from "./checks";
 
 // The transfer module declares this check but does not implement it: the same
 // metadata with no run, so it reports as a gap and contributes no findings.
@@ -7,12 +7,12 @@ const noOtherTransactions = {
   id: "no-other-transactions",
   severity: "error",
   description:
-    "No other transaction references the transaction's security_id, other than a warrant acceptance.",
+    "No other transaction dated on or before this transaction references its security_id, other than a warrant acceptance.",
 } satisfies CheckObject;
 
 export const TX_WARRANT_TRANSFER = defineValidator({
   transaction: "TX_WARRANT_TRANSFER",
   effect: "remove",
   collection: "warrantIssuances",
-  checks: [issuanceExists, dateOrder, noOtherTransactions],
+  checks: [issuanceExists, noOtherTransactions],
 });

--- a/tests/convertibleValidators.test.ts
+++ b/tests/convertibleValidators.test.ts
@@ -1,22 +1,15 @@
 import { describe, it, expect } from "vitest";
 import { TX_DESCRIPTORS } from "../ocf_validator/ocfMachine";
-import type { Finding } from "../types/finding";
-import type { GradedValidator, OcfMachineContext } from "../types/validator";
-import { baseContext, startSeeded, ev } from "./helpers";
-
-/** A context whose package `transactions` list is `transactions`. */
-const contextWith = (
-  overrides: Partial<OcfMachineContext> & { transactions?: any[] } = {},
-): OcfMachineContext => {
-  const { transactions = [], ...rest } = overrides;
-  return baseContext({
-    ...rest,
-    ocfPackageContent: {
-      ...baseContext().ocfPackageContent,
-      transactions,
-    } as OcfMachineContext["ocfPackageContent"],
-  });
-};
+import type { OcfMachineContext } from "../types/validator";
+import {
+  baseContext,
+  startSeeded,
+  ev,
+  contextWith,
+  runValidator,
+  implementedCheckIds,
+  expectFindingShape,
+} from "./helpers";
 
 const MIGRATED_KEYS = [
   "TX_CONVERTIBLE_ISSUANCE",
@@ -26,34 +19,6 @@ const MIGRATED_KEYS = [
   "TX_CONVERTIBLE_TRANSFER",
 ] as const;
 type MigratedKey = (typeof MIGRATED_KEYS)[number];
-
-/** Invoke the graded validator a migrated descriptor carries. */
-const runValidator = (
-  key: MigratedKey,
-  context: OcfMachineContext,
-  data: Record<string, unknown>,
-): Finding[] => {
-  const descriptor = TX_DESCRIPTORS[key] as { validate?: GradedValidator<any> };
-  if (!descriptor.validate) throw new Error(`${key} carries no graded validate`);
-  return descriptor.validate(context, data);
-};
-
-/** The check ids a descriptor declares as implemented (drops `implemented: false`). */
-const implementedCheckIds = (key: MigratedKey): string[] => {
-  const descriptor = TX_DESCRIPTORS[key] as { checks?: readonly { id: string; implemented?: false }[] };
-  return (descriptor.checks ?? []).filter((c) => c.implemented !== false).map((c) => c.id);
-};
-
-/** Assert a finding carries the declared id, error severity, and the transaction as subject. */
-const expectFindingShape = (
-  finding: Finding,
-  check: string,
-  subject: { object_type: string; id: string },
-) => {
-  expect(finding.check).toBe(check);
-  expect(finding.severity).toBe("error");
-  expect(finding.subject).toEqual(subject);
-};
 
 // A single convertible issuance, in the shape both the live collection and the
 // package transaction history hold it. `date` lets a scenario push the issuance

--- a/tests/convertibleValidators.test.ts
+++ b/tests/convertibleValidators.test.ts
@@ -21,8 +21,9 @@ const MIGRATED_KEYS = [
 type MigratedKey = (typeof MIGRATED_KEYS)[number];
 
 // A single convertible issuance, in the shape both the live collection and the
-// package transaction history hold it. `date` lets a scenario push the issuance
-// after the transaction under validation to trip the date-order check.
+// package transaction history hold it. `date` lets a scenario place the issuance
+// before or after the transaction under validation to exercise the existence
+// check's layered diagnostics.
 const issuanceRecord = (security_id: string, date = "2020-01-01") => ({
   id: `ci-${security_id}`,
   object_type: "TX_CONVERTIBLE_ISSUANCE",
@@ -92,7 +93,7 @@ describe("convertible issuance validity", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Acceptance: issuance-exists, date-order, no-retraction
+// Acceptance: issuance-exists, no-retraction
 // ---------------------------------------------------------------------------
 
 describe("convertible acceptance validity", () => {
@@ -105,7 +106,7 @@ describe("convertible acceptance validity", () => {
   });
   const subject = { object_type: "TX_CONVERTIBLE_ACCEPTANCE", id: "acc1" };
 
-  it("returns no findings when the issuance exists, dates order, and no retraction references it", () => {
+  it("returns no findings when the issuance is outstanding and no retraction references it", () => {
     const context = contextWith({
       convertibleIssuances: [issuanceRecord("sec1")] as any,
       transactions: [issuanceRecord("sec1")],
@@ -129,34 +130,13 @@ describe("convertible acceptance validity", () => {
     expect(snapshot.context.findings).toEqual([]);
   });
 
-  it("flags a missing issuance with an error naming the security_id", () => {
-    // In the package history (date-order passes) but not the live collection.
-    const context = contextWith({ transactions: [issuanceRecord("sec1")] });
-    const findings = runValidator("TX_CONVERTIBLE_ACCEPTANCE", context, acceptance());
-    expect(findings).toHaveLength(1);
-    expectFindingShape(findings[0], "issuance-exists", subject);
-    expect(findings[0].message).toContain("sec1");
-  });
-
-  it("flags an out-of-order date with an error naming the security_id", () => {
-    // Issuance is live (issuance-exists passes) but dated after the acceptance.
-    const context = contextWith({
-      convertibleIssuances: [issuanceRecord("sec1", "2022-01-01")] as any,
-      transactions: [issuanceRecord("sec1", "2022-01-01")],
-    });
-    const findings = runValidator("TX_CONVERTIBLE_ACCEPTANCE", context, acceptance());
-    expect(findings).toHaveLength(1);
-    expectFindingShape(findings[0], "date-order", subject);
-    expect(findings[0].message).toContain("sec1");
-  });
-
-  it("emits one no-retraction finding per offending retraction, each naming that retraction", () => {
+  it("emits one no-retraction finding per past offending retraction, each naming that retraction", () => {
     const context = contextWith({
       convertibleIssuances: [issuanceRecord("sec1")] as any,
       transactions: [
         issuanceRecord("sec1"),
-        { id: "ret-a", object_type: "TX_CONVERTIBLE_RETRACTION", security_id: "sec1", date: "2021-06-01" },
-        { id: "ret-b", object_type: "TX_CONVERTIBLE_RETRACTION", security_id: "sec1", date: "2021-07-01" },
+        { id: "ret-a", object_type: "TX_CONVERTIBLE_RETRACTION", security_id: "sec1", date: "2020-06-01" },
+        { id: "ret-b", object_type: "TX_CONVERTIBLE_RETRACTION", security_id: "sec1", date: "2020-07-01" },
       ],
     });
     const findings = runValidator("TX_CONVERTIBLE_ACCEPTANCE", context, acceptance());
@@ -168,7 +148,7 @@ describe("convertible acceptance validity", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Retraction: issuance-exists, date-order, no-acceptance
+// Retraction: issuance-exists, no-acceptance
 // ---------------------------------------------------------------------------
 
 describe("convertible retraction validity", () => {
@@ -181,7 +161,7 @@ describe("convertible retraction validity", () => {
   });
   const subject = { object_type: "TX_CONVERTIBLE_RETRACTION", id: "ret1" };
 
-  it("returns no findings when the issuance exists, dates order, and no acceptance references it", () => {
+  it("returns no findings when the issuance is outstanding and no acceptance references it", () => {
     const context = contextWith({
       convertibleIssuances: [issuanceRecord("sec1")] as any,
       transactions: [issuanceRecord("sec1")],
@@ -204,32 +184,13 @@ describe("convertible retraction validity", () => {
     expect(snapshot.context.findings).toEqual([]);
   });
 
-  it("flags a missing issuance with an error naming the security_id", () => {
-    const context = contextWith({ transactions: [issuanceRecord("sec1")] });
-    const findings = runValidator("TX_CONVERTIBLE_RETRACTION", context, retraction());
-    expect(findings).toHaveLength(1);
-    expectFindingShape(findings[0], "issuance-exists", subject);
-    expect(findings[0].message).toContain("sec1");
-  });
-
-  it("flags an out-of-order date with an error naming the security_id", () => {
-    const context = contextWith({
-      convertibleIssuances: [issuanceRecord("sec1", "2022-01-01")] as any,
-      transactions: [issuanceRecord("sec1", "2022-01-01")],
-    });
-    const findings = runValidator("TX_CONVERTIBLE_RETRACTION", context, retraction());
-    expect(findings).toHaveLength(1);
-    expectFindingShape(findings[0], "date-order", subject);
-    expect(findings[0].message).toContain("sec1");
-  });
-
-  it("emits one no-acceptance finding per offending acceptance, each naming that acceptance", () => {
+  it("emits one no-acceptance finding per past offending acceptance, each naming that acceptance", () => {
     const context = contextWith({
       convertibleIssuances: [issuanceRecord("sec1")] as any,
       transactions: [
         issuanceRecord("sec1"),
-        { id: "acc-a", object_type: "TX_CONVERTIBLE_ACCEPTANCE", security_id: "sec1", date: "2021-06-01" },
-        { id: "acc-b", object_type: "TX_CONVERTIBLE_ACCEPTANCE", security_id: "sec1", date: "2021-07-01" },
+        { id: "acc-a", object_type: "TX_CONVERTIBLE_ACCEPTANCE", security_id: "sec1", date: "2020-06-01" },
+        { id: "acc-b", object_type: "TX_CONVERTIBLE_ACCEPTANCE", security_id: "sec1", date: "2020-07-01" },
       ],
     });
     const findings = runValidator("TX_CONVERTIBLE_RETRACTION", context, retraction());
@@ -241,7 +202,7 @@ describe("convertible retraction validity", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Cancellation: issuance-exists, date-order, no-other-transactions
+// Cancellation: issuance-exists, no-other-transactions
 // ---------------------------------------------------------------------------
 
 describe("convertible cancellation validity", () => {
@@ -253,7 +214,7 @@ describe("convertible cancellation validity", () => {
     ...overrides,
   });
   const cancellationRecord = { id: "can1", object_type: "TX_CONVERTIBLE_CANCELLATION", security_id: "sec1", date: "2021-01-01" };
-  const acceptanceRecord = { id: "acc-x", object_type: "TX_CONVERTIBLE_ACCEPTANCE", security_id: "sec1", date: "2021-02-01" };
+  const acceptanceRecord = { id: "acc-x", object_type: "TX_CONVERTIBLE_ACCEPTANCE", security_id: "sec1", date: "2020-02-01" };
   const subject = { object_type: "TX_CONVERTIBLE_CANCELLATION", id: "can1" };
 
   it("returns no findings when only an issuance, a convertible acceptance, and the cancellation itself reference the security", () => {
@@ -288,34 +249,15 @@ describe("convertible cancellation validity", () => {
     expect(snapshot.context.convertibleIssuances.some((c: any) => c.security_id === "sec2")).toBe(true);
   });
 
-  it("flags a missing issuance with an error naming the security_id", () => {
-    const context = contextWith({ transactions: [issuanceRecord("sec1")] });
-    const findings = runValidator("TX_CONVERTIBLE_CANCELLATION", context, cancellation());
-    expect(findings).toHaveLength(1);
-    expectFindingShape(findings[0], "issuance-exists", subject);
-    expect(findings[0].message).toContain("sec1");
-  });
-
-  it("flags an out-of-order date with an error naming the security_id", () => {
-    const context = contextWith({
-      convertibleIssuances: [issuanceRecord("sec1", "2022-01-01")] as any,
-      transactions: [issuanceRecord("sec1", "2022-01-01")],
-    });
-    const findings = runValidator("TX_CONVERTIBLE_CANCELLATION", context, cancellation());
-    expect(findings).toHaveLength(1);
-    expectFindingShape(findings[0], "date-order", subject);
-    expect(findings[0].message).toContain("sec1");
-  });
-
-  it("emits one no-other-transactions finding per offender, exempting acceptances and itself", () => {
+  it("emits one no-other-transactions finding per past offender, exempting acceptances and itself", () => {
     const context = contextWith({
       convertibleIssuances: [issuanceRecord("sec1")] as any,
       transactions: [
         issuanceRecord("sec1"),
         acceptanceRecord,
         cancellationRecord,
-        { id: "xfer-a", object_type: "TX_CONVERTIBLE_TRANSFER", security_id: "sec1", date: "2021-06-01" },
-        { id: "xfer-b", object_type: "TX_CONVERTIBLE_TRANSFER", security_id: "sec1", date: "2021-07-01" },
+        { id: "xfer-a", object_type: "TX_CONVERTIBLE_TRANSFER", security_id: "sec1", date: "2020-06-01" },
+        { id: "xfer-b", object_type: "TX_CONVERTIBLE_TRANSFER", security_id: "sec1", date: "2020-07-01" },
       ],
     });
     const findings = runValidator("TX_CONVERTIBLE_CANCELLATION", context, cancellation());
@@ -330,7 +272,7 @@ describe("convertible cancellation validity", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Transfer: issuance-exists, date-order (no-other-transactions is a declared gap)
+// Transfer: issuance-exists (no-other-transactions is a declared gap)
 // ---------------------------------------------------------------------------
 
 describe("convertible transfer validity", () => {
@@ -341,9 +283,8 @@ describe("convertible transfer validity", () => {
     date: "2021-01-01",
     ...overrides,
   });
-  const subject = { object_type: "TX_CONVERTIBLE_TRANSFER", id: "xfer1" };
 
-  it("returns no findings when the issuance exists and dates order", () => {
+  it("returns no findings when the issuance is outstanding", () => {
     const context = contextWith({
       convertibleIssuances: [issuanceRecord("sec1")] as any,
       transactions: [issuanceRecord("sec1")],
@@ -365,38 +306,170 @@ describe("convertible transfer validity", () => {
     expect(snapshot.context.convertibleIssuances.some((c: any) => c.security_id === "sec2")).toBe(true);
   });
 
-  it("flags a missing issuance with an error naming the security_id", () => {
-    const context = contextWith({ transactions: [issuanceRecord("sec1")] });
-    const findings = runValidator("TX_CONVERTIBLE_TRANSFER", context, transfer());
-    expect(findings).toHaveLength(1);
-    expectFindingShape(findings[0], "issuance-exists", subject);
-    expect(findings[0].message).toContain("sec1");
-  });
-
-  it("flags an out-of-order date with an error naming the security_id", () => {
-    const context = contextWith({
-      convertibleIssuances: [issuanceRecord("sec1", "2022-01-01")] as any,
-      transactions: [issuanceRecord("sec1", "2022-01-01")],
-    });
-    const findings = runValidator("TX_CONVERTIBLE_TRANSFER", context, transfer());
-    expect(findings).toHaveLength(1);
-    expectFindingShape(findings[0], "date-order", subject);
-    expect(findings[0].message).toContain("sec1");
-  });
-
-  it("never emits no-other-transactions, even when other transactions reference the security", () => {
+  it("never emits no-other-transactions, even when a past transaction references the security", () => {
     const context = contextWith({
       convertibleIssuances: [issuanceRecord("sec1")] as any,
       transactions: [
         issuanceRecord("sec1"),
-        { id: "ret-x", object_type: "TX_CONVERTIBLE_RETRACTION", security_id: "sec1", date: "2021-06-01" },
-        { id: "can-x", object_type: "TX_CONVERTIBLE_CANCELLATION", security_id: "sec1", date: "2021-07-01" },
+        { id: "ret-x", object_type: "TX_CONVERTIBLE_RETRACTION", security_id: "sec1", date: "2020-06-01" },
+        { id: "can-x", object_type: "TX_CONVERTIBLE_CANCELLATION", security_id: "sec1", date: "2020-07-01" },
       ],
     });
     const findings = runValidator("TX_CONVERTIBLE_TRANSFER", context, transfer());
     // The declared gap is never checked, so the transaction stays valid here.
     expect(findings).toEqual([]);
     expect(findings.some((f) => f.check === "no-other-transactions")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Existence check: layered failure diagnostics
+// ---------------------------------------------------------------------------
+
+describe("issuance-exists reports why the referenced issuance is unavailable", () => {
+  const acceptance = { id: "acc1", object_type: "TX_CONVERTIBLE_ACCEPTANCE", security_id: "sec1", date: "2021-01-01" };
+  const subject = { object_type: "TX_CONVERTIBLE_ACCEPTANCE", id: "acc1" };
+
+  // Every scenario keeps the live collection empty so the existence check fails and
+  // takes the history-scanning path; the message names one of the three causes.
+  const expectSoleCause = (context: OcfMachineContext, message: string) => {
+    const findings = runValidator("TX_CONVERTIBLE_ACCEPTANCE", context, acceptance);
+    expect(findings).toHaveLength(1);
+    expectFindingShape(findings[0], "issuance-exists", subject);
+    expect(findings[0].message).toBe(message);
+    expect(findings.some((f) => f.check === "date-order")).toBe(false);
+  };
+
+  it("names a security that was never issued in the package", () => {
+    expectSoleCause(
+      contextWith({ transactions: [] }),
+      "No convertible issuance with security_id sec1 appears in the package.",
+    );
+  });
+
+  it("names an issuance dated after the transaction", () => {
+    expectSoleCause(
+      contextWith({ transactions: [issuanceRecord("sec1", "2022-01-01")] }),
+      "The convertible issuance referenced by security_id sec1 is dated 2022-01-01, after this transaction (2021-01-01).",
+    );
+  });
+
+  it("reports an issuance issued on or before the transaction but no longer outstanding", () => {
+    expectSoleCause(
+      contextWith({ transactions: [issuanceRecord("sec1", "2020-01-01")] }),
+      "The convertible issuance referenced by security_id sec1 (dated 2020-01-01) is not outstanding as of this transaction's date.",
+    );
+  });
+
+  it("displays the on-or-before issuance's date when the history holds both an earlier and a later match", () => {
+    expectSoleCause(
+      contextWith({ transactions: [issuanceRecord("sec1", "2020-01-01"), issuanceRecord("sec1", "2022-01-01")] }),
+      "The convertible issuance referenced by security_id sec1 (dated 2020-01-01) is not outstanding as of this transaction's date.",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Offender scans: past-only
+// ---------------------------------------------------------------------------
+
+describe("offender scans consider only offenders dated on or before the transaction", () => {
+  // Each implemented scan judged at the date boundary: the transaction under
+  // validation is dated 2021-06-01, with the referenced issuance already live so
+  // the existence check passes and only the scan under test can emit.
+  const TX_DATE = "2021-06-01";
+  const scans = [
+    { scan: "no-retraction", txType: "TX_CONVERTIBLE_ACCEPTANCE", txId: "acc1", offenderType: "TX_CONVERTIBLE_RETRACTION", offenderId: "ret1" },
+    { scan: "no-acceptance", txType: "TX_CONVERTIBLE_RETRACTION", txId: "ret1", offenderType: "TX_CONVERTIBLE_ACCEPTANCE", offenderId: "acc1" },
+    { scan: "no-other-transactions", txType: "TX_CONVERTIBLE_CANCELLATION", txId: "can1", offenderType: "TX_CONVERTIBLE_TRANSFER", offenderId: "xfer1" },
+  ] as const;
+
+  it.each(scans)("$scan flags a same-day or earlier offender but ignores a later one", ({ scan, txType, txId, offenderType, offenderId }) => {
+    const tx = { id: txId, object_type: txType, security_id: "sec1", date: TX_DATE };
+    const emitsAt = (offenderDate: string) => {
+      const context = contextWith({
+        convertibleIssuances: [issuanceRecord("sec1")] as any,
+        transactions: [
+          issuanceRecord("sec1"),
+          { id: offenderId, object_type: offenderType, security_id: "sec1", date: offenderDate },
+        ],
+      });
+      return runValidator(txType, context, tx).some((f) => f.check === scan);
+    };
+
+    expect(emitsAt("2021-12-01")).toBe(false);
+    expect(emitsAt(TX_DATE)).toBe(true);
+    expect(emitsAt("2021-01-01")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Conflicting transactions: the later one carries the error
+// ---------------------------------------------------------------------------
+
+describe("a conflicting transaction pair flags the later transaction, not the earlier", () => {
+  const issuance = { id: "ci1", object_type: "TX_CONVERTIBLE_ISSUANCE", security_id: "sec1", date: "2020-01-01" };
+
+  it("clears an acceptance and flags a later retraction by its backward scan", () => {
+    const acceptance = { id: "acc1", object_type: "TX_CONVERTIBLE_ACCEPTANCE", security_id: "sec1", date: "2020-02-01" };
+    const retraction = { id: "ret1", object_type: "TX_CONVERTIBLE_RETRACTION", security_id: "sec1", date: "2020-03-01" };
+
+    const actor = startSeeded(
+      contextWith({
+        convertibleIssuances: [issuance] as any,
+        transactions: [issuance, acceptance, retraction],
+      }),
+    );
+
+    actor.send(ev("TX_CONVERTIBLE_ACCEPTANCE", acceptance));
+    expect(actor.getSnapshot().value).toBe("capTable");
+    expect(actor.getSnapshot().context.findings).toEqual([]);
+
+    actor.send(ev("TX_CONVERTIBLE_RETRACTION", retraction));
+    const { context, value } = actor.getSnapshot();
+    expect(value).toBe("validationError");
+
+    const errors = context.findings.filter((f) => f.severity === "error");
+    expect(errors).toHaveLength(1);
+    expect(errors[0].check).toBe("no-acceptance");
+    for (const finding of context.findings) {
+      expect(finding.subject).toEqual({ object_type: "TX_CONVERTIBLE_RETRACTION", id: "ret1" });
+    }
+    expect(context.findings.some((f) => f.subject.id === "acc1")).toBe(false);
+  });
+
+  it("clears a retraction that removes the issuance and then flags the later acceptance by both checks", () => {
+    const retraction = { id: "ret1", object_type: "TX_CONVERTIBLE_RETRACTION", security_id: "sec1", date: "2020-02-01" };
+    const acceptance = { id: "acc1", object_type: "TX_CONVERTIBLE_ACCEPTANCE", security_id: "sec1", date: "2020-03-01" };
+
+    const actor = startSeeded(
+      contextWith({
+        convertibleIssuances: [issuance] as any,
+        transactions: [issuance, retraction, acceptance],
+      }),
+    );
+
+    actor.send(ev("TX_CONVERTIBLE_RETRACTION", retraction));
+    const afterRetraction = actor.getSnapshot();
+    expect(afterRetraction.value).toBe("capTable");
+    expect(afterRetraction.context.findings).toEqual([]);
+    // The retraction removed the issuance from the live collection.
+    expect(afterRetraction.context.convertibleIssuances.some((c: any) => c.security_id === "sec1")).toBe(false);
+
+    actor.send(ev("TX_CONVERTIBLE_ACCEPTANCE", acceptance));
+    const { context, value } = actor.getSnapshot();
+    expect(value).toBe("validationError");
+
+    const errors = context.findings.filter((f) => f.severity === "error");
+    expect(errors.map((f) => f.check).sort()).toEqual(["issuance-exists", "no-retraction"]);
+    const existence = errors.find((f) => f.check === "issuance-exists");
+    expect(existence?.message).toBe(
+      "The convertible issuance referenced by security_id sec1 (dated 2020-01-01) is not outstanding as of this transaction's date.",
+    );
+    for (const finding of context.findings) {
+      expect(finding.subject).toEqual({ object_type: "TX_CONVERTIBLE_ACCEPTANCE", id: "acc1" });
+    }
+    expect(context.findings.some((f) => f.subject.id === "ret1")).toBe(false);
   });
 });
 
@@ -426,22 +499,18 @@ const failingScenarios: Record<MigratedKey, { context: OcfMachineContext; data: 
   ],
   TX_CONVERTIBLE_ACCEPTANCE: [
     { context: contextWith({ transactions: [issuanceRecord("sec1")] }), data: txRecord("TX_CONVERTIBLE_ACCEPTANCE", "a1", "sec1", "2021-01-01") },
-    { context: contextWith({ convertibleIssuances: [issuanceRecord("sec1", "2022-01-01")] as any, transactions: [issuanceRecord("sec1", "2022-01-01")] }), data: txRecord("TX_CONVERTIBLE_ACCEPTANCE", "a1", "sec1", "2021-01-01") },
-    { context: contextWith({ convertibleIssuances: [issuanceRecord("sec1")] as any, transactions: [issuanceRecord("sec1"), txRecord("TX_CONVERTIBLE_RETRACTION", "r1")] }), data: txRecord("TX_CONVERTIBLE_ACCEPTANCE", "a1", "sec1", "2021-01-01") },
+    { context: contextWith({ convertibleIssuances: [issuanceRecord("sec1")] as any, transactions: [issuanceRecord("sec1"), txRecord("TX_CONVERTIBLE_RETRACTION", "r1", "sec1", "2020-06-01")] }), data: txRecord("TX_CONVERTIBLE_ACCEPTANCE", "a1", "sec1", "2021-01-01") },
   ],
   TX_CONVERTIBLE_RETRACTION: [
     { context: contextWith({ transactions: [issuanceRecord("sec1")] }), data: txRecord("TX_CONVERTIBLE_RETRACTION", "r1", "sec1", "2021-01-01") },
-    { context: contextWith({ convertibleIssuances: [issuanceRecord("sec1", "2022-01-01")] as any, transactions: [issuanceRecord("sec1", "2022-01-01")] }), data: txRecord("TX_CONVERTIBLE_RETRACTION", "r1", "sec1", "2021-01-01") },
-    { context: contextWith({ convertibleIssuances: [issuanceRecord("sec1")] as any, transactions: [issuanceRecord("sec1"), txRecord("TX_CONVERTIBLE_ACCEPTANCE", "a1")] }), data: txRecord("TX_CONVERTIBLE_RETRACTION", "r1", "sec1", "2021-01-01") },
+    { context: contextWith({ convertibleIssuances: [issuanceRecord("sec1")] as any, transactions: [issuanceRecord("sec1"), txRecord("TX_CONVERTIBLE_ACCEPTANCE", "a1", "sec1", "2020-06-01")] }), data: txRecord("TX_CONVERTIBLE_RETRACTION", "r1", "sec1", "2021-01-01") },
   ],
   TX_CONVERTIBLE_CANCELLATION: [
     { context: contextWith({ transactions: [issuanceRecord("sec1")] }), data: txRecord("TX_CONVERTIBLE_CANCELLATION", "c1", "sec1", "2021-01-01") },
-    { context: contextWith({ convertibleIssuances: [issuanceRecord("sec1", "2022-01-01")] as any, transactions: [issuanceRecord("sec1", "2022-01-01")] }), data: txRecord("TX_CONVERTIBLE_CANCELLATION", "c1", "sec1", "2021-01-01") },
-    { context: contextWith({ convertibleIssuances: [issuanceRecord("sec1")] as any, transactions: [issuanceRecord("sec1"), txRecord("TX_CONVERTIBLE_TRANSFER", "x1")] }), data: txRecord("TX_CONVERTIBLE_CANCELLATION", "c1", "sec1", "2021-01-01") },
+    { context: contextWith({ convertibleIssuances: [issuanceRecord("sec1")] as any, transactions: [issuanceRecord("sec1"), txRecord("TX_CONVERTIBLE_TRANSFER", "x1", "sec1", "2020-06-01")] }), data: txRecord("TX_CONVERTIBLE_CANCELLATION", "c1", "sec1", "2021-01-01") },
   ],
   TX_CONVERTIBLE_TRANSFER: [
     { context: contextWith({ transactions: [issuanceRecord("sec1")] }), data: txRecord("TX_CONVERTIBLE_TRANSFER", "x1", "sec1", "2021-01-01") },
-    { context: contextWith({ convertibleIssuances: [issuanceRecord("sec1", "2022-01-01")] as any, transactions: [issuanceRecord("sec1", "2022-01-01")] }), data: txRecord("TX_CONVERTIBLE_TRANSFER", "x1", "sec1", "2021-01-01") },
   ],
 };
 

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -1,10 +1,14 @@
-// Shared machine-test helpers: a full empty context, an actor seeded straight
-// into `capTable`, and the test-only event cast. Imported by every suite that
-// drives the machine, so each validator family's tests build on one definition.
+// Shared test helpers: a full empty context, an actor seeded straight into
+// `capTable`, the test-only event cast, and the family-agnostic validator
+// helpers every migrated-family suite builds on. Imported by every suite that
+// drives the machine or a graded validator, so each family's tests share one
+// definition.
 
+import { expect } from "vitest";
 import { createActor } from "xstate";
-import { ocfMachine, type OcfMachineEvent } from "../ocf_validator/ocfMachine";
-import type { OcfMachineContext } from "../types/validator";
+import { ocfMachine, TX_DESCRIPTORS, type OcfMachineEvent } from "../ocf_validator/ocfMachine";
+import type { Finding } from "../types/finding";
+import type { GradedValidator, OcfMachineContext } from "../types/validator";
 
 /** A full, mostly-empty machine context; `overrides` replace top-level fields. */
 export const baseContext = (overrides: Partial<OcfMachineContext> = {}): OcfMachineContext => ({
@@ -39,3 +43,49 @@ export const startSeeded = (context: OcfMachineContext) =>
 /** Cast a hand-built event to the typed event union (test-only boundary). */
 export const ev = (type: string, data: Record<string, unknown> = {}): OcfMachineEvent =>
   ({ type, data } as unknown as OcfMachineEvent);
+
+/** A context whose package `transactions` list is `transactions`. */
+export const contextWith = (
+  overrides: Partial<OcfMachineContext> & { transactions?: any[] } = {},
+): OcfMachineContext => {
+  const { transactions = [], ...rest } = overrides;
+  return baseContext({
+    ...rest,
+    ocfPackageContent: {
+      ...baseContext().ocfPackageContent,
+      transactions,
+    } as OcfMachineContext["ocfPackageContent"],
+  });
+};
+
+/** Invoke the graded validator a migrated descriptor carries. */
+export const runValidator = (
+  key: string,
+  context: OcfMachineContext,
+  data: Record<string, unknown>,
+): Finding[] => {
+  const descriptor = TX_DESCRIPTORS[key as keyof typeof TX_DESCRIPTORS] as {
+    validate?: GradedValidator<any>;
+  };
+  if (!descriptor.validate) throw new Error(`${key} carries no graded validate`);
+  return descriptor.validate(context, data);
+};
+
+/** The check ids a descriptor declares as implemented (drops `implemented: false`). */
+export const implementedCheckIds = (key: string): string[] => {
+  const descriptor = TX_DESCRIPTORS[key as keyof typeof TX_DESCRIPTORS] as {
+    checks?: readonly { id: string; implemented?: false }[];
+  };
+  return (descriptor.checks ?? []).filter((c) => c.implemented !== false).map((c) => c.id);
+};
+
+/** Assert a finding carries the declared id, error severity, and the transaction as subject. */
+export const expectFindingShape = (
+  finding: Finding,
+  check: string,
+  subject: { object_type: string; id: string },
+) => {
+  expect(finding.check).toBe(check);
+  expect(finding.severity).toBe("error");
+  expect(finding.subject).toEqual(subject);
+};

--- a/tests/ocfMachine.test.ts
+++ b/tests/ocfMachine.test.ts
@@ -398,3 +398,70 @@ describe("legacy validators through the machine", () => {
     expect(snapshot.context.findings).toEqual([]);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Family collections hold only issuances
+// ---------------------------------------------------------------------------
+//
+// The existence check matches on security_id alone because a family collection
+// only ever holds issuance records. These runs drive a full valid history —
+// issue and accept security A (A survives), issue and retract security B (B is
+// appended then removed) — so at least one append and one removal demonstrably
+// run without the machine halting, and each collection ends as exactly the
+// surviving issuance. Distinct securities keep every transaction valid under the
+// past-only offender scans, so the machine processes the whole package rather
+// than halting at the first error.
+
+describe("family collections end holding only the surviving issuance", () => {
+  it("keeps the convertible collection as exactly the security-A issuance after an append and a removal", () => {
+    const issueA = { id: "ciA", object_type: "TX_CONVERTIBLE_ISSUANCE", security_id: "secA", stakeholder_id: "sh1", date: "2020-01-01" };
+    const acceptA = { id: "accA", object_type: "TX_CONVERTIBLE_ACCEPTANCE", security_id: "secA", date: "2020-02-01" };
+    const issueB = { id: "ciB", object_type: "TX_CONVERTIBLE_ISSUANCE", security_id: "secB", stakeholder_id: "sh1", date: "2020-03-01" };
+    const retractB = { id: "retB", object_type: "TX_CONVERTIBLE_RETRACTION", security_id: "secB", date: "2020-04-01" };
+
+    const seeded = baseContext({
+      ocfPackageContent: {
+        ...baseContext().ocfPackageContent,
+        stakeholders: [{ id: "sh1" }],
+        transactions: [issueA, acceptA, issueB, retractB],
+      } as OcfMachineContext["ocfPackageContent"],
+    });
+
+    const actor = startSeeded(seeded);
+    actor.send(ev("TX_CONVERTIBLE_ISSUANCE", issueA));
+    actor.send(ev("TX_CONVERTIBLE_ACCEPTANCE", acceptA));
+    actor.send(ev("TX_CONVERTIBLE_ISSUANCE", issueB));
+    actor.send(ev("TX_CONVERTIBLE_RETRACTION", retractB));
+
+    const snapshot = actor.getSnapshot();
+    expect(snapshot.value).toBe("capTable");
+    expect(snapshot.context.findings).toEqual([]);
+    expect(snapshot.context.convertibleIssuances).toEqual([issueA]);
+  });
+
+  it("keeps the warrant collection as exactly the security-A issuance after an append and a removal", () => {
+    const issueA = { id: "wiA", object_type: "TX_WARRANT_ISSUANCE", security_id: "secA", stakeholder_id: "sh1", date: "2020-01-01" };
+    const acceptA = { id: "accA", object_type: "TX_WARRANT_ACCEPTANCE", security_id: "secA", date: "2020-02-01" };
+    const issueB = { id: "wiB", object_type: "TX_WARRANT_ISSUANCE", security_id: "secB", stakeholder_id: "sh1", date: "2020-03-01" };
+    const retractB = { id: "retB", object_type: "TX_WARRANT_RETRACTION", security_id: "secB", date: "2020-04-01" };
+
+    const seeded = baseContext({
+      ocfPackageContent: {
+        ...baseContext().ocfPackageContent,
+        stakeholders: [{ id: "sh1" }],
+        transactions: [issueA, acceptA, issueB, retractB],
+      } as OcfMachineContext["ocfPackageContent"],
+    });
+
+    const actor = startSeeded(seeded);
+    actor.send(ev("TX_WARRANT_ISSUANCE", issueA));
+    actor.send(ev("TX_WARRANT_ACCEPTANCE", acceptA));
+    actor.send(ev("TX_WARRANT_ISSUANCE", issueB));
+    actor.send(ev("TX_WARRANT_RETRACTION", retractB));
+
+    const snapshot = actor.getSnapshot();
+    expect(snapshot.value).toBe("capTable");
+    expect(snapshot.context.findings).toEqual([]);
+    expect(snapshot.context.warrantIssuances).toEqual([issueA]);
+  });
+});

--- a/tests/warrantValidators.test.ts
+++ b/tests/warrantValidators.test.ts
@@ -21,8 +21,9 @@ const MIGRATED_KEYS = [
 type MigratedKey = (typeof MIGRATED_KEYS)[number];
 
 // A single warrant issuance, in the shape both the live collection and the
-// package transaction history hold it. `date` lets a scenario push the issuance
-// after the transaction under validation to trip the date-order check.
+// package transaction history hold it. `date` lets a scenario place the issuance
+// before or after the transaction under validation to exercise the existence
+// check's layered diagnostics.
 const issuanceRecord = (security_id: string, date = "2020-01-01") => ({
   id: `wi-${security_id}`,
   object_type: "TX_WARRANT_ISSUANCE",
@@ -92,7 +93,7 @@ describe("warrant issuance validity", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Acceptance: issuance-exists, date-order, no-retraction
+// Acceptance: issuance-exists, no-retraction
 // ---------------------------------------------------------------------------
 
 describe("warrant acceptance validity", () => {
@@ -105,7 +106,7 @@ describe("warrant acceptance validity", () => {
   });
   const subject = { object_type: "TX_WARRANT_ACCEPTANCE", id: "acc1" };
 
-  it("returns no findings when the issuance exists, dates order, and no retraction references it", () => {
+  it("returns no findings when the issuance is outstanding and no retraction references it", () => {
     const context = contextWith({
       warrantIssuances: [issuanceRecord("sec1")] as any,
       transactions: [issuanceRecord("sec1")],
@@ -129,34 +130,13 @@ describe("warrant acceptance validity", () => {
     expect(snapshot.context.findings).toEqual([]);
   });
 
-  it("flags a missing issuance with an error naming the security_id", () => {
-    // In the package history (date-order passes) but not the live collection.
-    const context = contextWith({ transactions: [issuanceRecord("sec1")] });
-    const findings = runValidator("TX_WARRANT_ACCEPTANCE", context, acceptance());
-    expect(findings).toHaveLength(1);
-    expectFindingShape(findings[0], "issuance-exists", subject);
-    expect(findings[0].message).toContain("sec1");
-  });
-
-  it("flags an out-of-order date with an error naming the security_id", () => {
-    // Issuance is live (issuance-exists passes) but dated after the acceptance.
-    const context = contextWith({
-      warrantIssuances: [issuanceRecord("sec1", "2022-01-01")] as any,
-      transactions: [issuanceRecord("sec1", "2022-01-01")],
-    });
-    const findings = runValidator("TX_WARRANT_ACCEPTANCE", context, acceptance());
-    expect(findings).toHaveLength(1);
-    expectFindingShape(findings[0], "date-order", subject);
-    expect(findings[0].message).toContain("sec1");
-  });
-
-  it("emits one no-retraction finding per offending retraction, each naming that retraction", () => {
+  it("emits one no-retraction finding per past offending retraction, each naming that retraction", () => {
     const context = contextWith({
       warrantIssuances: [issuanceRecord("sec1")] as any,
       transactions: [
         issuanceRecord("sec1"),
-        { id: "ret-a", object_type: "TX_WARRANT_RETRACTION", security_id: "sec1", date: "2021-06-01" },
-        { id: "ret-b", object_type: "TX_WARRANT_RETRACTION", security_id: "sec1", date: "2021-07-01" },
+        { id: "ret-a", object_type: "TX_WARRANT_RETRACTION", security_id: "sec1", date: "2020-06-01" },
+        { id: "ret-b", object_type: "TX_WARRANT_RETRACTION", security_id: "sec1", date: "2020-07-01" },
       ],
     });
     const findings = runValidator("TX_WARRANT_ACCEPTANCE", context, acceptance());
@@ -168,7 +148,7 @@ describe("warrant acceptance validity", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Retraction: issuance-exists, date-order, no-acceptance
+// Retraction: issuance-exists, no-acceptance
 // ---------------------------------------------------------------------------
 
 describe("warrant retraction validity", () => {
@@ -181,7 +161,7 @@ describe("warrant retraction validity", () => {
   });
   const subject = { object_type: "TX_WARRANT_RETRACTION", id: "ret1" };
 
-  it("returns no findings when the issuance exists, dates order, and no acceptance references it", () => {
+  it("returns no findings when the issuance is outstanding and no acceptance references it", () => {
     const context = contextWith({
       warrantIssuances: [issuanceRecord("sec1")] as any,
       transactions: [issuanceRecord("sec1")],
@@ -204,32 +184,13 @@ describe("warrant retraction validity", () => {
     expect(snapshot.context.findings).toEqual([]);
   });
 
-  it("flags a missing issuance with an error naming the security_id", () => {
-    const context = contextWith({ transactions: [issuanceRecord("sec1")] });
-    const findings = runValidator("TX_WARRANT_RETRACTION", context, retraction());
-    expect(findings).toHaveLength(1);
-    expectFindingShape(findings[0], "issuance-exists", subject);
-    expect(findings[0].message).toContain("sec1");
-  });
-
-  it("flags an out-of-order date with an error naming the security_id", () => {
-    const context = contextWith({
-      warrantIssuances: [issuanceRecord("sec1", "2022-01-01")] as any,
-      transactions: [issuanceRecord("sec1", "2022-01-01")],
-    });
-    const findings = runValidator("TX_WARRANT_RETRACTION", context, retraction());
-    expect(findings).toHaveLength(1);
-    expectFindingShape(findings[0], "date-order", subject);
-    expect(findings[0].message).toContain("sec1");
-  });
-
-  it("emits one no-acceptance finding per offending acceptance, each naming that acceptance", () => {
+  it("emits one no-acceptance finding per past offending acceptance, each naming that acceptance", () => {
     const context = contextWith({
       warrantIssuances: [issuanceRecord("sec1")] as any,
       transactions: [
         issuanceRecord("sec1"),
-        { id: "acc-a", object_type: "TX_WARRANT_ACCEPTANCE", security_id: "sec1", date: "2021-06-01" },
-        { id: "acc-b", object_type: "TX_WARRANT_ACCEPTANCE", security_id: "sec1", date: "2021-07-01" },
+        { id: "acc-a", object_type: "TX_WARRANT_ACCEPTANCE", security_id: "sec1", date: "2020-06-01" },
+        { id: "acc-b", object_type: "TX_WARRANT_ACCEPTANCE", security_id: "sec1", date: "2020-07-01" },
       ],
     });
     const findings = runValidator("TX_WARRANT_RETRACTION", context, retraction());
@@ -241,7 +202,7 @@ describe("warrant retraction validity", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Cancellation: issuance-exists, date-order, no-other-transactions
+// Cancellation: issuance-exists, no-other-transactions
 // ---------------------------------------------------------------------------
 
 describe("warrant cancellation validity", () => {
@@ -253,7 +214,7 @@ describe("warrant cancellation validity", () => {
     ...overrides,
   });
   const cancellationRecord = { id: "can1", object_type: "TX_WARRANT_CANCELLATION", security_id: "sec1", date: "2021-01-01" };
-  const acceptanceRecord = { id: "acc-x", object_type: "TX_WARRANT_ACCEPTANCE", security_id: "sec1", date: "2021-02-01" };
+  const acceptanceRecord = { id: "acc-x", object_type: "TX_WARRANT_ACCEPTANCE", security_id: "sec1", date: "2020-02-01" };
   const subject = { object_type: "TX_WARRANT_CANCELLATION", id: "can1" };
 
   it("returns no findings when only an issuance, a warrant acceptance, and the cancellation itself reference the security", () => {
@@ -288,34 +249,15 @@ describe("warrant cancellation validity", () => {
     expect(snapshot.context.warrantIssuances.some((w: any) => w.security_id === "sec2")).toBe(true);
   });
 
-  it("flags a missing issuance with an error naming the security_id", () => {
-    const context = contextWith({ transactions: [issuanceRecord("sec1")] });
-    const findings = runValidator("TX_WARRANT_CANCELLATION", context, cancellation());
-    expect(findings).toHaveLength(1);
-    expectFindingShape(findings[0], "issuance-exists", subject);
-    expect(findings[0].message).toContain("sec1");
-  });
-
-  it("flags an out-of-order date with an error naming the security_id", () => {
-    const context = contextWith({
-      warrantIssuances: [issuanceRecord("sec1", "2022-01-01")] as any,
-      transactions: [issuanceRecord("sec1", "2022-01-01")],
-    });
-    const findings = runValidator("TX_WARRANT_CANCELLATION", context, cancellation());
-    expect(findings).toHaveLength(1);
-    expectFindingShape(findings[0], "date-order", subject);
-    expect(findings[0].message).toContain("sec1");
-  });
-
-  it("emits one no-other-transactions finding per offender, exempting acceptances and itself", () => {
+  it("emits one no-other-transactions finding per past offender, exempting acceptances and itself", () => {
     const context = contextWith({
       warrantIssuances: [issuanceRecord("sec1")] as any,
       transactions: [
         issuanceRecord("sec1"),
         acceptanceRecord,
         cancellationRecord,
-        { id: "xfer-a", object_type: "TX_WARRANT_TRANSFER", security_id: "sec1", date: "2021-06-01" },
-        { id: "xfer-b", object_type: "TX_WARRANT_TRANSFER", security_id: "sec1", date: "2021-07-01" },
+        { id: "xfer-a", object_type: "TX_WARRANT_TRANSFER", security_id: "sec1", date: "2020-06-01" },
+        { id: "xfer-b", object_type: "TX_WARRANT_TRANSFER", security_id: "sec1", date: "2020-07-01" },
       ],
     });
     const findings = runValidator("TX_WARRANT_CANCELLATION", context, cancellation());
@@ -330,7 +272,7 @@ describe("warrant cancellation validity", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Transfer: issuance-exists, date-order (no-other-transactions is a declared gap)
+// Transfer: issuance-exists (no-other-transactions is a declared gap)
 // ---------------------------------------------------------------------------
 
 describe("warrant transfer validity", () => {
@@ -341,9 +283,8 @@ describe("warrant transfer validity", () => {
     date: "2021-01-01",
     ...overrides,
   });
-  const subject = { object_type: "TX_WARRANT_TRANSFER", id: "xfer1" };
 
-  it("returns no findings when the issuance exists and dates order", () => {
+  it("returns no findings when the issuance is outstanding", () => {
     const context = contextWith({
       warrantIssuances: [issuanceRecord("sec1")] as any,
       transactions: [issuanceRecord("sec1")],
@@ -365,38 +306,170 @@ describe("warrant transfer validity", () => {
     expect(snapshot.context.warrantIssuances.some((w: any) => w.security_id === "sec2")).toBe(true);
   });
 
-  it("flags a missing issuance with an error naming the security_id", () => {
-    const context = contextWith({ transactions: [issuanceRecord("sec1")] });
-    const findings = runValidator("TX_WARRANT_TRANSFER", context, transfer());
-    expect(findings).toHaveLength(1);
-    expectFindingShape(findings[0], "issuance-exists", subject);
-    expect(findings[0].message).toContain("sec1");
-  });
-
-  it("flags an out-of-order date with an error naming the security_id", () => {
-    const context = contextWith({
-      warrantIssuances: [issuanceRecord("sec1", "2022-01-01")] as any,
-      transactions: [issuanceRecord("sec1", "2022-01-01")],
-    });
-    const findings = runValidator("TX_WARRANT_TRANSFER", context, transfer());
-    expect(findings).toHaveLength(1);
-    expectFindingShape(findings[0], "date-order", subject);
-    expect(findings[0].message).toContain("sec1");
-  });
-
-  it("never emits no-other-transactions, even when other transactions reference the security", () => {
+  it("never emits no-other-transactions, even when a past transaction references the security", () => {
     const context = contextWith({
       warrantIssuances: [issuanceRecord("sec1")] as any,
       transactions: [
         issuanceRecord("sec1"),
-        { id: "ret-x", object_type: "TX_WARRANT_RETRACTION", security_id: "sec1", date: "2021-06-01" },
-        { id: "can-x", object_type: "TX_WARRANT_CANCELLATION", security_id: "sec1", date: "2021-07-01" },
+        { id: "ret-x", object_type: "TX_WARRANT_RETRACTION", security_id: "sec1", date: "2020-06-01" },
+        { id: "can-x", object_type: "TX_WARRANT_CANCELLATION", security_id: "sec1", date: "2020-07-01" },
       ],
     });
     const findings = runValidator("TX_WARRANT_TRANSFER", context, transfer());
     // The declared gap is never checked, so the transaction stays valid here.
     expect(findings).toEqual([]);
     expect(findings.some((f) => f.check === "no-other-transactions")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Existence check: layered failure diagnostics
+// ---------------------------------------------------------------------------
+
+describe("issuance-exists reports why the referenced issuance is unavailable", () => {
+  const acceptance = { id: "acc1", object_type: "TX_WARRANT_ACCEPTANCE", security_id: "sec1", date: "2021-01-01" };
+  const subject = { object_type: "TX_WARRANT_ACCEPTANCE", id: "acc1" };
+
+  // Every scenario keeps the live collection empty so the existence check fails and
+  // takes the history-scanning path; the message names one of the three causes.
+  const expectSoleCause = (context: OcfMachineContext, message: string) => {
+    const findings = runValidator("TX_WARRANT_ACCEPTANCE", context, acceptance);
+    expect(findings).toHaveLength(1);
+    expectFindingShape(findings[0], "issuance-exists", subject);
+    expect(findings[0].message).toBe(message);
+    expect(findings.some((f) => f.check === "date-order")).toBe(false);
+  };
+
+  it("names a security that was never issued in the package", () => {
+    expectSoleCause(
+      contextWith({ transactions: [] }),
+      "No warrant issuance with security_id sec1 appears in the package.",
+    );
+  });
+
+  it("names an issuance dated after the transaction", () => {
+    expectSoleCause(
+      contextWith({ transactions: [issuanceRecord("sec1", "2022-01-01")] }),
+      "The warrant issuance referenced by security_id sec1 is dated 2022-01-01, after this transaction (2021-01-01).",
+    );
+  });
+
+  it("reports an issuance issued on or before the transaction but no longer outstanding", () => {
+    expectSoleCause(
+      contextWith({ transactions: [issuanceRecord("sec1", "2020-01-01")] }),
+      "The warrant issuance referenced by security_id sec1 (dated 2020-01-01) is not outstanding as of this transaction's date.",
+    );
+  });
+
+  it("displays the on-or-before issuance's date when the history holds both an earlier and a later match", () => {
+    expectSoleCause(
+      contextWith({ transactions: [issuanceRecord("sec1", "2020-01-01"), issuanceRecord("sec1", "2022-01-01")] }),
+      "The warrant issuance referenced by security_id sec1 (dated 2020-01-01) is not outstanding as of this transaction's date.",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Offender scans: past-only
+// ---------------------------------------------------------------------------
+
+describe("offender scans consider only offenders dated on or before the transaction", () => {
+  // Each implemented scan judged at the date boundary: the transaction under
+  // validation is dated 2021-06-01, with the referenced issuance already live so
+  // the existence check passes and only the scan under test can emit.
+  const TX_DATE = "2021-06-01";
+  const scans = [
+    { scan: "no-retraction", txType: "TX_WARRANT_ACCEPTANCE", txId: "acc1", offenderType: "TX_WARRANT_RETRACTION", offenderId: "ret1" },
+    { scan: "no-acceptance", txType: "TX_WARRANT_RETRACTION", txId: "ret1", offenderType: "TX_WARRANT_ACCEPTANCE", offenderId: "acc1" },
+    { scan: "no-other-transactions", txType: "TX_WARRANT_CANCELLATION", txId: "can1", offenderType: "TX_WARRANT_TRANSFER", offenderId: "xfer1" },
+  ] as const;
+
+  it.each(scans)("$scan flags a same-day or earlier offender but ignores a later one", ({ scan, txType, txId, offenderType, offenderId }) => {
+    const tx = { id: txId, object_type: txType, security_id: "sec1", date: TX_DATE };
+    const emitsAt = (offenderDate: string) => {
+      const context = contextWith({
+        warrantIssuances: [issuanceRecord("sec1")] as any,
+        transactions: [
+          issuanceRecord("sec1"),
+          { id: offenderId, object_type: offenderType, security_id: "sec1", date: offenderDate },
+        ],
+      });
+      return runValidator(txType, context, tx).some((f) => f.check === scan);
+    };
+
+    expect(emitsAt("2021-12-01")).toBe(false);
+    expect(emitsAt(TX_DATE)).toBe(true);
+    expect(emitsAt("2021-01-01")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Conflicting transactions: the later one carries the error
+// ---------------------------------------------------------------------------
+
+describe("a conflicting transaction pair flags the later transaction, not the earlier", () => {
+  const issuance = { id: "wi1", object_type: "TX_WARRANT_ISSUANCE", security_id: "sec1", date: "2020-01-01" };
+
+  it("clears an acceptance and flags a later retraction by its backward scan", () => {
+    const acceptance = { id: "acc1", object_type: "TX_WARRANT_ACCEPTANCE", security_id: "sec1", date: "2020-02-01" };
+    const retraction = { id: "ret1", object_type: "TX_WARRANT_RETRACTION", security_id: "sec1", date: "2020-03-01" };
+
+    const actor = startSeeded(
+      contextWith({
+        warrantIssuances: [issuance] as any,
+        transactions: [issuance, acceptance, retraction],
+      }),
+    );
+
+    actor.send(ev("TX_WARRANT_ACCEPTANCE", acceptance));
+    expect(actor.getSnapshot().value).toBe("capTable");
+    expect(actor.getSnapshot().context.findings).toEqual([]);
+
+    actor.send(ev("TX_WARRANT_RETRACTION", retraction));
+    const { context, value } = actor.getSnapshot();
+    expect(value).toBe("validationError");
+
+    const errors = context.findings.filter((f) => f.severity === "error");
+    expect(errors).toHaveLength(1);
+    expect(errors[0].check).toBe("no-acceptance");
+    for (const finding of context.findings) {
+      expect(finding.subject).toEqual({ object_type: "TX_WARRANT_RETRACTION", id: "ret1" });
+    }
+    expect(context.findings.some((f) => f.subject.id === "acc1")).toBe(false);
+  });
+
+  it("clears a retraction that removes the issuance and then flags the later acceptance by both checks", () => {
+    const retraction = { id: "ret1", object_type: "TX_WARRANT_RETRACTION", security_id: "sec1", date: "2020-02-01" };
+    const acceptance = { id: "acc1", object_type: "TX_WARRANT_ACCEPTANCE", security_id: "sec1", date: "2020-03-01" };
+
+    const actor = startSeeded(
+      contextWith({
+        warrantIssuances: [issuance] as any,
+        transactions: [issuance, retraction, acceptance],
+      }),
+    );
+
+    actor.send(ev("TX_WARRANT_RETRACTION", retraction));
+    const afterRetraction = actor.getSnapshot();
+    expect(afterRetraction.value).toBe("capTable");
+    expect(afterRetraction.context.findings).toEqual([]);
+    // The retraction removed the issuance from the live collection.
+    expect(afterRetraction.context.warrantIssuances.some((w: any) => w.security_id === "sec1")).toBe(false);
+
+    actor.send(ev("TX_WARRANT_ACCEPTANCE", acceptance));
+    const { context, value } = actor.getSnapshot();
+    expect(value).toBe("validationError");
+
+    const errors = context.findings.filter((f) => f.severity === "error");
+    expect(errors.map((f) => f.check).sort()).toEqual(["issuance-exists", "no-retraction"]);
+    const existence = errors.find((f) => f.check === "issuance-exists");
+    expect(existence?.message).toBe(
+      "The warrant issuance referenced by security_id sec1 (dated 2020-01-01) is not outstanding as of this transaction's date.",
+    );
+    for (const finding of context.findings) {
+      expect(finding.subject).toEqual({ object_type: "TX_WARRANT_ACCEPTANCE", id: "acc1" });
+    }
+    expect(context.findings.some((f) => f.subject.id === "ret1")).toBe(false);
   });
 });
 
@@ -426,22 +499,18 @@ const failingScenarios: Record<MigratedKey, { context: OcfMachineContext; data: 
   ],
   TX_WARRANT_ACCEPTANCE: [
     { context: contextWith({ transactions: [issuanceRecord("sec1")] }), data: txRecord("TX_WARRANT_ACCEPTANCE", "a1", "sec1", "2021-01-01") },
-    { context: contextWith({ warrantIssuances: [issuanceRecord("sec1", "2022-01-01")] as any, transactions: [issuanceRecord("sec1", "2022-01-01")] }), data: txRecord("TX_WARRANT_ACCEPTANCE", "a1", "sec1", "2021-01-01") },
-    { context: contextWith({ warrantIssuances: [issuanceRecord("sec1")] as any, transactions: [issuanceRecord("sec1"), txRecord("TX_WARRANT_RETRACTION", "r1")] }), data: txRecord("TX_WARRANT_ACCEPTANCE", "a1", "sec1", "2021-01-01") },
+    { context: contextWith({ warrantIssuances: [issuanceRecord("sec1")] as any, transactions: [issuanceRecord("sec1"), txRecord("TX_WARRANT_RETRACTION", "r1", "sec1", "2020-06-01")] }), data: txRecord("TX_WARRANT_ACCEPTANCE", "a1", "sec1", "2021-01-01") },
   ],
   TX_WARRANT_RETRACTION: [
     { context: contextWith({ transactions: [issuanceRecord("sec1")] }), data: txRecord("TX_WARRANT_RETRACTION", "r1", "sec1", "2021-01-01") },
-    { context: contextWith({ warrantIssuances: [issuanceRecord("sec1", "2022-01-01")] as any, transactions: [issuanceRecord("sec1", "2022-01-01")] }), data: txRecord("TX_WARRANT_RETRACTION", "r1", "sec1", "2021-01-01") },
-    { context: contextWith({ warrantIssuances: [issuanceRecord("sec1")] as any, transactions: [issuanceRecord("sec1"), txRecord("TX_WARRANT_ACCEPTANCE", "a1")] }), data: txRecord("TX_WARRANT_RETRACTION", "r1", "sec1", "2021-01-01") },
+    { context: contextWith({ warrantIssuances: [issuanceRecord("sec1")] as any, transactions: [issuanceRecord("sec1"), txRecord("TX_WARRANT_ACCEPTANCE", "a1", "sec1", "2020-06-01")] }), data: txRecord("TX_WARRANT_RETRACTION", "r1", "sec1", "2021-01-01") },
   ],
   TX_WARRANT_CANCELLATION: [
     { context: contextWith({ transactions: [issuanceRecord("sec1")] }), data: txRecord("TX_WARRANT_CANCELLATION", "c1", "sec1", "2021-01-01") },
-    { context: contextWith({ warrantIssuances: [issuanceRecord("sec1", "2022-01-01")] as any, transactions: [issuanceRecord("sec1", "2022-01-01")] }), data: txRecord("TX_WARRANT_CANCELLATION", "c1", "sec1", "2021-01-01") },
-    { context: contextWith({ warrantIssuances: [issuanceRecord("sec1")] as any, transactions: [issuanceRecord("sec1"), txRecord("TX_WARRANT_TRANSFER", "x1")] }), data: txRecord("TX_WARRANT_CANCELLATION", "c1", "sec1", "2021-01-01") },
+    { context: contextWith({ warrantIssuances: [issuanceRecord("sec1")] as any, transactions: [issuanceRecord("sec1"), txRecord("TX_WARRANT_TRANSFER", "x1", "sec1", "2020-06-01")] }), data: txRecord("TX_WARRANT_CANCELLATION", "c1", "sec1", "2021-01-01") },
   ],
   TX_WARRANT_TRANSFER: [
     { context: contextWith({ transactions: [issuanceRecord("sec1")] }), data: txRecord("TX_WARRANT_TRANSFER", "x1", "sec1", "2021-01-01") },
-    { context: contextWith({ warrantIssuances: [issuanceRecord("sec1", "2022-01-01")] as any, transactions: [issuanceRecord("sec1", "2022-01-01")] }), data: txRecord("TX_WARRANT_TRANSFER", "x1", "sec1", "2021-01-01") },
   ],
 };
 

--- a/tests/warrantValidators.test.ts
+++ b/tests/warrantValidators.test.ts
@@ -1,22 +1,15 @@
 import { describe, it, expect } from "vitest";
 import { TX_DESCRIPTORS } from "../ocf_validator/ocfMachine";
-import type { Finding } from "../types/finding";
-import type { GradedValidator, OcfMachineContext } from "../types/validator";
-import { baseContext, startSeeded, ev } from "./helpers";
-
-/** A context whose package `transactions` list is `transactions`. */
-const contextWith = (
-  overrides: Partial<OcfMachineContext> & { transactions?: any[] } = {},
-): OcfMachineContext => {
-  const { transactions = [], ...rest } = overrides;
-  return baseContext({
-    ...rest,
-    ocfPackageContent: {
-      ...baseContext().ocfPackageContent,
-      transactions,
-    } as OcfMachineContext["ocfPackageContent"],
-  });
-};
+import type { OcfMachineContext } from "../types/validator";
+import {
+  baseContext,
+  startSeeded,
+  ev,
+  contextWith,
+  runValidator,
+  implementedCheckIds,
+  expectFindingShape,
+} from "./helpers";
 
 const MIGRATED_KEYS = [
   "TX_WARRANT_ISSUANCE",
@@ -26,34 +19,6 @@ const MIGRATED_KEYS = [
   "TX_WARRANT_TRANSFER",
 ] as const;
 type MigratedKey = (typeof MIGRATED_KEYS)[number];
-
-/** Invoke the graded validator a migrated descriptor carries. */
-const runValidator = (
-  key: MigratedKey,
-  context: OcfMachineContext,
-  data: Record<string, unknown>,
-): Finding[] => {
-  const descriptor = TX_DESCRIPTORS[key] as { validate?: GradedValidator<any> };
-  if (!descriptor.validate) throw new Error(`${key} carries no graded validate`);
-  return descriptor.validate(context, data);
-};
-
-/** The check ids a descriptor declares as implemented (drops `implemented: false`). */
-const implementedCheckIds = (key: MigratedKey): string[] => {
-  const descriptor = TX_DESCRIPTORS[key] as { checks?: readonly { id: string; implemented?: false }[] };
-  return (descriptor.checks ?? []).filter((c) => c.implemented !== false).map((c) => c.id);
-};
-
-/** Assert a finding carries the declared id, error severity, and the transaction as subject. */
-const expectFindingShape = (
-  finding: Finding,
-  check: string,
-  subject: { object_type: string; id: string },
-) => {
-  expect(finding.check).toBe(check);
-  expect(finding.severity).toBe("error");
-  expect(finding.subject).toEqual(subject);
-};
 
 // A single warrant issuance, in the shape both the live collection and the
 // package transaction history hold it. `date` lets a scenario push the issuance


### PR DESCRIPTION
Closes #198.

This lands the two semantics decisions recorded on #198, in both migrated families. It is the one PR in the migration series that deliberately changes validator output; the family ports (#199, #200) and the declarative restructuring (#201) were behavior-preserving by design.

## What changes

1. **One existence check with layered diagnostics.** `issuance-exists` still passes or fails on the live cap-table state, but a failure now explains itself by consulting the package history: the referenced issuance never appears in the package, or it is dated after the transaction that references it, or it was issued on time but is no longer outstanding. The separate `date-order` check retires: the machine processes transactions chronologically, so it could only fail when the existence check also failed, and its whole value was diagnostic. A bad reference now produces one informative finding instead of two overlapping ones.

2. **Offender scans only look backward.** `no-retraction`, `no-acceptance`, and `no-other-transactions` now consider only transactions dated on or before the one under validation (same-day included). An acceptance no longer fails because of a retraction dated months later; instead the later transaction of a conflicting pair carries the error, either through its own backward scan or because the earlier transaction already removed the issuance. For a same-day pair, the driver's fixed type order decides which one is flagged.

**Which packages pass or fail does not change.** For the first change that is immediate (`date-order` was redundant with existence). For the second, the argument recorded on #198 holds: each conflicting pair is still flagged, just on the later transaction. What changes is which transaction the error names, what the message says, and where validation halts.

Also in this PR, since it edits the test suites anyway: a guard test pinning the machine invariant that family collections only ever hold issuance records (the fact that justifies the bare `security_id` lookup adopted in #201), and the four family-agnostic test helpers move into `tests/helpers.ts` (first commit, behavior-neutral).

One residual worth knowing when reading output: a transaction that references a removed issuance can carry two findings, "not outstanding" plus the backward scan naming the past conflict. Both are accurate; they describe two aspects of the same story.

CI: build and 136 tests green; the characterization snapshot is byte-identical (the fixture package contains no convertible or warrant transactions).
