### PR TITLE
Migrate the convertible conversion validator to the declarative check form

### DIFF
--- a/ocf_validator/ocfMachine.ts
+++ b/ocf_validator/ocfMachine.ts
@@ -16,6 +16,7 @@ import { TX_CONVERTIBLE_ACCEPTANCE } from "./validators/convertible/tx_convertib
 import { TX_CONVERTIBLE_RETRACTION } from "./validators/convertible/tx_convertible_retraction";
 import { TX_CONVERTIBLE_CANCELLATION } from "./validators/convertible/tx_convertible_cancellation";
 import { TX_CONVERTIBLE_TRANSFER } from "./validators/convertible/tx_convertible_transfer";
+import { TX_CONVERTIBLE_CONVERSION } from "./validators/convertible/tx_convertible_conversion";
 import { TX_WARRANT_ISSUANCE } from "./validators/warrant/tx_warrant_issuance";
 import { TX_WARRANT_ACCEPTANCE } from "./validators/warrant/tx_warrant_acceptance";
 import { TX_WARRANT_RETRACTION } from "./validators/warrant/tx_warrant_retraction";
@@ -196,7 +197,7 @@ export const TX_DESCRIPTORS = {
   TX_CONVERTIBLE_RETRACTION,
   TX_CONVERTIBLE_CANCELLATION,
   TX_CONVERTIBLE_TRANSFER,
-  TX_CONVERTIBLE_CONVERSION: { effect: "remove", collection: "convertibleIssuances", legacyValidate: validators.valid_tx_convertible_conversion },
+  TX_CONVERTIBLE_CONVERSION,
   TX_WARRANT_RETRACTION,
   TX_WARRANT_CANCELLATION,
   TX_WARRANT_TRANSFER,

--- a/ocf_validator/validators/convertible/checks.ts
+++ b/ocf_validator/validators/convertible/checks.ts
@@ -59,3 +59,38 @@ export const issuanceExists = {
     return messages;
   },
 } satisfies CheckObject;
+
+/**
+ * No other transaction dated on or before this transaction references its
+ * security_id, other than a convertible acceptance. One finding per offending
+ * transaction. The scan keeps every transaction type in play, so it narrows by
+ * property presence rather than by discriminant: a transaction carrying no
+ * security_id can never reference this one. The transaction under validation
+ * appears in its own history, so it is exempted by id.
+ */
+export const noOtherTransactions = {
+  id: "no-other-transactions",
+  severity: "error",
+  description:
+    "No other transaction dated on or before this transaction references its security_id, other than a convertible acceptance.",
+  run: (context, data: { id: string; security_id: string; date: string }) => {
+    const messages: string[] = [];
+
+    context.ocfPackageContent.transactions.forEach((ele) => {
+      if (
+        "security_id" in ele &&
+        ele.security_id === data.security_id &&
+        ele.date <= data.date &&
+        ele.object_type !== "TX_CONVERTIBLE_ISSUANCE" &&
+        ele.object_type !== "TX_CONVERTIBLE_ACCEPTANCE" &&
+        ele.id !== data.id
+      ) {
+        messages.push(
+          `Another transaction (${ele.id}) references the transaction's security_id.`,
+        );
+      }
+    });
+
+    return messages;
+  },
+} satisfies CheckObject;

--- a/ocf_validator/validators/convertible/tx_convertible_cancellation.ts
+++ b/ocf_validator/validators/convertible/tx_convertible_cancellation.ts
@@ -1,38 +1,5 @@
-import { defineValidator, type CheckObject } from "../checkKit";
-import { issuanceExists } from "./checks";
-
-const noOtherTransactions = {
-  id: "no-other-transactions",
-  severity: "error",
-  description:
-    "No other transaction dated on or before this transaction references its security_id, other than a convertible acceptance.",
-  run: (context, data: { id: string; security_id: string; date: string }) => {
-    const messages: string[] = [];
-    const { transactions } = context.ocfPackageContent;
-
-    // no-other-transactions emits one finding per transaction on this security_id
-    // dated on or before this cancellation, exempting the issuance, any convertible
-    // acceptance, and this cancellation itself. This scan keeps every transaction
-    // type in play, so it narrows by property presence rather than by discriminant:
-    // a transaction that carries no security_id can never reference this one.
-    transactions.forEach((ele) => {
-      if (
-        "security_id" in ele &&
-        ele.security_id === data.security_id &&
-        ele.date <= data.date &&
-        ele.object_type !== "TX_CONVERTIBLE_ISSUANCE" &&
-        ele.object_type !== "TX_CONVERTIBLE_ACCEPTANCE" &&
-        !(ele.object_type === "TX_CONVERTIBLE_CANCELLATION" && ele.id === data.id)
-      ) {
-        messages.push(
-          `Another transaction (${ele.id}) references the transaction's security_id.`,
-        );
-      }
-    });
-
-    return messages;
-  },
-} satisfies CheckObject;
+import { defineValidator } from "../checkKit";
+import { issuanceExists, noOtherTransactions } from "./checks";
 
 export const TX_CONVERTIBLE_CANCELLATION = defineValidator({
   transaction: "TX_CONVERTIBLE_CANCELLATION",

--- a/ocf_validator/validators/convertible/tx_convertible_conversion.ts
+++ b/ocf_validator/validators/convertible/tx_convertible_conversion.ts
@@ -1,127 +1,177 @@
-import { OcfMachineContext } from "../../ocfMachine";
+import type { OCFStockIssuance } from "@opencaptablecoalition/ocf-types";
+import type { DeepReadonly, OcfMachineContext } from "../../../types/validator";
+import { defineValidator, type CheckObject } from "../checkKit";
+import { issuanceExists } from "./checks";
 
-/*
-CURRENT CHECKS:
-Check that convertible issuance in incoming security_id referenced by transaction exists in current state.
-The date of the convertible issuance referred to in the security_id must have a date equal to or earlier than the date of the convertible conversion
-Any stock issuances with corresponding security IDs referred to in the resulting_security_ids array must exist
-The security_id of the convertible issuance referred to in the security_id variable must not be the security_id related to any other transactions with the exception of a convertible acceptance transaction.
-The dates of any convertible issuances referred to in the resulting_security_ids variables must have a date equal to the date of the convertible conversion
-The stakeholder_id of the convertible issuance referred to in the security_id variable must equal the stakeholder_id of any stock issuances referred to in the resulting_security_ids variable
+// A convertible's conversion right can only point at a stock class, so every id
+// in resulting_security_ids names a stock issuance. The three resulting checks
+// locate those issuances in the package transaction history, dated the same day
+// as the conversion, so the result does not depend on the order the driver
+// processes same-day transactions in.
 
-NOT IMPLEMENTED:
-The quantity_converted variable must equal the sum of any convertible issuances referred to in the resulting_security_ids variable
-*/
+// The stock issuance a resulting id names: the first TX_STOCK_ISSUANCE in
+// package order matching the id, so each resulting check makes one comparison
+// per id even when an id matches more than one issuance.
+const resultingStockIssuance = (
+  context: DeepReadonly<OcfMachineContext>,
+  resultingId: string,
+): DeepReadonly<OCFStockIssuance> | undefined =>
+  context.ocfPackageContent.transactions.find(
+    (ele): ele is DeepReadonly<OCFStockIssuance> =>
+      ele.object_type === "TX_STOCK_ISSUANCE" && ele.security_id === resultingId,
+  );
 
-const valid_tx_convertible_conversion = (context: OcfMachineContext, event: any, isGuard: Boolean) => {
-  let validity = false;
-  const { transactions } = context.ocfPackageContent;
-  let report: any = { transaction_type: "TX_CONVERTIBLE_CONVERSION", transaction_id: event.data.id, transaction_date: event.data.date };
+const noOtherTransactions = {
+  id: "no-other-transactions",
+  severity: "error",
+  description:
+    "No other transaction dated on or before this transaction references its security_id, other than a convertible acceptance.",
+  run: (context, data: { id: string; security_id: string; date: string }) => {
+    const messages: string[] = [];
+    const { transactions } = context.ocfPackageContent;
 
-  // Check that convertible issuance in incoming security_id referenced by transaction exists in current state.
-  let incoming_convertibleIssuance_validity = false;
-  let incoming_stakeholder = "";
-  context.convertibleIssuances.forEach((ele: any) => {
-    if (ele.security_id === event.data.security_id && ele.object_type === "TX_CONVERTIBLE_ISSUANCE") {
-      incoming_convertibleIssuance_validity = true;
-      report.incoming_convertibleIssuance_validity = true;
-    }
-  });
-  if (!incoming_convertibleIssuance_validity) {
-    report.incoming_convertibleIssuance_validity = false;
-  }
-
-  // The date of the convertible issuance referred to in the security_id must have a date equal to or earlier than the date of the convertible conversion
-  let incoming_date_validity = false;
-  transactions.forEach((ele: any) => {
-    if (ele.security_id === event.data.security_id && ele.object_type === "TX_CONVERTIBLE_ISSUANCE") {
-      if (ele.date <= event.data.date) {
-        incoming_date_validity = true;
-        report.incoming_date_validity = true;
-      }
-    }
-  });
-  if (!incoming_date_validity) {
-    report.incoming_date_validity = false;
-  }
-
-  // Any stock issuances with corresponding security IDs referred to in the resulting_security_ids array must exist
-  let resulting_stockIssuances_validity = false;
-  for (let i = 0; i < event.data.resulting_security_ids.length; i++) {
-    const res = event.data.resulting_security_ids[i];
-    resulting_stockIssuances_validity = false;
-    transactions.map((ele: any) => {
-      if (ele.security_id === res && ele.object_type === "TX_STOCK_ISSUANCE") {
-        resulting_stockIssuances_validity = true;
-        report.resulting_convertibleIssuances_validity = true;
+    // One finding per transaction on this security_id dated on or before this
+    // conversion, exempting the issuance, any convertible acceptance, and this
+    // conversion itself. The scan keeps every transaction type in play, so it
+    // narrows by property presence rather than by discriminant: a transaction
+    // carrying no security_id can never reference this one. The conversion
+    // appears in its own history, so the self-exemption is by id, not by type.
+    transactions.forEach((ele) => {
+      if (
+        "security_id" in ele &&
+        ele.security_id === data.security_id &&
+        ele.date <= data.date &&
+        ele.object_type !== "TX_CONVERTIBLE_ISSUANCE" &&
+        ele.object_type !== "TX_CONVERTIBLE_ACCEPTANCE" &&
+        !(ele.object_type === "TX_CONVERTIBLE_CONVERSION" && ele.id === data.id)
+      ) {
+        messages.push(
+          `Another transaction (${ele.id}) references the transaction's security_id.`,
+        );
       }
     });
-    if (!resulting_stockIssuances_validity) {
-      report.resulting_convertibleIssuances_validity = false;
-    }
-  }
 
+    return messages;
+  },
+} satisfies CheckObject;
 
-  // The security_id of the convertible issuance referred to in the security_id variable must not be the security_id related to any other transactions with the exception of a convertible acceptance transaction.
-  let only_transaction_validity = true;
-  transactions.map((ele: any) => {
-    if (ele.security_id === event.data.security_id && ele.object_type !== "TX_CONVERTIBLE_ISSUANCE" && ele.object_type !== "TX_CONVERTIBLE_ACCEPTANCE" && !(ele.object_type === "TX_CONVERTIBLE_CONVERSION" && ele.id === event.data.id)) {
-      only_transaction_validity = false;
-      report.only_transaction_validity = false;
-    }
-  });
-  if (only_transaction_validity) {
-    report.only_transaction_validity = true;
-  }
+const resultingSecurityNamed = {
+  id: "resulting-security-named",
+  severity: "warning",
+  description: "The conversion names at least one resulting security.",
+  run: (_context, data: { resulting_security_ids: string[] }) => {
+    if (data.resulting_security_ids.length > 0) return [];
+    return ["The conversion names no resulting security."];
+  },
+} satisfies CheckObject;
 
-  // The dates of any convertible issuances referred to in the resulting_security_ids must have a date equal to the date of the convertible conversion
-  let resulting_dates_validity = false;
-  for (let i = 0; i < event.data.resulting_security_ids.length; i++) {
-    const res = event.data.resulting_security_ids[i];
-    resulting_dates_validity = false;
-    transactions.map((ele: any) => {
-      if (ele.security_id === res && ele.object_type === "TX_CONVERTIBLE_ISSUANCE" && ele.date === event.data.date) {
-        resulting_dates_validity = true;
-        report.resulting_dates_validity = true;
+const resultingStockExists = {
+  id: "resulting-stock-exists",
+  severity: "error",
+  description:
+    "Each resulting security is a stock issuance present in the package.",
+  run: (context, data: { resulting_security_ids: string[] }) => {
+    const messages: string[] = [];
+
+    // One finding per resulting id with no matching stock issuance in history.
+    data.resulting_security_ids.forEach((resultingId) => {
+      if (resultingStockIssuance(context, resultingId) === undefined) {
+        messages.push(
+          `No stock issuance with security_id ${resultingId} appears in the package.`,
+        );
       }
     });
-    if (!resulting_dates_validity) {
-      report.resulting_dates_validity = false;
-    }
-  }
 
+    return messages;
+  },
+} satisfies CheckObject;
 
-  // The stakeholder_id of the convertible issuance referred to in the security_id variable must equal the stakeholder_id of any convertible issuances referred to in the resulting_security_ids variable
-  let resulting_stakeholder_validity = false;
-  for (let i = 0; i < event.data.resulting_security_ids.length; i++) {
-    const res = event.data.resulting_security_ids[i];
-    resulting_stakeholder_validity = false;
-    transactions.map((ele: any) => {
-      if (ele.security_id === res && ele.object_type === "TX_STOCK_ISSUANCE") {
-        if (ele.stakeholder_id === incoming_stakeholder) {
-          resulting_stakeholder_validity = true;
-          report.resulting_stakeholder_validity = true;
-        }
+const resultingStockDated = {
+  id: "resulting-stock-dated",
+  severity: "error",
+  description:
+    "Each resulting stock issuance is dated the same day as the conversion.",
+  run: (context, data: { resulting_security_ids: string[]; date: string }) => {
+    const messages: string[] = [];
+
+    // Only resulting ids backed by a stock issuance are judged here; a missing
+    // id is solely resulting-stock-exists's concern.
+    data.resulting_security_ids.forEach((resultingId) => {
+      const issuance = resultingStockIssuance(context, resultingId);
+      if (issuance !== undefined && issuance.date !== data.date) {
+        messages.push(
+          `The resulting stock issuance ${resultingId} is dated ${issuance.date}, which differs from the conversion date ${data.date}.`,
+        );
       }
     });
-    if (!resulting_stakeholder_validity) {
-      report.resulting_stakeholder_validity = false;
-    }
-  }
 
-  if (
-    incoming_convertibleIssuance_validity &&
-    incoming_date_validity &&
-    only_transaction_validity &&
-    resulting_dates_validity &&
-    resulting_stakeholder_validity
-  ) {
-    validity = true;
-  }
+    return messages;
+  },
+} satisfies CheckObject;
 
-  const result = isGuard ? validity : report;
+const resultingStockStakeholder = {
+  id: "resulting-stock-stakeholder",
+  severity: "error",
+  description:
+    "Each resulting stock issuance names the stakeholder of the converted convertible issuance.",
+  run: (
+    context,
+    data: { security_id: string; resulting_security_ids: string[] },
+  ) => {
+    const messages: string[] = [];
 
-  return result;
-};
+    // The reference stakeholder comes from the live convertible issuance this
+    // conversion converts — the same record issuance-exists matches. With no live
+    // record, issuance-exists already carries the failure and there is no
+    // reference to compare against, so this check stays silent.
+    const reference = context.convertibleIssuances.find(
+      (ele) => ele.security_id === data.security_id,
+    );
+    if (reference === undefined) return messages;
 
-export default valid_tx_convertible_conversion;
+    // As with the date check, only resulting ids backed by a stock issuance are
+    // judged.
+    data.resulting_security_ids.forEach((resultingId) => {
+      const issuance = resultingStockIssuance(context, resultingId);
+      if (issuance !== undefined && issuance.stakeholder_id !== reference.stakeholder_id) {
+        messages.push(
+          `The resulting stock issuance ${resultingId} names stakeholder ${issuance.stakeholder_id}, which differs from the convertible issuance's stakeholder ${reference.stakeholder_id}.`,
+        );
+      }
+    });
+
+    return messages;
+  },
+} satisfies CheckObject;
+
+// Declared but not implemented: the same metadata with no run, so each reports
+// as a gap and contributes no findings.
+const quantityReconciles = {
+  id: "quantity-reconciles",
+  severity: "error",
+  description:
+    "The quantity converted equals the sum across the resulting securities.",
+} satisfies CheckObject;
+
+const balanceSecurityExists = {
+  id: "balance-security-exists",
+  severity: "error",
+  description:
+    "The balance security, when named, is a convertible issuance present in the package.",
+} satisfies CheckObject;
+
+export const TX_CONVERTIBLE_CONVERSION = defineValidator({
+  transaction: "TX_CONVERTIBLE_CONVERSION",
+  effect: "remove",
+  collection: "convertibleIssuances",
+  checks: [
+    issuanceExists,
+    noOtherTransactions,
+    resultingSecurityNamed,
+    resultingStockExists,
+    resultingStockDated,
+    resultingStockStakeholder,
+    quantityReconciles,
+    balanceSecurityExists,
+  ],
+});

--- a/ocf_validator/validators/convertible/tx_convertible_conversion.ts
+++ b/ocf_validator/validators/convertible/tx_convertible_conversion.ts
@@ -1,7 +1,7 @@
 import type { OCFStockIssuance } from "@opencaptablecoalition/ocf-types";
 import type { DeepReadonly, OcfMachineContext } from "../../../types/validator";
 import { defineValidator, type CheckObject } from "../checkKit";
-import { issuanceExists } from "./checks";
+import { issuanceExists, noOtherTransactions } from "./checks";
 
 // A convertible's conversion right can only point at a stock class, so every id
 // in resulting_security_ids names a stock issuance. The three resulting checks
@@ -20,40 +20,6 @@ const resultingStockIssuance = (
     (ele): ele is DeepReadonly<OCFStockIssuance> =>
       ele.object_type === "TX_STOCK_ISSUANCE" && ele.security_id === resultingId,
   );
-
-const noOtherTransactions = {
-  id: "no-other-transactions",
-  severity: "error",
-  description:
-    "No other transaction dated on or before this transaction references its security_id, other than a convertible acceptance.",
-  run: (context, data: { id: string; security_id: string; date: string }) => {
-    const messages: string[] = [];
-    const { transactions } = context.ocfPackageContent;
-
-    // One finding per transaction on this security_id dated on or before this
-    // conversion, exempting the issuance, any convertible acceptance, and this
-    // conversion itself. The scan keeps every transaction type in play, so it
-    // narrows by property presence rather than by discriminant: a transaction
-    // carrying no security_id can never reference this one. The conversion
-    // appears in its own history, so the self-exemption is by id, not by type.
-    transactions.forEach((ele) => {
-      if (
-        "security_id" in ele &&
-        ele.security_id === data.security_id &&
-        ele.date <= data.date &&
-        ele.object_type !== "TX_CONVERTIBLE_ISSUANCE" &&
-        ele.object_type !== "TX_CONVERTIBLE_ACCEPTANCE" &&
-        !(ele.object_type === "TX_CONVERTIBLE_CONVERSION" && ele.id === data.id)
-      ) {
-        messages.push(
-          `Another transaction (${ele.id}) references the transaction's security_id.`,
-        );
-      }
-    });
-
-    return messages;
-  },
-} satisfies CheckObject;
 
 const resultingSecurityNamed = {
   id: "resulting-security-named",

--- a/ocf_validator/validators/index.ts
+++ b/ocf_validator/validators/index.ts
@@ -6,7 +6,6 @@ import valid_tx_stock_conversion from './stock/tx_stock_conversion';
 import valid_tx_stock_reissuance from './stock/tx_stock_reissuance';
 import valid_tx_stock_repurchase from './stock/tx_stock_repurchase';
 import valid_tx_stock_transfer from './stock/tx_stock_transfer';
-import valid_tx_convertible_conversion from './convertible/tx_convertible_conversion';
 import valid_tx_warrant_exercise from './warrant/tx_warrant_exercise';
 import valid_tx_equity_compensation_issuance from './equity_compensation/tx_equity_compensation_issuance';
 import valid_tx_equity_compensation_retraction from './equity_compensation/tx_equity_compensation_retraction';
@@ -40,7 +39,6 @@ const validators = {
   valid_tx_stock_reissuance,
   valid_tx_stock_repurchase,
   valid_tx_stock_transfer,
-  valid_tx_convertible_conversion,
   valid_tx_warrant_exercise,
   valid_tx_equity_compensation_issuance,
   valid_tx_equity_compensation_retraction,

--- a/tests/convertibleValidators.test.ts
+++ b/tests/convertibleValidators.test.ts
@@ -17,6 +17,7 @@ const MIGRATED_KEYS = [
   "TX_CONVERTIBLE_RETRACTION",
   "TX_CONVERTIBLE_CANCELLATION",
   "TX_CONVERTIBLE_TRANSFER",
+  "TX_CONVERTIBLE_CONVERSION",
 ] as const;
 type MigratedKey = (typeof MIGRATED_KEYS)[number];
 
@@ -323,6 +324,250 @@ describe("convertible transfer validity", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Conversion: issuance-exists, no-other-transactions, resulting-security checks
+// ---------------------------------------------------------------------------
+
+describe("convertible conversion validity", () => {
+  const CONVERSION_DATE = "2021-06-01";
+  const conversion = (overrides: Record<string, unknown> = {}) => ({
+    id: "conv-main",
+    object_type: "TX_CONVERTIBLE_CONVERSION",
+    security_id: "conv-sec",
+    resulting_security_ids: ["result-stock"],
+    date: CONVERSION_DATE,
+    ...overrides,
+  });
+  const subject = { object_type: "TX_CONVERTIBLE_CONVERSION", id: "conv-main" };
+  const resultingChecks = ["resulting-stock-exists", "resulting-stock-dated", "resulting-stock-stakeholder"];
+
+  // A live convertible issuance carrying an explicit stakeholder_id — the reference
+  // the stakeholder check reads. The shared issuanceRecord helper omits it.
+  const liveConvertible = (security_id: string, stakeholder_id: string) => ({
+    id: `ci-${security_id}`,
+    object_type: "TX_CONVERTIBLE_ISSUANCE",
+    security_id,
+    stakeholder_id,
+    date: "2020-01-01",
+  });
+  // A resulting stock issuance as it sits in the package history.
+  const stockIssuance = (security_id: string, stakeholder_id: string, date: string) => ({
+    id: `si-${security_id}`,
+    object_type: "TX_STOCK_ISSUANCE",
+    security_id,
+    stakeholder_id,
+    date,
+  });
+
+  it("flags only the missing resulting id when a missing id precedes a present one", () => {
+    const context = contextWith({
+      convertibleIssuances: [liveConvertible("conv-sec", "holder-a")] as any,
+      transactions: [
+        liveConvertible("conv-sec", "holder-a"),
+        stockIssuance("present-stock", "holder-a", CONVERSION_DATE),
+      ],
+    });
+    const findings = runValidator(
+      "TX_CONVERTIBLE_CONVERSION",
+      context,
+      conversion({ resulting_security_ids: ["absent-stock", "present-stock"] }),
+    );
+    // The present id, second in the list, does not mask the missing id, first.
+    expect(findings).toHaveLength(1);
+    expectFindingShape(findings[0], "resulting-stock-exists", subject);
+    expect(findings[0].message).toContain("absent-stock");
+    expect(findings[0].message).not.toContain("present-stock");
+  });
+
+  it("flags a resulting stock issuance dated before or after the conversion, but not one dated the same day", () => {
+    const datedFindings = (stockDate: string) => {
+      const context = contextWith({
+        convertibleIssuances: [liveConvertible("conv-sec", "holder-a")] as any,
+        transactions: [
+          liveConvertible("conv-sec", "holder-a"),
+          stockIssuance("result-stock", "holder-a", stockDate),
+        ],
+      });
+      return runValidator("TX_CONVERTIBLE_CONVERSION", context, conversion()).filter(
+        (f) => f.check === "resulting-stock-dated",
+      );
+    };
+
+    const earlier = datedFindings("2021-05-01");
+    expect(earlier).toHaveLength(1);
+    expectFindingShape(earlier[0], "resulting-stock-dated", subject);
+    expect(earlier[0].message).toContain("differs");
+    expect(earlier[0].message).toContain("result-stock");
+    expect(earlier[0].message).toContain("2021-05-01");
+    expect(earlier[0].message).toContain(CONVERSION_DATE);
+
+    const later = datedFindings("2021-07-01");
+    expect(later).toHaveLength(1);
+    expect(later[0].message).toContain("differs");
+    expect(later[0].message).toContain("2021-07-01");
+
+    expect(datedFindings(CONVERSION_DATE)).toEqual([]);
+  });
+
+  it("flags a resulting stock issuance held by a different stakeholder than the converted issuance", () => {
+    const context = contextWith({
+      convertibleIssuances: [liveConvertible("conv-sec", "holder-alpha")] as any,
+      transactions: [
+        liveConvertible("conv-sec", "holder-alpha"),
+        stockIssuance("result-stock", "holder-beta", CONVERSION_DATE),
+      ],
+    });
+    const findings = runValidator("TX_CONVERTIBLE_CONVERSION", context, conversion()).filter(
+      (f) => f.check === "resulting-stock-stakeholder",
+    );
+    expect(findings).toHaveLength(1);
+    expectFindingShape(findings[0], "resulting-stock-stakeholder", subject);
+    expect(findings[0].message).toContain("result-stock");
+    expect(findings[0].message).toContain("holder-alpha");
+    expect(findings[0].message).toContain("holder-beta");
+  });
+
+  it("says nothing about resulting stakeholders when the converted issuance is absent from the live collection", () => {
+    // No live convertible record for conv-sec, so there is no reference stakeholder
+    // to compare against — yet a resulting stock issuance carrying a stakeholder_id
+    // is present, so the silence is the missing reference, not a missing value.
+    const context = contextWith({
+      convertibleIssuances: [] as any,
+      transactions: [stockIssuance("result-stock", "holder-beta", CONVERSION_DATE)],
+    });
+    const findings = runValidator("TX_CONVERTIBLE_CONVERSION", context, conversion());
+    expect(findings.some((f) => f.check === "resulting-stock-stakeholder")).toBe(false);
+  });
+
+  // A conversion's own record appears in its history scan; each fixture includes it
+  // so the self-exemption by id is exercised, alongside the offender under test.
+  const noOtherFindings = (...offenders: Record<string, unknown>[]) => {
+    const conversionRecord = conversion({ resulting_security_ids: [] });
+    const context = contextWith({
+      convertibleIssuances: [issuanceRecord("conv-sec")] as any,
+      transactions: [issuanceRecord("conv-sec"), conversionRecord, ...offenders],
+    });
+    return runValidator("TX_CONVERTIBLE_CONVERSION", context, conversionRecord).filter(
+      (f) => f.check === "no-other-transactions",
+    );
+  };
+
+  it("ignores an offender dated after the conversion but flags one dated on or before", () => {
+    const retraction = (date: string) => ({ id: "ret-off", object_type: "TX_CONVERTIBLE_RETRACTION", security_id: "conv-sec", date });
+    expect(noOtherFindings(retraction("2021-12-01"))).toEqual([]);
+
+    const sameDay = noOtherFindings(retraction(CONVERSION_DATE));
+    expect(sameDay).toHaveLength(1);
+    expectFindingShape(sameDay[0], "no-other-transactions", subject);
+    expect(sameDay[0].message).toContain("ret-off");
+
+    expect(noOtherFindings(retraction("2021-01-01"))).toHaveLength(1);
+  });
+
+  it("exempts a convertible acceptance dated on or before and never flags the conversion itself", () => {
+    const acceptance = { id: "acc-x", object_type: "TX_CONVERTIBLE_ACCEPTANCE", security_id: "conv-sec", date: "2021-01-01" };
+    expect(noOtherFindings(acceptance)).toEqual([]);
+    // With no other transaction present, the conversion's own history record is never flagged.
+    expect(noOtherFindings()).toEqual([]);
+  });
+
+  it("flags a second conversion sharing the security_id, pinning the self-exemption to the transaction id", () => {
+    const secondConversion = { id: "conv-other", object_type: "TX_CONVERTIBLE_CONVERSION", security_id: "conv-sec", resulting_security_ids: [], date: "2021-01-01" };
+    const findings = noOtherFindings(secondConversion);
+    expect(findings).toHaveLength(1);
+    expectFindingShape(findings[0], "no-other-transactions", subject);
+    expect(findings[0].message).toContain("conv-other");
+  });
+
+  it("warns once when the resulting array is empty and stays silent on the per-element resulting checks", () => {
+    const context = contextWith({
+      convertibleIssuances: [issuanceRecord("conv-sec")] as any,
+      transactions: [issuanceRecord("conv-sec")],
+    });
+    const findings = runValidator(
+      "TX_CONVERTIBLE_CONVERSION",
+      context,
+      conversion({ resulting_security_ids: [] }),
+    );
+    const named = findings.filter((f) => f.check === "resulting-security-named");
+    expect(named).toHaveLength(1);
+    expect(named[0].severity).toBe("warning");
+    expect(named[0].subject).toEqual(subject);
+    for (const check of resultingChecks) {
+      expect(findings.some((f) => f.check === check)).toBe(false);
+    }
+  });
+
+  it("raises no resulting-security-named finding when the resulting array names a security", () => {
+    const context = contextWith({
+      convertibleIssuances: [liveConvertible("conv-sec", "holder-a")] as any,
+      transactions: [
+        liveConvertible("conv-sec", "holder-a"),
+        stockIssuance("result-stock", "holder-a", CONVERSION_DATE),
+      ],
+    });
+    const findings = runValidator("TX_CONVERTIBLE_CONVERSION", context, conversion());
+    expect(findings.some((f) => f.check === "resulting-security-named")).toBe(false);
+  });
+
+  it("declares quantity-reconciles and balance-security-exists as unimplemented gaps", () => {
+    const declared = (TX_DESCRIPTORS.TX_CONVERTIBLE_CONVERSION as { checks: readonly { id: string; implemented?: false }[] }).checks;
+    for (const id of ["quantity-reconciles", "balance-security-exists"]) {
+      expect(declared.some((c) => c.id === id && c.implemented === false)).toBe(true);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Conversion drives the machine end to end
+// ---------------------------------------------------------------------------
+
+describe("convertible conversion drives the machine to completion", () => {
+  // The resulting stock stays history-only — never sent as an event — so the
+  // legacy stock validator is not dragged into these runs; the conversion checks
+  // find it in history regardless.
+  const seedPackage = (transactions: Record<string, unknown>[]) =>
+    baseContext({
+      ocfPackageContent: {
+        ...baseContext().ocfPackageContent,
+        stakeholders: [{ id: "holder-a" }],
+        transactions,
+      } as OcfMachineContext["ocfPackageContent"],
+    });
+
+  it("clears a fully valid conversion, removing the converted convertible and recording no findings", () => {
+    const issuance = { id: "ci-x", object_type: "TX_CONVERTIBLE_ISSUANCE", security_id: "conv-sec", stakeholder_id: "holder-a", date: "2020-01-01" };
+    const conversion = { id: "cv-x", object_type: "TX_CONVERTIBLE_CONVERSION", security_id: "conv-sec", resulting_security_ids: ["stock-sec"], date: "2020-01-02" };
+    const resultingStock = { id: "si-x", object_type: "TX_STOCK_ISSUANCE", security_id: "stock-sec", stakeholder_id: "holder-a", date: "2020-01-02" };
+
+    const actor = startSeeded(seedPackage([issuance, conversion, resultingStock]));
+    actor.send(ev("TX_CONVERTIBLE_ISSUANCE", issuance));
+    actor.send(ev("TX_CONVERTIBLE_CONVERSION", conversion));
+
+    const snapshot = actor.getSnapshot();
+    expect(snapshot.value).toBe("capTable");
+    expect(snapshot.context.findings).toEqual([]);
+    expect(snapshot.context.convertibleIssuances).toEqual([]);
+  });
+
+  it("completes an empty-resulting conversion on its warning alone and still removes the converted convertible", () => {
+    const issuance = { id: "ci-y", object_type: "TX_CONVERTIBLE_ISSUANCE", security_id: "conv-sec", stakeholder_id: "holder-a", date: "2020-01-01" };
+    const conversion = { id: "cv-y", object_type: "TX_CONVERTIBLE_CONVERSION", security_id: "conv-sec", resulting_security_ids: [], date: "2020-01-02" };
+
+    const actor = startSeeded(seedPackage([issuance, conversion]));
+    actor.send(ev("TX_CONVERTIBLE_ISSUANCE", issuance));
+    actor.send(ev("TX_CONVERTIBLE_CONVERSION", conversion));
+
+    const snapshot = actor.getSnapshot();
+    expect(snapshot.value).toBe("capTable");
+    // The lone finding is the warning, which does not block the machine.
+    expect(snapshot.context.findings).toHaveLength(1);
+    expect(snapshot.context.findings[0].check).toBe("resulting-security-named");
+    expect(snapshot.context.findings[0].severity).toBe("warning");
+    expect(snapshot.context.convertibleIssuances).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Existence check: layered failure diagnostics
 // ---------------------------------------------------------------------------
 
@@ -512,6 +757,29 @@ const failingScenarios: Record<MigratedKey, { context: OcfMachineContext; data: 
   TX_CONVERTIBLE_TRANSFER: [
     { context: contextWith({ transactions: [issuanceRecord("sec1")] }), data: txRecord("TX_CONVERTIBLE_TRANSFER", "x1", "sec1", "2021-01-01") },
   ],
+  TX_CONVERTIBLE_CONVERSION: [
+    // Missing issuance and an empty resulting array: issuance-exists and the
+    // resulting-security-named warning.
+    {
+      context: contextWith({ transactions: [] }),
+      data: { id: "cv1", object_type: "TX_CONVERTIBLE_CONVERSION", security_id: "sec1", resulting_security_ids: [], date: "2021-01-01" },
+    },
+    // A live issuance clears issuance-exists, leaving the remaining four checks
+    // to fire: an offender for no-other-transactions, and three resulting ids
+    // that are respectively absent, wrongly dated, and wrongly held.
+    {
+      context: contextWith({
+        convertibleIssuances: [{ id: "ci-sec1", object_type: "TX_CONVERTIBLE_ISSUANCE", security_id: "sec1", stakeholder_id: "holder-ref", date: "2020-01-01" }] as any,
+        transactions: [
+          { id: "ci-sec1", object_type: "TX_CONVERTIBLE_ISSUANCE", security_id: "sec1", stakeholder_id: "holder-ref", date: "2020-01-01" },
+          txRecord("TX_CONVERTIBLE_RETRACTION", "ret-off", "sec1", "2020-06-01"),
+          { id: "si-early", object_type: "TX_STOCK_ISSUANCE", security_id: "stock-early", stakeholder_id: "holder-ref", date: "2020-05-01" },
+          { id: "si-other", object_type: "TX_STOCK_ISSUANCE", security_id: "stock-other-holder", stakeholder_id: "holder-other", date: "2021-01-01" },
+        ],
+      }),
+      data: { id: "cv1", object_type: "TX_CONVERTIBLE_CONVERSION", security_id: "sec1", resulting_security_ids: ["stock-absent", "stock-early", "stock-other-holder"], date: "2021-01-01" },
+    },
+  ],
 };
 
 /** Every check id emitted across a module's failing scenarios. */
@@ -538,9 +806,9 @@ describe("declared and emitted checks stay consistent across the family", () => 
     expect(declared.some((c) => c.id === "no-other-transactions" && c.implemented === false)).toBe(true);
   });
 
-  it("leaves conversion on the legacy convention", () => {
-    expect("legacyValidate" in TX_DESCRIPTORS.TX_CONVERTIBLE_CONVERSION).toBe(true);
-    expect("validate" in TX_DESCRIPTORS.TX_CONVERTIBLE_CONVERSION).toBe(false);
+  it("carries conversion on the graded convention", () => {
+    expect("validate" in TX_DESCRIPTORS.TX_CONVERTIBLE_CONVERSION).toBe(true);
+    expect("legacyValidate" in TX_DESCRIPTORS.TX_CONVERTIBLE_CONVERSION).toBe(false);
   });
 });
 


### PR DESCRIPTION
Part of #193, the first of two module PRs; the warrant exercise migration follows on this branch and will close the issue. Stacked on #202 (`issue-198-scan-semantics`).

This migrates the last legacy convertible module, `tx_convertible_conversion`, to the declarative check form and rewrites its resulting-security block per the decisions recorded on #193.

## What changes

Today every convertible conversion fails validation: the stakeholder comparison reads a variable that is never assigned, and the resulting dates check searches for convertible issuances where the resulting securities are stock. After this PR a correct conversion passes. Specifics:

1. The resulting-security checks (existence, same-day date, stakeholder match) all target stock issuances, per the OCF conversion right, and each element of resulting_security_ids is judged independently with one finding per failing element. This also fixes #192's last-element-wins grading for this module, plus a legacy defect where the resulting-existence flag never participated in the final verdict.
2. The stakeholder reference comes from the convertible issuance the transaction references (the same live record the existence check matches); each resulting stock issuance must name that stakeholder.
3. A conversion naming no resulting securities draws a warning, not an error. Warnings do not block validation; an empty array is schema-legal, and the consistency checks judge what the array names.
4. Two known validations are declared but deliberately not implemented, surfacing as gaps in the check metadata: quantity_converted reconciliation (the legacy header already admitted this one) and balance_security_id validation for partial conversions.
5. The incoming-side checks come from the shared family checks: issuance-exists with the layered diagnostics from #198, and the past-only no-other-transactions scan with its acceptance exception and self-exemption. The legacy incoming-date check is subsumed by those diagnostics, as in the other migrated modules.

Also promotes the no-other-transactions scan into the family checks file, since conversion made it two modules carrying identical copies.

## Verification

Build and the full suite green: 149 tests (13 new). The characterization snapshot is byte-identical (the fixture package contains no convertible transactions). The conversion module now participates in the family invariant that a migrated module emits exactly the check ids its descriptor declares implemented.
