### PR TITLE
Migrate the warrant exercise validator to the declarative check form

### DIFF
--- a/ocf_validator/ocfMachine.ts
+++ b/ocf_validator/ocfMachine.ts
@@ -22,6 +22,7 @@ import { TX_WARRANT_ACCEPTANCE } from "./validators/warrant/tx_warrant_acceptanc
 import { TX_WARRANT_RETRACTION } from "./validators/warrant/tx_warrant_retraction";
 import { TX_WARRANT_CANCELLATION } from "./validators/warrant/tx_warrant_cancellation";
 import { TX_WARRANT_TRANSFER } from "./validators/warrant/tx_warrant_transfer";
+import { TX_WARRANT_EXERCISE } from "./validators/warrant/tx_warrant_exercise";
 import run_EOD from "./eod";
 
 // The validator contract types are defined in types/validator.ts; re-exported
@@ -201,7 +202,7 @@ export const TX_DESCRIPTORS = {
   TX_WARRANT_RETRACTION,
   TX_WARRANT_CANCELLATION,
   TX_WARRANT_TRANSFER,
-  TX_WARRANT_EXERCISE: { effect: "remove", collection: "warrantIssuances", legacyValidate: validators.valid_tx_warrant_exercise },
+  TX_WARRANT_EXERCISE,
   TX_EQUITY_COMPENSATION_RETRACTION: { effect: "remove", collection: "equityCompensation", legacyValidate: validators.valid_tx_equity_compensation_retraction },
   TX_EQUITY_COMPENSATION_CANCELLATION: { effect: "remove", collection: "equityCompensation", legacyValidate: validators.valid_tx_equity_compensation_cancellation },
   TX_EQUITY_COMPENSATION_TRANSFER: { effect: "remove", collection: "equityCompensation", legacyValidate: validators.valid_tx_equity_compensation_transfer },

--- a/ocf_validator/validators/index.ts
+++ b/ocf_validator/validators/index.ts
@@ -6,7 +6,6 @@ import valid_tx_stock_conversion from './stock/tx_stock_conversion';
 import valid_tx_stock_reissuance from './stock/tx_stock_reissuance';
 import valid_tx_stock_repurchase from './stock/tx_stock_repurchase';
 import valid_tx_stock_transfer from './stock/tx_stock_transfer';
-import valid_tx_warrant_exercise from './warrant/tx_warrant_exercise';
 import valid_tx_equity_compensation_issuance from './equity_compensation/tx_equity_compensation_issuance';
 import valid_tx_equity_compensation_retraction from './equity_compensation/tx_equity_compensation_retraction';
 import valid_tx_equity_compensation_acceptance from './equity_compensation/tx_equity_compensation_acceptance';
@@ -39,7 +38,6 @@ const validators = {
   valid_tx_stock_reissuance,
   valid_tx_stock_repurchase,
   valid_tx_stock_transfer,
-  valid_tx_warrant_exercise,
   valid_tx_equity_compensation_issuance,
   valid_tx_equity_compensation_retraction,
   valid_tx_equity_compensation_acceptance,

--- a/ocf_validator/validators/warrant/checks.ts
+++ b/ocf_validator/validators/warrant/checks.ts
@@ -59,3 +59,38 @@ export const issuanceExists = {
     return messages;
   },
 } satisfies CheckObject;
+
+/**
+ * No other transaction dated on or before this transaction references its
+ * security_id, other than a warrant acceptance. One finding per offending
+ * transaction. The scan keeps every transaction type in play, so it narrows by
+ * property presence rather than by discriminant: a transaction carrying no
+ * security_id can never reference this one. The transaction under validation
+ * appears in its own history, so it is exempted by id.
+ */
+export const noOtherTransactions = {
+  id: "no-other-transactions",
+  severity: "error",
+  description:
+    "No other transaction dated on or before this transaction references its security_id, other than a warrant acceptance.",
+  run: (context, data: { id: string; security_id: string; date: string }) => {
+    const messages: string[] = [];
+
+    context.ocfPackageContent.transactions.forEach((ele) => {
+      if (
+        "security_id" in ele &&
+        ele.security_id === data.security_id &&
+        ele.date <= data.date &&
+        ele.object_type !== "TX_WARRANT_ISSUANCE" &&
+        ele.object_type !== "TX_WARRANT_ACCEPTANCE" &&
+        ele.id !== data.id
+      ) {
+        messages.push(
+          `Another transaction (${ele.id}) references the transaction's security_id.`,
+        );
+      }
+    });
+
+    return messages;
+  },
+} satisfies CheckObject;

--- a/ocf_validator/validators/warrant/tx_warrant_cancellation.ts
+++ b/ocf_validator/validators/warrant/tx_warrant_cancellation.ts
@@ -1,38 +1,5 @@
-import { defineValidator, type CheckObject } from "../checkKit";
-import { issuanceExists } from "./checks";
-
-const noOtherTransactions = {
-  id: "no-other-transactions",
-  severity: "error",
-  description:
-    "No other transaction dated on or before this transaction references its security_id, other than a warrant acceptance.",
-  run: (context, data: { id: string; security_id: string; date: string }) => {
-    const messages: string[] = [];
-    const { transactions } = context.ocfPackageContent;
-
-    // no-other-transactions emits one finding per transaction on this security_id
-    // dated on or before this cancellation, exempting the issuance, any warrant
-    // acceptance, and this cancellation itself. This scan keeps every transaction
-    // type in play, so it narrows by property presence rather than by discriminant:
-    // a transaction that carries no security_id can never reference this one.
-    transactions.forEach((ele) => {
-      if (
-        "security_id" in ele &&
-        ele.security_id === data.security_id &&
-        ele.date <= data.date &&
-        ele.object_type !== "TX_WARRANT_ISSUANCE" &&
-        ele.object_type !== "TX_WARRANT_ACCEPTANCE" &&
-        !(ele.object_type === "TX_WARRANT_CANCELLATION" && ele.id === data.id)
-      ) {
-        messages.push(
-          `Another transaction (${ele.id}) references the transaction's security_id.`,
-        );
-      }
-    });
-
-    return messages;
-  },
-} satisfies CheckObject;
+import { defineValidator } from "../checkKit";
+import { issuanceExists, noOtherTransactions } from "./checks";
 
 export const TX_WARRANT_CANCELLATION = defineValidator({
   transaction: "TX_WARRANT_CANCELLATION",

--- a/ocf_validator/validators/warrant/tx_warrant_exercise.ts
+++ b/ocf_validator/validators/warrant/tx_warrant_exercise.ts
@@ -1,127 +1,125 @@
-import { OcfMachineContext } from "../../ocfMachine";
+import type { OCFStockIssuance } from "@opencaptablecoalition/ocf-types";
+import type { DeepReadonly, OcfMachineContext } from "../../../types/validator";
+import { defineValidator, type CheckObject } from "../checkKit";
+import { issuanceExists, noOtherTransactions } from "./checks";
 
-/*
-CURRENT CHECKS:
-Check that warrant issuance in incoming security_id referenced by transaction exists in current state.
-The date of the warrant issuance referred to in the security_id must have a date equal to or earlier than the date of the warrant exercise
-Any stock issuances with corresponding security IDs referred to in the resulting_security_ids array must exist
-The security_id of the warrant issuance referred to in the security_id variable must not be the security_id related to any other transactions with the exception of a warrant acceptance transaction.
-The dates of any warrant issuances referred to in the resulting_security_ids variables must have a date equal to the date of the warrant exercise
-The stakeholder_id of the warrant issuance referred to in the security_id variable must equal the stakeholder_id of any stock issuances referred to in the resulting_security_ids variable
+// A warrant's conversion right can only point at a stock class, so every id in
+// resulting_security_ids names a stock issuance. The three resulting checks
+// locate those issuances in the package transaction history, dated the same day
+// as the exercise, so the result does not depend on the order the driver
+// processes same-day transactions in.
 
-NOT IMPLEMENTED:
-The quantity_converted variable must equal the sum of any warrant issuances referred to in the resulting_security_ids variable
-*/
+// The stock issuance a resulting id names: the first TX_STOCK_ISSUANCE in
+// package order matching the id, so each resulting check makes one comparison
+// per id even when an id matches more than one issuance.
+const resultingStockIssuance = (
+  context: DeepReadonly<OcfMachineContext>,
+  resultingId: string,
+): DeepReadonly<OCFStockIssuance> | undefined =>
+  context.ocfPackageContent.transactions.find(
+    (ele): ele is DeepReadonly<OCFStockIssuance> =>
+      ele.object_type === "TX_STOCK_ISSUANCE" && ele.security_id === resultingId,
+  );
 
-const valid_tx_warrant_exercise = (context: OcfMachineContext, event: any, isGuard: Boolean) => {
-  let validity = false;
-  const { transactions } = context.ocfPackageContent;
-  let report: any = { transaction_type: "TX_WARRANT_EXERCISE", transaction_id: event.data.id, transaction_date: event.data.date };
+const resultingSecurityNamed = {
+  id: "resulting-security-named",
+  severity: "warning",
+  description: "The exercise names at least one resulting security.",
+  run: (_context, data: { resulting_security_ids: string[] }) => {
+    if (data.resulting_security_ids.length > 0) return [];
+    return ["The exercise names no resulting security."];
+  },
+} satisfies CheckObject;
 
-  // Check that warrant issuance in incoming security_id referenced by transaction exists in current state.
-  let incoming_warrantIssuance_validity = false;
-  let incoming_stakeholder = "";
-  context.warrantIssuances.forEach((ele: any) => {
-    if (ele.security_id === event.data.security_id && ele.object_type === "TX_WARRANT_ISSUANCE") {
-      incoming_warrantIssuance_validity = true;
-      report.incoming_warrantIssuance_validity = true;
-    }
-  });
-  if (!incoming_warrantIssuance_validity) {
-    report.incoming_warrantIssuance_validity = false;
-  }
+const resultingStockExists = {
+  id: "resulting-stock-exists",
+  severity: "error",
+  description:
+    "Each resulting security is a stock issuance present in the package.",
+  run: (context, data: { resulting_security_ids: string[] }) => {
+    const messages: string[] = [];
 
-  // The date of the warrant issuance referred to in the security_id must have a date equal to or earlier than the date of the warrant exercise
-  let incoming_date_validity = false;
-  transactions.forEach((ele: any) => {
-    if (ele.security_id === event.data.security_id && ele.object_type === "TX_WARRANT_ISSUANCE") {
-      if (ele.date <= event.data.date) {
-        incoming_date_validity = true;
-        report.incoming_date_validity = true;
-      }
-    }
-  });
-  if (!incoming_date_validity) {
-    report.incoming_date_validity = false;
-  }
-
-  // Any stock issuances with corresponding security IDs referred to in the resulting_security_ids array must exist
-  let resulting_stockIssuances_validity = false;
-  for (let i = 0; i < event.data.resulting_security_ids.length; i++) {
-    const res = event.data.resulting_security_ids[i];
-    resulting_stockIssuances_validity = false;
-    transactions.map((ele: any) => {
-      if (ele.security_id === res && ele.object_type === "TX_STOCK_ISSUANCE") {
-        resulting_stockIssuances_validity = true;
-        report.resulting_warrantIssuances_validity = true;
+    // One finding per resulting id with no matching stock issuance in history.
+    data.resulting_security_ids.forEach((resultingId) => {
+      if (resultingStockIssuance(context, resultingId) === undefined) {
+        messages.push(
+          `No stock issuance with security_id ${resultingId} appears in the package.`,
+        );
       }
     });
-    if (!resulting_stockIssuances_validity) {
-      report.resulting_warrantIssuances_validity = false;
-    }
-  }
 
+    return messages;
+  },
+} satisfies CheckObject;
 
-  // The security_id of the warrant issuance referred to in the security_id variable must not be the security_id related to any other transactions with the exception of a warrant acceptance transaction.
-  let only_transaction_validity = true;
-  transactions.map((ele: any) => {
-    if (ele.security_id === event.data.security_id && ele.object_type !== "TX_WARRANT_ISSUANCE" && ele.object_type !== "TX_WARRANT_ACCEPTANCE" && !(ele.object_type === "TX_WARRANT_EXERCISE" && ele.id === event.data.id)) {
-      only_transaction_validity = false;
-      report.only_transaction_validity = false;
-    }
-  });
-  if (only_transaction_validity) {
-    report.only_transaction_validity = true;
-  }
+const resultingStockDated = {
+  id: "resulting-stock-dated",
+  severity: "error",
+  description:
+    "Each resulting stock issuance is dated the same day as the exercise.",
+  run: (context, data: { resulting_security_ids: string[]; date: string }) => {
+    const messages: string[] = [];
 
-  // The dates of any warrant issuances referred to in the resulting_security_ids must have a date equal to the date of the warrant exercise
-  let resulting_dates_validity = false;
-  for (let i = 0; i < event.data.resulting_security_ids.length; i++) {
-    const res = event.data.resulting_security_ids[i];
-    resulting_dates_validity = false;
-    transactions.map((ele: any) => {
-      if (ele.security_id === res && ele.object_type === "TX_WARRANT_ISSUANCE" && ele.date === event.data.date) {
-        resulting_dates_validity = true;
-        report.resulting_dates_validity = true;
+    // Only resulting ids backed by a stock issuance are judged here; a missing
+    // id is solely resulting-stock-exists's concern.
+    data.resulting_security_ids.forEach((resultingId) => {
+      const issuance = resultingStockIssuance(context, resultingId);
+      if (issuance !== undefined && issuance.date !== data.date) {
+        messages.push(
+          `The resulting stock issuance ${resultingId} is dated ${issuance.date}, which differs from the exercise date ${data.date}.`,
+        );
       }
     });
-    if (!resulting_dates_validity) {
-      report.resulting_dates_validity = false;
-    }
-  }
 
+    return messages;
+  },
+} satisfies CheckObject;
 
-  // The stakeholder_id of the warrant issuance referred to in the security_id variable must equal the stakeholder_id of any warrant issuances referred to in the resulting_security_ids variable
-  let resulting_stakeholder_validity = false;
-  for (let i = 0; i < event.data.resulting_security_ids.length; i++) {
-    const res = event.data.resulting_security_ids[i];
-    resulting_stakeholder_validity = false;
-    transactions.map((ele: any) => {
-      if (ele.security_id === res && ele.object_type === "TX_STOCK_ISSUANCE") {
-        if (ele.stakeholder_id === incoming_stakeholder) {
-          resulting_stakeholder_validity = true;
-          report.resulting_stakeholder_validity = true;
-        }
+const resultingStockStakeholder = {
+  id: "resulting-stock-stakeholder",
+  severity: "error",
+  description:
+    "Each resulting stock issuance names the stakeholder of the exercised warrant issuance.",
+  run: (
+    context,
+    data: { security_id: string; resulting_security_ids: string[] },
+  ) => {
+    const messages: string[] = [];
+
+    // The reference stakeholder comes from the live warrant issuance this
+    // exercise references — the same record issuance-exists matches. With no live
+    // record, issuance-exists already carries the failure and there is no
+    // reference to compare against, so this check stays silent.
+    const reference = context.warrantIssuances.find(
+      (ele) => ele.security_id === data.security_id,
+    );
+    if (reference === undefined) return messages;
+
+    // As with the date check, only resulting ids backed by a stock issuance are
+    // judged.
+    data.resulting_security_ids.forEach((resultingId) => {
+      const issuance = resultingStockIssuance(context, resultingId);
+      if (issuance !== undefined && issuance.stakeholder_id !== reference.stakeholder_id) {
+        messages.push(
+          `The resulting stock issuance ${resultingId} names stakeholder ${issuance.stakeholder_id}, which differs from the warrant issuance's stakeholder ${reference.stakeholder_id}.`,
+        );
       }
     });
-    if (!resulting_stakeholder_validity) {
-      report.resulting_stakeholder_validity = false;
-    }
-  }
 
-  if (
-    incoming_warrantIssuance_validity &&
-    incoming_date_validity &&
-    only_transaction_validity &&
-    resulting_dates_validity &&
-    resulting_stakeholder_validity
-  ) {
-    validity = true;
-  }
+    return messages;
+  },
+} satisfies CheckObject;
 
-  const result = isGuard ? validity : report;
-
-  return result;
-};
-
-export default valid_tx_warrant_exercise;
+export const TX_WARRANT_EXERCISE = defineValidator({
+  transaction: "TX_WARRANT_EXERCISE",
+  effect: "remove",
+  collection: "warrantIssuances",
+  checks: [
+    issuanceExists,
+    noOtherTransactions,
+    resultingSecurityNamed,
+    resultingStockExists,
+    resultingStockDated,
+    resultingStockStakeholder,
+  ],
+});

--- a/tests/warrantValidators.test.ts
+++ b/tests/warrantValidators.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { TX_DESCRIPTORS } from "../ocf_validator/ocfMachine";
+import validators from "../ocf_validator/validators";
 import type { OcfMachineContext } from "../types/validator";
 import {
   baseContext,
@@ -17,6 +18,7 @@ const MIGRATED_KEYS = [
   "TX_WARRANT_RETRACTION",
   "TX_WARRANT_CANCELLATION",
   "TX_WARRANT_TRANSFER",
+  "TX_WARRANT_EXERCISE",
 ] as const;
 type MigratedKey = (typeof MIGRATED_KEYS)[number];
 
@@ -323,6 +325,307 @@ describe("warrant transfer validity", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Exercise: issuance-exists, no-other-transactions, resulting-security checks
+// ---------------------------------------------------------------------------
+
+describe("warrant exercise validity", () => {
+  const EXERCISE_DATE = "2021-06-01";
+  const exercise = (overrides: Record<string, unknown> = {}) => ({
+    id: "ex-main",
+    object_type: "TX_WARRANT_EXERCISE",
+    security_id: "war-sec",
+    resulting_security_ids: ["result-stock"],
+    date: EXERCISE_DATE,
+    ...overrides,
+  });
+  const subject = { object_type: "TX_WARRANT_EXERCISE", id: "ex-main" };
+  const resultingChecks = ["resulting-stock-exists", "resulting-stock-dated", "resulting-stock-stakeholder"];
+
+  // A live warrant issuance carrying an explicit stakeholder_id — the reference
+  // the stakeholder check reads. The shared issuanceRecord helper omits it.
+  const liveWarrant = (security_id: string, stakeholder_id: string) => ({
+    id: `wi-${security_id}`,
+    object_type: "TX_WARRANT_ISSUANCE",
+    security_id,
+    stakeholder_id,
+    date: "2020-01-01",
+  });
+  // A resulting stock issuance as it sits in the package history.
+  const stockIssuance = (security_id: string, stakeholder_id: string, date: string) => ({
+    id: `si-${security_id}`,
+    object_type: "TX_STOCK_ISSUANCE",
+    security_id,
+    stakeholder_id,
+    date,
+  });
+
+  it("emits one resulting-stock-exists finding per missing resulting id", () => {
+    const context = contextWith({
+      warrantIssuances: [liveWarrant("war-sec", "holder-a")] as any,
+      transactions: [liveWarrant("war-sec", "holder-a")],
+    });
+    const findings = runValidator(
+      "TX_WARRANT_EXERCISE",
+      context,
+      exercise({ resulting_security_ids: ["absent-one", "absent-two"] }),
+    ).filter((f) => f.check === "resulting-stock-exists");
+    expect(findings).toHaveLength(2);
+    for (const finding of findings) expectFindingShape(finding, "resulting-stock-exists", subject);
+    const messages = findings.map((f) => f.message).join("\n");
+    expect(messages).toContain("absent-one");
+    expect(messages).toContain("absent-two");
+  });
+
+  it("flags only the missing resulting id when a missing id precedes a present one", () => {
+    const context = contextWith({
+      warrantIssuances: [liveWarrant("war-sec", "holder-a")] as any,
+      transactions: [
+        liveWarrant("war-sec", "holder-a"),
+        stockIssuance("present-stock", "holder-a", EXERCISE_DATE),
+      ],
+    });
+    const findings = runValidator(
+      "TX_WARRANT_EXERCISE",
+      context,
+      exercise({ resulting_security_ids: ["absent-stock", "present-stock"] }),
+    );
+    // The present id, second in the list, does not mask the missing id, first.
+    expect(findings).toHaveLength(1);
+    expectFindingShape(findings[0], "resulting-stock-exists", subject);
+    expect(findings[0].message).toContain("absent-stock");
+    expect(findings[0].message).not.toContain("present-stock");
+  });
+
+  it("flags a resulting stock issuance dated before or after the exercise, but not one dated the same day", () => {
+    const datedFindings = (stockDate: string) => {
+      const context = contextWith({
+        warrantIssuances: [liveWarrant("war-sec", "holder-a")] as any,
+        transactions: [
+          liveWarrant("war-sec", "holder-a"),
+          stockIssuance("result-stock", "holder-a", stockDate),
+        ],
+      });
+      return runValidator("TX_WARRANT_EXERCISE", context, exercise()).filter(
+        (f) => f.check === "resulting-stock-dated",
+      );
+    };
+
+    const earlier = datedFindings("2021-05-01");
+    expect(earlier).toHaveLength(1);
+    expectFindingShape(earlier[0], "resulting-stock-dated", subject);
+    expect(earlier[0].message).toContain("differs");
+    expect(earlier[0].message).toContain("result-stock");
+    expect(earlier[0].message).toContain("2021-05-01");
+    expect(earlier[0].message).toContain(EXERCISE_DATE);
+
+    const later = datedFindings("2021-07-01");
+    expect(later).toHaveLength(1);
+    expect(later[0].message).toContain("differs");
+    expect(later[0].message).toContain("2021-07-01");
+
+    expect(datedFindings(EXERCISE_DATE)).toEqual([]);
+  });
+
+  it("flags a wrongly-dated resulting id before a correctly-dated one and ignores a resulting id with no backing issuance", () => {
+    const context = contextWith({
+      warrantIssuances: [liveWarrant("war-sec", "holder-a")] as any,
+      transactions: [
+        liveWarrant("war-sec", "holder-a"),
+        stockIssuance("wrong-date", "holder-a", "2021-05-01"),
+        stockIssuance("right-date", "holder-a", EXERCISE_DATE),
+      ],
+    });
+    const findings = runValidator(
+      "TX_WARRANT_EXERCISE",
+      context,
+      exercise({ resulting_security_ids: ["wrong-date", "right-date", "absent-stock"] }),
+    ).filter((f) => f.check === "resulting-stock-dated");
+    // The correctly-dated id, second, does not mask the wrong-dated id, first; the
+    // absent id is judged only by resulting-stock-exists.
+    expect(findings).toHaveLength(1);
+    expectFindingShape(findings[0], "resulting-stock-dated", subject);
+    expect(findings[0].message).toContain("wrong-date");
+    expect(findings[0].message).not.toContain("right-date");
+    expect(findings[0].message).not.toContain("absent-stock");
+  });
+
+  it("flags a resulting stock issuance held by a different stakeholder than the exercised warrant issuance", () => {
+    const context = contextWith({
+      warrantIssuances: [liveWarrant("war-sec", "holder-alpha")] as any,
+      transactions: [
+        liveWarrant("war-sec", "holder-alpha"),
+        stockIssuance("result-stock", "holder-beta", EXERCISE_DATE),
+      ],
+    });
+    const findings = runValidator("TX_WARRANT_EXERCISE", context, exercise()).filter(
+      (f) => f.check === "resulting-stock-stakeholder",
+    );
+    expect(findings).toHaveLength(1);
+    expectFindingShape(findings[0], "resulting-stock-stakeholder", subject);
+    expect(findings[0].message).toContain("result-stock");
+    expect(findings[0].message).toContain("holder-alpha");
+    expect(findings[0].message).toContain("holder-beta");
+  });
+
+  it("flags a mismatching resulting id before a matching one and ignores a resulting id with no backing issuance", () => {
+    const context = contextWith({
+      warrantIssuances: [liveWarrant("war-sec", "holder-match")] as any,
+      transactions: [
+        liveWarrant("war-sec", "holder-match"),
+        stockIssuance("wrong-holder", "holder-other", EXERCISE_DATE),
+        stockIssuance("right-holder", "holder-match", EXERCISE_DATE),
+      ],
+    });
+    const findings = runValidator(
+      "TX_WARRANT_EXERCISE",
+      context,
+      exercise({ resulting_security_ids: ["wrong-holder", "right-holder", "absent-stock"] }),
+    ).filter((f) => f.check === "resulting-stock-stakeholder");
+    // The matching id, second, does not mask the mismatching id, first; the absent
+    // id is judged only by resulting-stock-exists.
+    expect(findings).toHaveLength(1);
+    expectFindingShape(findings[0], "resulting-stock-stakeholder", subject);
+    expect(findings[0].message).toContain("wrong-holder");
+    expect(findings[0].message).not.toContain("right-holder");
+    expect(findings[0].message).not.toContain("absent-stock");
+  });
+
+  it("says nothing about resulting stakeholders when the exercised warrant issuance is absent from the live collection", () => {
+    // No live warrant record for war-sec, so there is no reference stakeholder to
+    // compare against — yet a resulting stock issuance carrying a stakeholder_id is
+    // present, so the silence is the missing reference, not a missing value.
+    const context = contextWith({
+      warrantIssuances: [] as any,
+      transactions: [stockIssuance("result-stock", "holder-beta", EXERCISE_DATE)],
+    });
+    const findings = runValidator("TX_WARRANT_EXERCISE", context, exercise());
+    expect(findings.some((f) => f.check === "resulting-stock-stakeholder")).toBe(false);
+    expect(findings.some((f) => f.check === "issuance-exists")).toBe(true);
+  });
+
+  // An exercise's own record appears in its history scan; each fixture includes it
+  // so the self-exemption by id is exercised, alongside the offender under test.
+  const noOtherFindings = (...offenders: Record<string, unknown>[]) => {
+    const exerciseRecord = exercise({ resulting_security_ids: [] });
+    const context = contextWith({
+      warrantIssuances: [issuanceRecord("war-sec")] as any,
+      transactions: [issuanceRecord("war-sec"), exerciseRecord, ...offenders],
+    });
+    return runValidator("TX_WARRANT_EXERCISE", context, exerciseRecord).filter(
+      (f) => f.check === "no-other-transactions",
+    );
+  };
+
+  it("ignores an offender dated after the exercise but flags one dated on or before", () => {
+    const retraction = (date: string) => ({ id: "ret-off", object_type: "TX_WARRANT_RETRACTION", security_id: "war-sec", date });
+    expect(noOtherFindings(retraction("2021-12-01"))).toEqual([]);
+
+    const sameDay = noOtherFindings(retraction(EXERCISE_DATE));
+    expect(sameDay).toHaveLength(1);
+    expectFindingShape(sameDay[0], "no-other-transactions", subject);
+    expect(sameDay[0].message).toContain("ret-off");
+
+    expect(noOtherFindings(retraction("2021-01-01"))).toHaveLength(1);
+  });
+
+  it("exempts a warrant acceptance dated on or before and never flags the exercise itself", () => {
+    const acceptance = { id: "acc-x", object_type: "TX_WARRANT_ACCEPTANCE", security_id: "war-sec", date: "2021-01-01" };
+    expect(noOtherFindings(acceptance)).toEqual([]);
+    // With no other transaction present, the exercise's own history record is never flagged.
+    expect(noOtherFindings()).toEqual([]);
+  });
+
+  it("flags a second exercise sharing the security_id, pinning the self-exemption to the transaction id", () => {
+    const secondExercise = { id: "ex-other", object_type: "TX_WARRANT_EXERCISE", security_id: "war-sec", resulting_security_ids: [], date: "2021-01-01" };
+    const findings = noOtherFindings(secondExercise);
+    expect(findings).toHaveLength(1);
+    expectFindingShape(findings[0], "no-other-transactions", subject);
+    expect(findings[0].message).toContain("ex-other");
+  });
+
+  it("warns once when the resulting array is empty and stays silent on the per-element resulting checks", () => {
+    const context = contextWith({
+      warrantIssuances: [issuanceRecord("war-sec")] as any,
+      transactions: [issuanceRecord("war-sec")],
+    });
+    const findings = runValidator(
+      "TX_WARRANT_EXERCISE",
+      context,
+      exercise({ resulting_security_ids: [] }),
+    );
+    const named = findings.filter((f) => f.check === "resulting-security-named");
+    expect(named).toHaveLength(1);
+    expect(named[0].severity).toBe("warning");
+    expect(named[0].subject).toEqual(subject);
+    for (const check of resultingChecks) {
+      expect(findings.some((f) => f.check === check)).toBe(false);
+    }
+  });
+
+  it("raises no resulting-security-named finding when the resulting array names a security", () => {
+    const context = contextWith({
+      warrantIssuances: [liveWarrant("war-sec", "holder-a")] as any,
+      transactions: [
+        liveWarrant("war-sec", "holder-a"),
+        stockIssuance("result-stock", "holder-a", EXERCISE_DATE),
+      ],
+    });
+    const findings = runValidator("TX_WARRANT_EXERCISE", context, exercise());
+    expect(findings.some((f) => f.check === "resulting-security-named")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Exercise drives the machine end to end
+// ---------------------------------------------------------------------------
+
+describe("warrant exercise drives the machine to completion", () => {
+  // The resulting stock stays history-only — never sent as an event — so the
+  // legacy stock validator is not dragged into these runs; the exercise checks
+  // find it in history regardless.
+  const seedPackage = (transactions: Record<string, unknown>[]) =>
+    baseContext({
+      ocfPackageContent: {
+        ...baseContext().ocfPackageContent,
+        stakeholders: [{ id: "holder-a" }],
+        transactions,
+      } as OcfMachineContext["ocfPackageContent"],
+    });
+
+  it("clears a fully valid exercise, removing the exercised warrant and recording no findings", () => {
+    const issuance = { id: "wi-x", object_type: "TX_WARRANT_ISSUANCE", security_id: "war-sec", stakeholder_id: "holder-a", date: "2020-01-01" };
+    const exercise = { id: "ex-x", object_type: "TX_WARRANT_EXERCISE", security_id: "war-sec", resulting_security_ids: ["stock-sec"], date: "2020-01-02" };
+    const resultingStock = { id: "si-x", object_type: "TX_STOCK_ISSUANCE", security_id: "stock-sec", stakeholder_id: "holder-a", date: "2020-01-02" };
+
+    const actor = startSeeded(seedPackage([issuance, exercise, resultingStock]));
+    actor.send(ev("TX_WARRANT_ISSUANCE", issuance));
+    actor.send(ev("TX_WARRANT_EXERCISE", exercise));
+
+    const snapshot = actor.getSnapshot();
+    expect(snapshot.value).toBe("capTable");
+    expect(snapshot.context.findings).toEqual([]);
+    expect(snapshot.context.warrantIssuances).toEqual([]);
+  });
+
+  it("completes an empty-resulting exercise on its warning alone and still removes the exercised warrant", () => {
+    const issuance = { id: "wi-y", object_type: "TX_WARRANT_ISSUANCE", security_id: "war-sec", stakeholder_id: "holder-a", date: "2020-01-01" };
+    const exercise = { id: "ex-y", object_type: "TX_WARRANT_EXERCISE", security_id: "war-sec", resulting_security_ids: [], date: "2020-01-02" };
+
+    const actor = startSeeded(seedPackage([issuance, exercise]));
+    actor.send(ev("TX_WARRANT_ISSUANCE", issuance));
+    actor.send(ev("TX_WARRANT_EXERCISE", exercise));
+
+    const snapshot = actor.getSnapshot();
+    expect(snapshot.value).toBe("capTable");
+    // The lone finding is the warning, which does not block the machine.
+    expect(snapshot.context.findings).toHaveLength(1);
+    expect(snapshot.context.findings[0].check).toBe("resulting-security-named");
+    expect(snapshot.context.findings[0].severity).toBe("warning");
+    expect(snapshot.context.warrantIssuances).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Existence check: layered failure diagnostics
 // ---------------------------------------------------------------------------
 
@@ -512,6 +815,29 @@ const failingScenarios: Record<MigratedKey, { context: OcfMachineContext; data: 
   TX_WARRANT_TRANSFER: [
     { context: contextWith({ transactions: [issuanceRecord("sec1")] }), data: txRecord("TX_WARRANT_TRANSFER", "x1", "sec1", "2021-01-01") },
   ],
+  TX_WARRANT_EXERCISE: [
+    // Missing issuance and an empty resulting array: issuance-exists and the
+    // resulting-security-named warning.
+    {
+      context: contextWith({ transactions: [] }),
+      data: { id: "ex1", object_type: "TX_WARRANT_EXERCISE", security_id: "sec1", resulting_security_ids: [], date: "2021-01-01" },
+    },
+    // A live issuance clears issuance-exists, leaving the remaining four checks
+    // to fire: an offender for no-other-transactions, and three resulting ids
+    // that are respectively absent, wrongly dated, and wrongly held.
+    {
+      context: contextWith({
+        warrantIssuances: [{ id: "wi-sec1", object_type: "TX_WARRANT_ISSUANCE", security_id: "sec1", stakeholder_id: "holder-ref", date: "2020-01-01" }] as any,
+        transactions: [
+          { id: "wi-sec1", object_type: "TX_WARRANT_ISSUANCE", security_id: "sec1", stakeholder_id: "holder-ref", date: "2020-01-01" },
+          txRecord("TX_WARRANT_RETRACTION", "ret-off", "sec1", "2020-06-01"),
+          { id: "si-early", object_type: "TX_STOCK_ISSUANCE", security_id: "stock-early", stakeholder_id: "holder-ref", date: "2020-05-01" },
+          { id: "si-other", object_type: "TX_STOCK_ISSUANCE", security_id: "stock-other-holder", stakeholder_id: "holder-other", date: "2021-01-01" },
+        ],
+      }),
+      data: { id: "ex1", object_type: "TX_WARRANT_EXERCISE", security_id: "sec1", resulting_security_ids: ["stock-absent", "stock-early", "stock-other-holder"], date: "2021-01-01" },
+    },
+  ],
 };
 
 /** Every check id emitted across a module's failing scenarios. */
@@ -538,9 +864,12 @@ describe("declared and emitted checks stay consistent across the family", () => 
     expect(declared.some((c) => c.id === "no-other-transactions" && c.implemented === false)).toBe(true);
   });
 
-  it("leaves warrant exercise on the legacy convention", () => {
-    expect("legacyValidate" in TX_DESCRIPTORS.TX_WARRANT_EXERCISE).toBe(true);
-    expect("validate" in TX_DESCRIPTORS.TX_WARRANT_EXERCISE).toBe(false);
+  it("carries warrant exercise on the graded convention with no legacy validator", () => {
+    expect("validate" in TX_DESCRIPTORS.TX_WARRANT_EXERCISE).toBe(true);
+    expect("legacyValidate" in TX_DESCRIPTORS.TX_WARRANT_EXERCISE).toBe(false);
+    // A stray default export would still register a legacy key here, so assert its
+    // absence directly rather than trusting the descriptor swap alone.
+    expect("valid_tx_warrant_exercise" in validators).toBe(false);
   });
 });
 


### PR DESCRIPTION
Closes #193. Second of the two module PRs; stacked on #203 (`issue-193-convertible-conversion`).

This migrates the last legacy warrant module, `tx_warrant_exercise`, to the declarative check form and rewrites its resulting-security block per the decisions recorded on #193.

## What changes

Today every warrant exercise fails validation: the stakeholder comparison reads a variable that is never assigned, and the resulting dates check searches for warrant issuances where the resulting securities are stock. After this PR a correct exercise passes. Specifics:

1. The resulting-security checks (existence, same-day date, stakeholder match) all target stock issuances, per the OCF conversion right, and each element of resulting_security_ids is judged independently with one finding per failing element. This also fixes #192's last-element-wins grading for this module, plus the legacy defect where the resulting-existence flag never participated in the final verdict.
2. The stakeholder reference comes from the warrant issuance the transaction references (the same live record the existence check matches); each resulting stock issuance must name that stakeholder.
3. An exercise naming no resulting securities draws a warning, not an error. Warnings do not block validation; an empty array is schema-legal, and the consistency checks judge what the array names.
4. Unlike the convertible conversion, no gaps are declared: warrant exercise has no quantity or balance fields (OCF models exercise as all-or-nothing), so all six checks are implemented. The legacy header's note about quantity_converted referred to a field the transaction does not have.
5. The incoming-side checks come from the shared family checks: issuance-exists with the layered diagnostics from #198, and the past-only no-other-transactions scan with its acceptance exception. The legacy incoming-date check is subsumed by those diagnostics, as in the other migrated modules.

The first commit promotes the no-other-transactions scan into the warrant checks file, mirroring the convertible promotion, so cancellation and exercise share one copy; the second commit migrates the module.

## Verification

Build and the full suite green: 164 tests (15 new). The characterization snapshot is byte-identical (the fixture package contains no warrant transactions). The exercise module participates in the family invariant that a migrated module emits exactly the check ids its descriptor declares implemented.
