### PR TITLE
Migrate equity compensation validators to graded descriptors

### DIFF
--- a/ocf_validator/ocfMachine.ts
+++ b/ocf_validator/ocfMachine.ts
@@ -21,6 +21,13 @@ import { TX_WARRANT_ACCEPTANCE } from "./validators/warrant/tx_warrant_acceptanc
 import { TX_WARRANT_RETRACTION } from "./validators/warrant/tx_warrant_retraction";
 import { TX_WARRANT_CANCELLATION } from "./validators/warrant/tx_warrant_cancellation";
 import { TX_WARRANT_TRANSFER } from "./validators/warrant/tx_warrant_transfer";
+import { TX_EQUITY_COMPENSATION_ISSUANCE } from "./validators/equity_compensation/tx_equity_compensation_issuance";
+import { TX_EQUITY_COMPENSATION_ACCEPTANCE } from "./validators/equity_compensation/tx_equity_compensation_acceptance";
+import { TX_EQUITY_COMPENSATION_EXERCISE } from "./validators/equity_compensation/tx_equity_compensation_exercise";
+import { TX_EQUITY_COMPENSATION_RELEASE } from "./validators/equity_compensation/tx_equity_compensation_release";
+import { TX_EQUITY_COMPENSATION_RETRACTION } from "./validators/equity_compensation/tx_equity_compensation_retraction";
+import { TX_EQUITY_COMPENSATION_CANCELLATION } from "./validators/equity_compensation/tx_equity_compensation_cancellation";
+import { TX_EQUITY_COMPENSATION_TRANSFER } from "./validators/equity_compensation/tx_equity_compensation_transfer";
 import run_EOD from "./eod";
 
 // The validator contract types are defined in types/validator.ts; re-exported
@@ -174,17 +181,18 @@ export const TX_DESCRIPTORS = {
   TX_STOCK_ISSUANCE: { effect: "append", collection: "stockIssuances", legacyValidate: validators.valid_tx_stock_issuance },
   TX_CONVERTIBLE_ISSUANCE,
   TX_WARRANT_ISSUANCE,
-  TX_EQUITY_COMPENSATION_ISSUANCE: { effect: "append", collection: "equityCompensation", legacyValidate: validators.valid_tx_equity_compensation_issuance },
+  TX_EQUITY_COMPENSATION_ISSUANCE,
 
   // --- none: validate + report, no collection mutation --------------------
   TX_STOCK_ACCEPTANCE: { effect: "none", legacyValidate: validators.valid_tx_stock_acceptance },
   TX_CONVERTIBLE_ACCEPTANCE,
   TX_WARRANT_ACCEPTANCE,
-  TX_EQUITY_COMPENSATION_ACCEPTANCE: { effect: "none", legacyValidate: validators.valid_tx_equity_compensation_acceptance },
-  // TX_EQUITY_COMPENSATION_EXERCISE removes nothing today (its collection filter
-  // is commented out in the legacy machine), asymmetric with TX_WARRANT_EXERCISE
-  // which removes. That asymmetry is PRESERVED pending investigation, not endorsed.
-  TX_EQUITY_COMPENSATION_EXERCISE: { effect: "none", legacyValidate: validators.valid_tx_equity_compensation_exercise },
+  TX_EQUITY_COMPENSATION_ACCEPTANCE,
+  // TX_EQUITY_COMPENSATION_EXERCISE removes nothing today, asymmetric with
+  // TX_WARRANT_EXERCISE which removes. That asymmetry is preserved pending
+  // investigation, not endorsed.
+  TX_EQUITY_COMPENSATION_EXERCISE,
+  TX_EQUITY_COMPENSATION_RELEASE,
 
   // --- remove: filter the family collection by security_id ---------------
   TX_STOCK_RETRACTION: { effect: "remove", collection: "stockIssuances", legacyValidate: validators.valid_tx_stock_retraction },
@@ -201,9 +209,9 @@ export const TX_DESCRIPTORS = {
   TX_WARRANT_CANCELLATION,
   TX_WARRANT_TRANSFER,
   TX_WARRANT_EXERCISE: { effect: "remove", collection: "warrantIssuances", legacyValidate: validators.valid_tx_warrant_exercise },
-  TX_EQUITY_COMPENSATION_RETRACTION: { effect: "remove", collection: "equityCompensation", legacyValidate: validators.valid_tx_equity_compensation_retraction },
-  TX_EQUITY_COMPENSATION_CANCELLATION: { effect: "remove", collection: "equityCompensation", legacyValidate: validators.valid_tx_equity_compensation_cancellation },
-  TX_EQUITY_COMPENSATION_TRANSFER: { effect: "remove", collection: "equityCompensation", legacyValidate: validators.valid_tx_equity_compensation_transfer },
+  TX_EQUITY_COMPENSATION_RETRACTION,
+  TX_EQUITY_COMPENSATION_CANCELLATION,
+  TX_EQUITY_COMPENSATION_TRANSFER,
 
   // --- passthrough: received and silently ignored today ------------------
   //   No validator, no report entry, no collection mutation. They stay in
@@ -211,7 +219,6 @@ export const TX_DESCRIPTORS = {
   //   contains TX_VESTING_START) is byte-identical. `satisfies Record<TxKey, …>`
   //   below forces any future OCF transaction type to be classified here — a
   //   compile error until it is.
-  TX_EQUITY_COMPENSATION_RELEASE: { effect: "passthrough" },
   TX_EQUITY_COMPENSATION_REPRICING: { effect: "passthrough" },
   TX_ISSUER_AUTHORIZED_SHARES_ADJUSTMENT: { effect: "passthrough" },
   TX_PLAN_SECURITY_ACCEPTANCE: { effect: "passthrough" },

--- a/ocf_validator/validators/equity_compensation/tx_equity_compensation_acceptance.ts
+++ b/ocf_validator/validators/equity_compensation/tx_equity_compensation_acceptance.ts
@@ -1,72 +1,90 @@
-const valid_tx_equity_compensation_acceptance = (context: any, event: any, isGuard: Boolean) => {
-  const {transactions} = context.ocfPackageContent;
+import type { TransactionFor } from "../../../types/ocf-input";
+import type { Check, GradedValidator } from "../../../types/validator";
+import type { Finding } from "../../../types/finding";
+import type { Descriptor } from "../../ocfMachine";
 
-  let validity = false;
-  let report: any = {transaction_type: "TX_EQUITY_COMPENSATION_ACCEPTANCE", transaction_id: event.data.id, transaction_date: event.data.date};
+type Acceptance = TransactionFor<"TX_EQUITY_COMPENSATION_ACCEPTANCE">;
 
-  // Check that equity_compensation issuance in incoming security_id referenced by transaction exists in current state.
-  let incoming_equity_compensationIssuance_validity = false;
-  context.equity_compensationIssuances.forEach((ele: any) => {
-    if (
-      ele.security_id === event.data.security_id &&
-      ele.object_type === 'TX_EQUITY_COMPENSATION_ISSUANCE'
-    ) {
-      incoming_equity_compensationIssuance_validity = true;
-      report.incoming_equity_compensationIssuance_validity = true;
+const checks: readonly Check[] = [
+  {
+    id: "issuance-exists",
+    severity: "error",
+    description:
+      "The equity compensation issuance referenced by the transaction's security_id exists in the current cap-table state.",
+  },
+  {
+    id: "date-order",
+    severity: "error",
+    description:
+      "The transaction is dated on or after the equity compensation issuance it references.",
+  },
+  {
+    id: "no-retraction",
+    severity: "error",
+    description: "No equity compensation retraction references the transaction's security_id.",
+  },
+];
+
+const validate: GradedValidator<Acceptance> = (context, data) => {
+  const findings: Finding[] = [];
+  const subject = { object_type: data.object_type, id: data.id };
+  const { transactions } = context.ocfPackageContent;
+
+  // issuance-exists scans the live equity compensation collection.
+  let issuanceExists = false;
+  context.equityCompensation.forEach((ele) => {
+    if (ele.security_id === data.security_id && ele.object_type === "TX_EQUITY_COMPENSATION_ISSUANCE") {
+      issuanceExists = true;
     }
   });
-  if (!incoming_equity_compensationIssuance_validity) {
-    report.incoming_equity_compensationIssuance_validity = false;
+  if (!issuanceExists) {
+    findings.push({
+      severity: "error",
+      check: "issuance-exists",
+      message: `No equity compensation issuance with security_id ${data.security_id} exists in the current cap-table state.`,
+      subject,
+    });
   }
 
-  // Check to ensure that the date of transaction is the same day or after the date of the incoming equity_compensation issuance.
-  let incoming_date_validity = false;
-  transactions.forEach((ele: any) => {
+  // date-order scans the full package transaction history for the issuance.
+  // The object_type test leads so it narrows the transaction union to a
+  // security_id-bearing member before the other reads.
+  let dateOrdered = false;
+  transactions.forEach((ele) => {
     if (
-      ele.security_id === event.data.security_id &&
-      ele.object_type === 'TX_EQUITY_COMPENSATION_ISSUANCE'
+      ele.object_type === "TX_EQUITY_COMPENSATION_ISSUANCE" &&
+      ele.security_id === data.security_id &&
+      ele.date <= data.date
     ) {
-      if (ele.date <= event.data.date) {
-        incoming_date_validity = true;
-        report.incoming_date_validity = true;
-      }
+      dateOrdered = true;
     }
   });
-  if (!incoming_date_validity) {
-    report.incoming_date_validity = false;
+  if (!dateOrdered) {
+    findings.push({
+      severity: "error",
+      check: "date-order",
+      message: `The transaction is not dated on or after an equity compensation issuance with security_id ${data.security_id}.`,
+      subject,
+    });
   }
 
-  // Check that equity_compensation issuance in incoming security_id does not have a equity_compensation retraction transaction associated with it.
-  let no_equity_compensation_retraction_validity = false;
-  let equity_compensation_retraction_exists = false;
-  transactions.forEach((ele: any) => {
-    if (
-      ele.security_id === event.data.security_id &&
-      ele.object_type === 'TX_EQUITY_COMPENSATION_RETRACTION'
-    ) {
-      equity_compensation_retraction_exists = true;
+  // no-retraction emits one finding per equity compensation retraction on this security_id.
+  transactions.forEach((ele) => {
+    if (ele.object_type === "TX_EQUITY_COMPENSATION_RETRACTION" && ele.security_id === data.security_id) {
+      findings.push({
+        severity: "error",
+        check: "no-retraction",
+        message: `An equity compensation retraction (${ele.id}) references the transaction's security_id.`,
+        subject,
+      });
     }
   });
 
-  if (!equity_compensation_retraction_exists) {
-    no_equity_compensation_retraction_validity = true;
-    report.no_equity_compensation_retraction_validity = true;
-  }
-  if (!no_equity_compensation_retraction_validity) {
-    report.no_equity_compensation_retraction_validity = false;
-  }
-
-  if (
-    incoming_equity_compensationIssuance_validity &&
-    incoming_date_validity &&
-    no_equity_compensation_retraction_validity
-  ) {
-    validity = true;
-  }
-
-  const result = isGuard ? validity : report;
-  
-  return result;
+  return findings;
 };
 
-export default valid_tx_equity_compensation_acceptance;
+export const TX_EQUITY_COMPENSATION_ACCEPTANCE = {
+  effect: "none",
+  validate,
+  checks,
+} satisfies Descriptor;

--- a/ocf_validator/validators/equity_compensation/tx_equity_compensation_cancellation.ts
+++ b/ocf_validator/validators/equity_compensation/tx_equity_compensation_cancellation.ts
@@ -1,79 +1,103 @@
-// Reference for tx_equity_compensation_cancellation: https://open-cap-table-coalition.github.io/Open-Cap-Format-OCF/schema_markdown/schema/objects/transactions/cancellation/StockCancellation/
-/*
-  CURRENT CHECKS:
-    1. Check that equity_compensation issuance in incoming security_id reference by transaction exists in current state.
-    2. Check to ensure that the date of transaction is the same day or after the date of the incoming equity_compensation issuance.
-    3. The security_id of the equity_compensation issuance referred to in the security_id variable must not be the security_id related to any other transactions with the exception of a equity_compensation acceptance transaction.
-*/
+import type { TransactionFor } from "../../../types/ocf-input";
+import type { Check, GradedValidator } from "../../../types/validator";
+import type { Finding } from "../../../types/finding";
+import type { Descriptor } from "../../ocfMachine";
 
-import {OcfMachineContext} from '../../ocfMachine';
+type Cancellation = TransactionFor<"TX_EQUITY_COMPENSATION_CANCELLATION">;
 
-const valid_tx_equity_compensation_cancellation = (
-  context: OcfMachineContext,
-  event: any,
-  isGuard: Boolean = false
-) => {
-  let validity = false;
-  let report: any = {transaction_type: "TX_EQUITY_COMPENSATION_CANCELLATION", transaction_id: event.data.id, transaction_date: event.data.date};
+const checks: readonly Check[] = [
+  {
+    id: "issuance-exists",
+    severity: "error",
+    description:
+      "The equity compensation issuance referenced by the transaction's security_id exists in the current cap-table state.",
+  },
+  {
+    id: "date-order",
+    severity: "error",
+    description:
+      "The transaction is dated on or after the equity compensation issuance it references.",
+  },
+  {
+    id: "no-other-transactions",
+    severity: "error",
+    description:
+      "No other transaction references the transaction's security_id, other than an equity compensation acceptance.",
+  },
+];
 
-  const {transactions} = context.ocfPackageContent;
-  // 1. Check that equity_compensation issuance in incoming security_id reference by transaction exists in current state.
-  let incoming_equity_compensationIssuance_validity = false;
-  context.equityCompensation.forEach((ele: any) => {
-    if (ele.security_id === event.data.security_id) {
-      incoming_equity_compensationIssuance_validity = true;
-      report.incoming_equity_compensationIssuance_validity = true;
+const validate: GradedValidator<Cancellation> = (context, data) => {
+  const findings: Finding[] = [];
+  const subject = { object_type: data.object_type, id: data.id };
+  const { transactions } = context.ocfPackageContent;
+
+  // issuance-exists here matches on security_id alone — unlike the sibling
+  // validators it does not also require object_type TX_EQUITY_COMPENSATION_ISSUANCE.
+  let issuanceExists = false;
+  context.equityCompensation.forEach((ele) => {
+    if (ele.security_id === data.security_id) {
+      issuanceExists = true;
     }
   });
-
-  if (!incoming_equity_compensationIssuance_validity) {
-    report.incoming_equity_compensationIssuance_validity = false;
+  if (!issuanceExists) {
+    findings.push({
+      severity: "error",
+      check: "issuance-exists",
+      message: `No equity compensation issuance with security_id ${data.security_id} exists in the current cap-table state.`,
+      subject,
+    });
   }
 
-  // 2. Check to ensure that the date of transaction is the same day or after the date of the incoming equity_compensation issuance.
-  let incoming_date_validity = false;
-  transactions.forEach((ele: any) => {
+  // date-order scans the full package transaction history for the issuance.
+  // The object_type test leads so it narrows the transaction union to a
+  // security_id-bearing member before the other reads.
+  let dateOrdered = false;
+  transactions.forEach((ele) => {
     if (
-      ele.security_id === event.data.security_id &&
-      ele.object_type === 'TX_EQUITY_COMPENSATION_ISSUANCE'
+      ele.object_type === "TX_EQUITY_COMPENSATION_ISSUANCE" &&
+      ele.security_id === data.security_id &&
+      ele.date <= data.date
     ) {
-      if (ele.date <= event.data.date) {
-        incoming_date_validity = true;
-        report.incoming_date_validity = true;
-      }
+      dateOrdered = true;
     }
   });
-  if (!incoming_date_validity) {
-    report.incoming_date_validity = false;
+  if (!dateOrdered) {
+    findings.push({
+      severity: "error",
+      check: "date-order",
+      message: `The transaction is not dated on or after an equity compensation issuance with security_id ${data.security_id}.`,
+      subject,
+    });
   }
 
-  let only_transaction_validity = true;
-  transactions.map((ele: any) => {
+  // no-other-transactions emits one finding per transaction on this security_id,
+  // exempting the issuance, any equity compensation acceptance, and this
+  // cancellation itself. This scan keeps every transaction type in play, so it
+  // narrows by property presence rather than by discriminant: a transaction that
+  // carries no security_id can never reference this one.
+  transactions.forEach((ele) => {
     if (
-      ele.security_id === event.data.security_id &&
-      ele.object_type !== 'TX_EQUITY_COMPENSATION_ISSUANCE' &&
-      ele.object_type !== 'TX_EQUITY_COMPENSATION_ACCEPTANCE' &&
-      !(ele.object_type === 'TX_EQUITY_COMPENSATION_CANCELLATION' && ele.id === event.data.id)
+      "security_id" in ele &&
+      ele.security_id === data.security_id &&
+      ele.object_type !== "TX_EQUITY_COMPENSATION_ISSUANCE" &&
+      ele.object_type !== "TX_EQUITY_COMPENSATION_ACCEPTANCE" &&
+      !(ele.object_type === "TX_EQUITY_COMPENSATION_CANCELLATION" && ele.id === data.id)
     ) {
-      only_transaction_validity = false;
-      report.only_transaction_validity = false;
+      findings.push({
+        severity: "error",
+        check: "no-other-transactions",
+        message: `Another transaction (${ele.id}) references the transaction's security_id.`,
+        subject,
+      });
     }
   });
-  if (only_transaction_validity) {
-    report.only_transaction_validity = true;
-  }
 
-  if (
-    incoming_equity_compensationIssuance_validity &&
-    incoming_date_validity &&
-    only_transaction_validity
-  ) {
-    validity = true;
-  }
-
-  const result = isGuard ? validity : report;
-  
-  return result;
+  return findings;
 };
 
-export default valid_tx_equity_compensation_cancellation;
+export const TX_EQUITY_COMPENSATION_CANCELLATION = {
+  effect: "remove",
+  collection: "equityCompensation",
+  validate,
+  checks,
+} satisfies Descriptor;

--- a/ocf_validator/validators/equity_compensation/tx_equity_compensation_exercise.ts
+++ b/ocf_validator/validators/equity_compensation/tx_equity_compensation_exercise.ts
@@ -1,64 +1,108 @@
-import { OcfMachineContext } from "../../ocfMachine";
+import type { TransactionFor } from "../../../types/ocf-input";
+import type { Check, GradedValidator } from "../../../types/validator";
+import type { Finding } from "../../../types/finding";
+import type { Descriptor } from "../../ocfMachine";
 
-/*
-CURRENT CHECKS:
-Check that equity_compensation issuance in incoming security_id referenced by transaction exists in current state.
-The date of the equity_compensation issuance referred to in the security_id must have a date equal to or earlier than the date of the equity_compensation exercise
-Any stock issuances with corresponding security IDs referred to in the resulting_security_ids array must exist
-The security_id of the equity_compensation issuance referred to in the security_id variable must not be the security_id related to any other transactions with the exception of a equity_compensation acceptance transaction.
-The dates of any equity_compensation issuances referred to in the resulting_security_ids variables must have a date equal to the date of the equity_compensation exercise
-The stakeholder_id of the equity_compensation issuance referred to in the security_id variable must equal the stakeholder_id of any stock issuances referred to in the resulting_security_ids variable
+type Exercise = TransactionFor<"TX_EQUITY_COMPENSATION_EXERCISE">;
 
-NOT IMPLEMENTED:
-The quantity_converted variable must equal the sum of any equity_compensation issuances referred to in the resulting_security_ids variable
-*/
+const checks: readonly Check[] = [
+  {
+    id: "issuance-exists",
+    severity: "error",
+    description:
+      "The equity compensation issuance referenced by the transaction's security_id exists in the current cap-table state.",
+  },
+  {
+    id: "date-order",
+    severity: "error",
+    description:
+      "The transaction is dated on or after the equity compensation issuance it references.",
+  },
+  {
+    id: "resulting-issuances-exist",
+    severity: "error",
+    description:
+      "The stock issuances named in resulting_security_ids exist in the package transaction history.",
+    implemented: false,
+  },
+  {
+    id: "no-other-transactions",
+    severity: "error",
+    description:
+      "No other transaction references the transaction's security_id, other than an equity compensation acceptance.",
+    implemented: false,
+  },
+  {
+    id: "resulting-dates-match",
+    severity: "error",
+    description:
+      "Each resulting issuance is dated on the same day as the exercise.",
+    implemented: false,
+  },
+  {
+    id: "resulting-stakeholder-matches",
+    severity: "error",
+    description:
+      "Each resulting issuance's stakeholder_id equals the exercised issuance's stakeholder_id.",
+    implemented: false,
+  },
+  {
+    id: "quantity-consistent",
+    severity: "error",
+    description:
+      "The exercised quantity equals the sum of the resulting issuances' quantities.",
+    implemented: false,
+  },
+];
 
-const valid_tx_equity_compensation_exercise = (context: OcfMachineContext, event: any, isGuard: Boolean) => {
-  let validity = false;
+const validate: GradedValidator<Exercise> = (context, data) => {
+  const findings: Finding[] = [];
+  const subject = { object_type: data.object_type, id: data.id };
   const { transactions } = context.ocfPackageContent;
-  let report: any = { transaction_type: "TX_EQUITY_COMPENSATION_EXERCISE", transaction_id: event.data.id, transaction_date: event.data.date };
 
-  // Check that equity_compensation issuance in incoming security_id referenced by transaction exists in current state.
-  let incoming_equity_compensationIssuance_validity = false;
-  
-  context.equityCompensation.forEach((ele: any) => {
-    console.log('ele.security_id', ele.security_id);
-    console.log('event.data.security_id', event.data.security_id);
-    console.log('ele.object_type', ele.object_type);
-    if (ele.security_id === event.data.security_id && ele.object_type === "TX_EQUITY_COMPENSATION_ISSUANCE") {
-      incoming_equity_compensationIssuance_validity = true;
-      report.incoming_equity_compensationIssuance_validity = true;
+  // issuance-exists scans the live equity compensation collection.
+  let issuanceExists = false;
+  context.equityCompensation.forEach((ele) => {
+    if (ele.security_id === data.security_id && ele.object_type === "TX_EQUITY_COMPENSATION_ISSUANCE") {
+      issuanceExists = true;
     }
   });
-  if (!incoming_equity_compensationIssuance_validity) {
-    report.incoming_equity_compensationIssuance_validity = false;
+  if (!issuanceExists) {
+    findings.push({
+      severity: "error",
+      check: "issuance-exists",
+      message: `No equity compensation issuance with security_id ${data.security_id} exists in the current cap-table state.`,
+      subject,
+    });
   }
 
-  // The date of the equity_compensation issuance referred to in the security_id must have a date equal to or earlier than the date of the equity_compensation exercise
-  let incoming_date_validity = false;
-  transactions.forEach((ele: any) => {
-    if (ele.security_id === event.data.security_id && ele.object_type === "TX_EQUITY_COMPENSATION_ISSUANCE") {
-      if (ele.date <= event.data.date) {
-        incoming_date_validity = true;
-        report.incoming_date_validity = true;
-      }
+  // date-order scans the full package transaction history for the issuance.
+  // The object_type test leads so it narrows the transaction union to a
+  // security_id-bearing member before the other reads.
+  let dateOrdered = false;
+  transactions.forEach((ele) => {
+    if (
+      ele.object_type === "TX_EQUITY_COMPENSATION_ISSUANCE" &&
+      ele.security_id === data.security_id &&
+      ele.date <= data.date
+    ) {
+      dateOrdered = true;
     }
   });
-  if (!incoming_date_validity) {
-    report.incoming_date_validity = false;
+  if (!dateOrdered) {
+    findings.push({
+      severity: "error",
+      check: "date-order",
+      message: `The transaction is not dated on or after an equity compensation issuance with security_id ${data.security_id}.`,
+      subject,
+    });
   }
 
-
-  if (
-    incoming_equity_compensationIssuance_validity &&
-    incoming_date_validity
-  ) {
-    validity = true;
-  }
-
-  const result = isGuard ? validity : report;
-
-  return result;
+  return findings;
 };
 
-export default valid_tx_equity_compensation_exercise;
+export const TX_EQUITY_COMPENSATION_EXERCISE = {
+  effect: "none",
+  validate,
+  checks,
+} satisfies Descriptor;

--- a/ocf_validator/validators/equity_compensation/tx_equity_compensation_issuance.ts
+++ b/ocf_validator/validators/equity_compensation/tx_equity_compensation_issuance.ts
@@ -1,27 +1,40 @@
-const valid_tx_equity_compensation_issuance = (context: any, event: any, isGuard: any) => {
-  let validity = false;
+import type { OCFEquityCompensationIssuance } from "@opencaptablecoalition/ocf-types";
+import type { Check, GradedValidator } from "../../../types/validator";
+import type { Finding } from "../../../types/finding";
+import type { Descriptor } from "../../ocfMachine";
+
+const checks: readonly Check[] = [
+  {
+    id: "stakeholder-exists",
+    severity: "error",
+    description:
+      "The stakeholder referenced by the transaction exists in the stakeholder file.",
+  },
+];
+
+const validate: GradedValidator<OCFEquityCompensationIssuance> = (context, data) => {
+  const findings: Finding[] = [];
   const { stakeholders } = context.ocfPackageContent;
-  let report: any = {transaction_type: "TX_EQUITY_COMPENSATION_ISSUANCE", transaction_id: event.data.id, transaction_date: event.data.date};
-  
-  // Check if the stakeholder referenced by the transaction exists in the stakeholder file.
-  let stakeholder_validity = false;
+
+  let stakeholderExists = false;
   stakeholders.forEach((ele: any) => {
-    if (ele.id === event.data.stakeholder_id) {
-      stakeholder_validity = true;
-      report.stakeholder_validity = true
-    }
+    if (ele.id === data.stakeholder_id) stakeholderExists = true;
   });
-  if (!stakeholder_validity) {
-    report.stakeholder_validity = false
+  if (!stakeholderExists) {
+    findings.push({
+      severity: "error",
+      check: "stakeholder-exists",
+      message: `The stakeholder ${data.stakeholder_id} referenced by the transaction was not found in the stakeholder file.`,
+      subject: { object_type: data.object_type, id: data.id },
+    });
   }
 
-  if (stakeholder_validity) {
-    validity = true;
-  }
-
-  const result = isGuard ? validity : report;
-  
-  return result;
+  return findings;
 };
 
-export default valid_tx_equity_compensation_issuance;
+export const TX_EQUITY_COMPENSATION_ISSUANCE = {
+  effect: "append",
+  collection: "equityCompensation",
+  validate,
+  checks,
+} satisfies Descriptor;

--- a/ocf_validator/validators/equity_compensation/tx_equity_compensation_release.ts
+++ b/ocf_validator/validators/equity_compensation/tx_equity_compensation_release.ts
@@ -1,53 +1,73 @@
-const valid_tx_equity_compensation_release = (context: any, event: any, isGuard: Boolean) => {
-  const {transactions} = context.ocfPackageContent;
+import type { TransactionFor } from "../../../types/ocf-input";
+import type { Check, GradedValidator } from "../../../types/validator";
+import type { Finding } from "../../../types/finding";
+import type { Descriptor } from "../../ocfMachine";
 
-  let validity = false;
-  let report: any = {transaction_type: "TX_EQUITY_COMPENSATION_RELEASE", transaction_id: event.data.id, transaction_date: event.data.date};
+type Release = TransactionFor<"TX_EQUITY_COMPENSATION_RELEASE">;
 
-  // Check that equity_compensation issuance in incoming security_id referenced by transaction exists in current state.
-  let incoming_equity_compensationIssuance_validity = false;
-  context.equity_compensationIssuances.forEach((ele: any) => {
-    if (
-      ele.security_id === event.data.security_id &&
-      ele.object_type === 'TX_EQUITY_COMPENSATION_ISSUANCE'
-    ) {
-      incoming_equity_compensationIssuance_validity = true;
-      report.incoming_equity_compensationIssuance_validity = true;
+const checks: readonly Check[] = [
+  {
+    id: "issuance-exists",
+    severity: "error",
+    description:
+      "The equity compensation issuance referenced by the transaction's security_id exists in the current cap-table state.",
+  },
+  {
+    id: "date-order",
+    severity: "error",
+    description:
+      "The transaction is dated on or after the equity compensation issuance it references.",
+  },
+];
+
+const validate: GradedValidator<Release> = (context, data) => {
+  const findings: Finding[] = [];
+  const subject = { object_type: data.object_type, id: data.id };
+  const { transactions } = context.ocfPackageContent;
+
+  // issuance-exists scans the live equity compensation collection.
+  let issuanceExists = false;
+  context.equityCompensation.forEach((ele) => {
+    if (ele.security_id === data.security_id && ele.object_type === "TX_EQUITY_COMPENSATION_ISSUANCE") {
+      issuanceExists = true;
     }
   });
-  if (!incoming_equity_compensationIssuance_validity) {
-    report.incoming_equity_compensationIssuance_validity = false;
+  if (!issuanceExists) {
+    findings.push({
+      severity: "error",
+      check: "issuance-exists",
+      message: `No equity compensation issuance with security_id ${data.security_id} exists in the current cap-table state.`,
+      subject,
+    });
   }
 
-  // Check to ensure that the date of transaction is the same day or after the date of the incoming equity_compensation issuance.
-  let incoming_date_validity = false;
-  transactions.forEach((ele: any) => {
+  // date-order scans the full package transaction history for the issuance.
+  // The object_type test leads so it narrows the transaction union to a
+  // security_id-bearing member before the other reads.
+  let dateOrdered = false;
+  transactions.forEach((ele) => {
     if (
-      ele.security_id === event.data.security_id &&
-      ele.object_type === 'TX_EQUITY_COMPENSATION_ISSUANCE'
+      ele.object_type === "TX_EQUITY_COMPENSATION_ISSUANCE" &&
+      ele.security_id === data.security_id &&
+      ele.date <= data.date
     ) {
-      if (ele.date <= event.data.date) {
-        incoming_date_validity = true;
-        report.incoming_date_validity = true;
-      }
+      dateOrdered = true;
     }
   });
-  if (!incoming_date_validity) {
-    report.incoming_date_validity = false;
+  if (!dateOrdered) {
+    findings.push({
+      severity: "error",
+      check: "date-order",
+      message: `The transaction is not dated on or after an equity compensation issuance with security_id ${data.security_id}.`,
+      subject,
+    });
   }
 
- 
-
-  if (
-    incoming_equity_compensationIssuance_validity &&
-    incoming_date_validity
-  ) {
-    validity = true;
-  }
-
-  const result = isGuard ? validity : report;
-  
-  return result;
+  return findings;
 };
 
-export default valid_tx_equity_compensation_release;
+export const TX_EQUITY_COMPENSATION_RELEASE = {
+  effect: "none",
+  validate,
+  checks,
+} satisfies Descriptor;

--- a/ocf_validator/validators/equity_compensation/tx_equity_compensation_retraction.ts
+++ b/ocf_validator/validators/equity_compensation/tx_equity_compensation_retraction.ts
@@ -1,75 +1,91 @@
-const valid_tx_equity_compensation_retraction = (context: any, event: any, isGuard: Boolean = false) => {
-  let validity = false;
+import type { TransactionFor } from "../../../types/ocf-input";
+import type { Check, GradedValidator } from "../../../types/validator";
+import type { Finding } from "../../../types/finding";
+import type { Descriptor } from "../../ocfMachine";
 
-  let report: any = {transaction_type: "TX_EQUITY_COMPENSATION_RETRACTION", transaction_id: event.data.id, transaction_date: event.data.date};
+type Retraction = TransactionFor<"TX_EQUITY_COMPENSATION_RETRACTION">;
 
-  // TBC: validation of tx_equity_compensation_retraction
-  const {transactions} = context.ocfPackageContent;
-  // Check that equity_compensation issuance in incoming security_id referenced by transaction exists in current state.
-  let incoming_equity_compensationIssuance_validity = false;
-  context.equity_compensationIssuances.forEach((ele: any) => {
-    if (
-      ele.security_id === event.data.security_id &&
-      ele.object_type === 'TX_EQUITY_COMPENSATION_ISSUANCE'
-    ) {
-      incoming_equity_compensationIssuance_validity = true;
-      report.incoming_equity_compensationIssuance_validity = true
+const checks: readonly Check[] = [
+  {
+    id: "issuance-exists",
+    severity: "error",
+    description:
+      "The equity compensation issuance referenced by the transaction's security_id exists in the current cap-table state.",
+  },
+  {
+    id: "date-order",
+    severity: "error",
+    description:
+      "The transaction is dated on or after the equity compensation issuance it references.",
+  },
+  {
+    id: "no-acceptance",
+    severity: "error",
+    description: "No equity compensation acceptance references the transaction's security_id.",
+  },
+];
+
+const validate: GradedValidator<Retraction> = (context, data) => {
+  const findings: Finding[] = [];
+  const subject = { object_type: data.object_type, id: data.id };
+  const { transactions } = context.ocfPackageContent;
+
+  // issuance-exists scans the live equity compensation collection.
+  let issuanceExists = false;
+  context.equityCompensation.forEach((ele) => {
+    if (ele.security_id === data.security_id && ele.object_type === "TX_EQUITY_COMPENSATION_ISSUANCE") {
+      issuanceExists = true;
     }
   });
-  if (!incoming_equity_compensationIssuance_validity) {
-    report.incoming_equity_compensationIssuance_validity = false
-
+  if (!issuanceExists) {
+    findings.push({
+      severity: "error",
+      check: "issuance-exists",
+      message: `No equity compensation issuance with security_id ${data.security_id} exists in the current cap-table state.`,
+      subject,
+    });
   }
 
-  // Check to ensure that the date of transaction is the same day or after the date of the incoming equity_compensation issuance.
-  let incoming_date_validity = false;
-  transactions.forEach((ele: any) => {
+  // date-order scans the full package transaction history for the issuance.
+  // The object_type test leads so it narrows the transaction union to a
+  // security_id-bearing member before the other reads.
+  let dateOrdered = false;
+  transactions.forEach((ele) => {
     if (
-      ele.security_id === event.data.security_id &&
-      ele.object_type === 'TX_EQUITY_COMPENSATION_ISSUANCE'
+      ele.object_type === "TX_EQUITY_COMPENSATION_ISSUANCE" &&
+      ele.security_id === data.security_id &&
+      ele.date <= data.date
     ) {
-      if (ele.date <= event.data.date) {
-        incoming_date_validity = true;
-        report.incoming_date_validity = true;
-      }
+      dateOrdered = true;
     }
   });
-  if (!incoming_date_validity) {
-    report.incoming_date_validity = false;
-
+  if (!dateOrdered) {
+    findings.push({
+      severity: "error",
+      check: "date-order",
+      message: `The transaction is not dated on or after an equity compensation issuance with security_id ${data.security_id}.`,
+      subject,
+    });
   }
 
-  // Check that equity_compensation issuance in incoming security_id does not have a equity_compensation acceptance transaction associated with it.
-  let no_equity_compensation_acceptance_validity = false;
-  let equity_compensation_acceptance_exists = false;
-  transactions.forEach((ele: any) => {
-    if (
-      ele.security_id === event.data.security_id &&
-      ele.object_type === 'TX_EQUITY_COMPENSATION_ACCEPTANCE'
-    ) {
-      equity_compensation_acceptance_exists = true;
+  // no-acceptance emits one finding per equity compensation acceptance on this security_id.
+  transactions.forEach((ele) => {
+    if (ele.object_type === "TX_EQUITY_COMPENSATION_ACCEPTANCE" && ele.security_id === data.security_id) {
+      findings.push({
+        severity: "error",
+        check: "no-acceptance",
+        message: `An equity compensation acceptance (${ele.id}) references the transaction's security_id.`,
+        subject,
+      });
     }
   });
 
-  if (!equity_compensation_acceptance_exists) {
-    no_equity_compensation_acceptance_validity = true;
-    report.no_equity_compensation_acceptance_validity = true;
-  }
-  if (!no_equity_compensation_acceptance_validity) {
-    report.no_equity_compensation_acceptance_validity = false;
-  }
-
-  if (
-    incoming_equity_compensationIssuance_validity &&
-    incoming_date_validity &&
-    no_equity_compensation_acceptance_validity
-  ) {
-    validity = true;
-  }
-
-  const result = isGuard ? validity : report;
-  
-  return result;
+  return findings;
 };
 
-export default valid_tx_equity_compensation_retraction;
+export const TX_EQUITY_COMPENSATION_RETRACTION = {
+  effect: "remove",
+  collection: "equityCompensation",
+  validate,
+  checks,
+} satisfies Descriptor;

--- a/ocf_validator/validators/equity_compensation/tx_equity_compensation_transfer.ts
+++ b/ocf_validator/validators/equity_compensation/tx_equity_compensation_transfer.ts
@@ -1,63 +1,81 @@
-import {OcfMachineContext} from '../../ocfMachine';
-// Reference for tx_equity_compensation_transfer transaction: https://open-cap-table-coalition.github.io/Open-Cap-Format-OCF/schema_markdown/schema/objects/transactions/transfer/StockTransfer/
+import type { TransactionFor } from "../../../types/ocf-input";
+import type { Check, GradedValidator } from "../../../types/validator";
+import type { Finding } from "../../../types/finding";
+import type { Descriptor } from "../../ocfMachine";
 
-/*
-  CURRENT CHECKS:
-    1. Does the incoming security_id referenced by transaction exist in current cap table state?
-    2. Is the date of transaction the same day or after the date of the incoming issuance?
- MISSING CHECKS:
-    1. The security_id of the equity_compensation issuance referred to in the security_id variable must not be the security_id related to any other transactions with the exception of a equity_compensation acceptance transaction.
-*/
+type Transfer = TransactionFor<"TX_EQUITY_COMPENSATION_TRANSFER">;
 
-const valid_tx_equity_compensation_transfer = (context: OcfMachineContext, event: any, isGuard: Boolean) => {
-  let validity = false;
-  const {transactions} = context.ocfPackageContent;
-  let report: any = {transaction_type: "TX_EQUITY_COMPENSATION_TRANSFER", transaction_id: event.data.id, transaction_date: event.data.date};
+const checks: readonly Check[] = [
+  {
+    id: "issuance-exists",
+    severity: "error",
+    description:
+      "The equity compensation issuance referenced by the transaction's security_id exists in the current cap-table state.",
+  },
+  {
+    id: "date-order",
+    severity: "error",
+    description:
+      "The transaction is dated on or after the equity compensation issuance it references.",
+  },
+  {
+    id: "no-other-transactions",
+    severity: "error",
+    description:
+      "No other transaction references the transaction's security_id, other than an equity compensation acceptance.",
+    implemented: false,
+  },
+];
 
-  // Check that equity_compensation issuance in incoming security_id referenced by transaction exists in current state.
-  let incoming_equity_compensationIssuance_validity = false;
-  context.equityCompensation.map((ele: any) => {
-    if (
-      ele.security_id === event.data.security_id &&
-      ele.object_type === 'TX_EQUITY_COMPENSATION_ISSUANCE'
-    ) {
-      incoming_equity_compensationIssuance_validity = true;
-      report.incoming_equity_compensationIssuance_validity = true;
+const validate: GradedValidator<Transfer> = (context, data) => {
+  const findings: Finding[] = [];
+  const subject = { object_type: data.object_type, id: data.id };
+  const { transactions } = context.ocfPackageContent;
+
+  // issuance-exists scans the live equity compensation collection.
+  let issuanceExists = false;
+  context.equityCompensation.forEach((ele) => {
+    if (ele.security_id === data.security_id && ele.object_type === "TX_EQUITY_COMPENSATION_ISSUANCE") {
+      issuanceExists = true;
     }
   });
-  if (!incoming_equity_compensationIssuance_validity) {
-    report.incoming_equity_compensationIssuance_validity = false;
+  if (!issuanceExists) {
+    findings.push({
+      severity: "error",
+      check: "issuance-exists",
+      message: `No equity compensation issuance with security_id ${data.security_id} exists in the current cap-table state.`,
+      subject,
+    });
   }
 
-  // Check to ensure that the date of transaction is the same day or after the date of the incoming equity_compensation issuance.
-  let incoming_date_validity = false;
-  transactions.map((ele: any) => {
+  // date-order scans the full package transaction history for the issuance.
+  // The object_type test leads so it narrows the transaction union to a
+  // security_id-bearing member before the other reads.
+  let dateOrdered = false;
+  transactions.forEach((ele) => {
     if (
-      ele.security_id === event.data.security_id &&
-      ele.object_type === 'TX_EQUITY_COMPENSATION_ISSUANCE'
+      ele.object_type === "TX_EQUITY_COMPENSATION_ISSUANCE" &&
+      ele.security_id === data.security_id &&
+      ele.date <= data.date
     ) {
-      if (ele.date <= event.data.date) {
-        incoming_date_validity = true;
-        report.incoming_date_validity = true;
-      }
+      dateOrdered = true;
     }
   });
-  if (!incoming_date_validity) {
-    report.incoming_date_validity = false;
+  if (!dateOrdered) {
+    findings.push({
+      severity: "error",
+      check: "date-order",
+      message: `The transaction is not dated on or after an equity compensation issuance with security_id ${data.security_id}.`,
+      subject,
+    });
   }
 
- 
-
-  if (
-    incoming_equity_compensationIssuance_validity &&
-    incoming_date_validity
-  ) {
-    validity = true;
-  }
-
-  const result = isGuard ? validity : report;
-  
-  return result;
+  return findings;
 };
 
-export default valid_tx_equity_compensation_transfer;
+export const TX_EQUITY_COMPENSATION_TRANSFER = {
+  effect: "remove",
+  collection: "equityCompensation",
+  validate,
+  checks,
+} satisfies Descriptor;

--- a/ocf_validator/validators/index.ts
+++ b/ocf_validator/validators/index.ts
@@ -8,13 +8,6 @@ import valid_tx_stock_repurchase from './stock/tx_stock_repurchase';
 import valid_tx_stock_transfer from './stock/tx_stock_transfer';
 import valid_tx_convertible_conversion from './convertible/tx_convertible_conversion';
 import valid_tx_warrant_exercise from './warrant/tx_warrant_exercise';
-import valid_tx_equity_compensation_issuance from './equity_compensation/tx_equity_compensation_issuance';
-import valid_tx_equity_compensation_retraction from './equity_compensation/tx_equity_compensation_retraction';
-import valid_tx_equity_compensation_acceptance from './equity_compensation/tx_equity_compensation_acceptance';
-import valid_tx_equity_compensation_cancellation from './equity_compensation/tx_equity_compensation_cancellation';
-import valid_tx_equity_compensation_release from './equity_compensation/tx_equity_compensation_release';
-import valid_tx_equity_compensation_transfer from './equity_compensation/tx_equity_compensation_transfer';
-import valid_tx_equity_compensation_exercise from './equity_compensation/tx_equity_compensation_exercise';
 import valid_tx_plan_security_issuance from './plan_security/tx_plan_security_issuance';
 import valid_tx_plan_security_retraction from './plan_security/tx_plan_security_retraction';
 import valid_tx_plan_security_acceptance from './plan_security/tx_plan_security_acceptance';
@@ -42,13 +35,6 @@ const validators = {
   valid_tx_stock_transfer,
   valid_tx_convertible_conversion,
   valid_tx_warrant_exercise,
-  valid_tx_equity_compensation_issuance,
-  valid_tx_equity_compensation_retraction,
-  valid_tx_equity_compensation_acceptance,
-  valid_tx_equity_compensation_cancellation,
-  valid_tx_equity_compensation_release,
-  valid_tx_equity_compensation_transfer,
-  valid_tx_equity_compensation_exercise,
   valid_tx_plan_security_issuance,
   valid_tx_plan_security_retraction,
   valid_tx_plan_security_acceptance,

--- a/tests/__snapshots__/characterization.test.ts.snap
+++ b/tests/__snapshots__/characterization.test.ts.snap
@@ -36,14 +36,7 @@ exports[`ocfValidator over testPackage > produces a stable validation result and
   ],
   "findings": [],
   "lastErrorFindings": [],
-  "report": [
-    {
-      "stakeholder_validity": true,
-      "transaction_date": "2019-06-01",
-      "transaction_id": "eci_01",
-      "transaction_type": "TX_EQUITY_COMPENSATION_ISSUANCE",
-    },
-  ],
+  "report": [],
   "result": "The validation of the OCF package for Acme Holdings Limited is complete and the package appears valid.",
   "snapshots": [
     {

--- a/tests/equityCompensationValidators.test.ts
+++ b/tests/equityCompensationValidators.test.ts
@@ -1,0 +1,698 @@
+import { describe, it, expect } from "vitest";
+import { TX_DESCRIPTORS } from "../ocf_validator/ocfMachine";
+import type { Finding } from "../types/finding";
+import type { GradedValidator, OcfMachineContext } from "../types/validator";
+import { baseContext, startSeeded, ev } from "./helpers";
+
+/** A context whose package `transactions` list is `transactions`. */
+const contextWith = (
+  overrides: Partial<OcfMachineContext> & { transactions?: any[] } = {},
+): OcfMachineContext => {
+  const { transactions = [], ...rest } = overrides;
+  return baseContext({
+    ...rest,
+    ocfPackageContent: {
+      ...baseContext().ocfPackageContent,
+      transactions,
+    } as OcfMachineContext["ocfPackageContent"],
+  });
+};
+
+const MIGRATED_KEYS = [
+  "TX_EQUITY_COMPENSATION_ISSUANCE",
+  "TX_EQUITY_COMPENSATION_ACCEPTANCE",
+  "TX_EQUITY_COMPENSATION_EXERCISE",
+  "TX_EQUITY_COMPENSATION_RELEASE",
+  "TX_EQUITY_COMPENSATION_RETRACTION",
+  "TX_EQUITY_COMPENSATION_CANCELLATION",
+  "TX_EQUITY_COMPENSATION_TRANSFER",
+] as const;
+type MigratedKey = (typeof MIGRATED_KEYS)[number];
+
+/** Invoke the graded validator a migrated descriptor carries. */
+const runValidator = (
+  key: MigratedKey,
+  context: OcfMachineContext,
+  data: Record<string, unknown>,
+): Finding[] => {
+  const descriptor = TX_DESCRIPTORS[key] as { validate?: GradedValidator<any> };
+  if (!descriptor.validate) throw new Error(`${key} carries no graded validate`);
+  return descriptor.validate(context, data);
+};
+
+/** The check ids a descriptor declares as implemented (drops `implemented: false`). */
+const implementedCheckIds = (key: MigratedKey): string[] => {
+  const descriptor = TX_DESCRIPTORS[key] as { checks?: readonly { id: string; implemented?: false }[] };
+  return (descriptor.checks ?? []).filter((c) => c.implemented !== false).map((c) => c.id);
+};
+
+/** Assert a finding carries the declared id, error severity, and the transaction as subject. */
+const expectFindingShape = (
+  finding: Finding,
+  check: string,
+  subject: { object_type: string; id: string },
+) => {
+  expect(finding.check).toBe(check);
+  expect(finding.severity).toBe("error");
+  expect(finding.subject).toEqual(subject);
+};
+
+// A single equity compensation issuance, in the shape both the live collection
+// and the package transaction history hold it. `date` lets a scenario push the
+// issuance after the transaction under validation to trip the date-order check.
+const issuanceRecord = (security_id: string, date = "2020-01-01") => ({
+  id: `eci-${security_id}`,
+  object_type: "TX_EQUITY_COMPENSATION_ISSUANCE",
+  security_id,
+  date,
+});
+
+// ---------------------------------------------------------------------------
+// Issuance: stakeholder-exists
+// ---------------------------------------------------------------------------
+
+describe("equity compensation issuance validity", () => {
+  const withStakeholder = (id: string) =>
+    baseContext({
+      ocfPackageContent: {
+        ...baseContext().ocfPackageContent,
+        stakeholders: [{ id }],
+      } as OcfMachineContext["ocfPackageContent"],
+    });
+
+  const issuance = (overrides: Record<string, unknown> = {}) => ({
+    id: "eci1",
+    object_type: "TX_EQUITY_COMPENSATION_ISSUANCE",
+    security_id: "sec1",
+    stakeholder_id: "sh1",
+    date: "2021-01-01",
+    ...overrides,
+  });
+
+  it("returns no findings when the referenced stakeholder exists", () => {
+    const findings = runValidator("TX_EQUITY_COMPENSATION_ISSUANCE", withStakeholder("sh1"), issuance());
+    expect(findings).toEqual([]);
+  });
+
+  it("flags a missing stakeholder with an error naming the stakeholder_id", () => {
+    const findings = runValidator("TX_EQUITY_COMPENSATION_ISSUANCE", withStakeholder("someone-else"), issuance());
+    expect(findings).toHaveLength(1);
+    expectFindingShape(findings[0], "stakeholder-exists", {
+      object_type: "TX_EQUITY_COMPENSATION_ISSUANCE",
+      id: "eci1",
+    });
+    expect(findings[0].message).toContain("sh1");
+  });
+
+  it("appends a valid issuance to equityCompensation and stays in capTable", () => {
+    const actor = startSeeded(withStakeholder("sh1"));
+    actor.send(ev("TX_EQUITY_COMPENSATION_ISSUANCE", issuance()));
+
+    const snapshot = actor.getSnapshot();
+    expect(snapshot.value).toBe("capTable");
+    expect(snapshot.context.equityCompensation).toHaveLength(1);
+    expect(snapshot.context.equityCompensation[0]).toMatchObject({ id: "eci1", security_id: "sec1" });
+    expect(snapshot.context.findings).toEqual([]);
+  });
+
+  it("halts an invalid issuance in validationError with the error finding recorded", () => {
+    const actor = startSeeded(withStakeholder("someone-else"));
+    actor.send(ev("TX_EQUITY_COMPENSATION_ISSUANCE", issuance()));
+
+    const snapshot = actor.getSnapshot();
+    expect(snapshot.value).toBe("validationError");
+    expect(snapshot.context.findings).toHaveLength(1);
+    expect(snapshot.context.findings[0].check).toBe("stakeholder-exists");
+    expect(snapshot.context.equityCompensation).toEqual([]);
+    expect(snapshot.context.result).toContain("stakeholder-exists");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Acceptance: issuance-exists, date-order, no-retraction
+// ---------------------------------------------------------------------------
+
+describe("equity compensation acceptance validity", () => {
+  const acceptance = (overrides: Record<string, unknown> = {}) => ({
+    id: "acc1",
+    object_type: "TX_EQUITY_COMPENSATION_ACCEPTANCE",
+    security_id: "sec1",
+    date: "2021-01-01",
+    ...overrides,
+  });
+  const subject = { object_type: "TX_EQUITY_COMPENSATION_ACCEPTANCE", id: "acc1" };
+
+  it("returns no findings when the issuance exists, dates order, and no retraction references it", () => {
+    const context = contextWith({
+      equityCompensation: [issuanceRecord("sec1")] as any,
+      transactions: [issuanceRecord("sec1")],
+    });
+    expect(runValidator("TX_EQUITY_COMPENSATION_ACCEPTANCE", context, acceptance())).toEqual([]);
+  });
+
+  it("leaves the machine in capTable without mutating collections on the valid branch", () => {
+    const seeded = contextWith({
+      equityCompensation: [issuanceRecord("sec1")] as any,
+      transactions: [issuanceRecord("sec1")],
+    });
+    const before = structuredClone(seeded.equityCompensation);
+
+    const actor = startSeeded(seeded);
+    actor.send(ev("TX_EQUITY_COMPENSATION_ACCEPTANCE", acceptance()));
+
+    const snapshot = actor.getSnapshot();
+    expect(snapshot.value).toBe("capTable");
+    expect(snapshot.context.equityCompensation).toEqual(before);
+    expect(snapshot.context.findings).toEqual([]);
+  });
+
+  it("flags a missing issuance with an error naming the security_id", () => {
+    // In the package history (date-order passes) but not the live collection.
+    const context = contextWith({ transactions: [issuanceRecord("sec1")] });
+    const findings = runValidator("TX_EQUITY_COMPENSATION_ACCEPTANCE", context, acceptance());
+    expect(findings).toHaveLength(1);
+    expectFindingShape(findings[0], "issuance-exists", subject);
+    expect(findings[0].message).toContain("sec1");
+  });
+
+  it("flags an out-of-order date with an error naming the security_id", () => {
+    // Issuance is live (issuance-exists passes) but dated after the acceptance.
+    const context = contextWith({
+      equityCompensation: [issuanceRecord("sec1", "2022-01-01")] as any,
+      transactions: [issuanceRecord("sec1", "2022-01-01")],
+    });
+    const findings = runValidator("TX_EQUITY_COMPENSATION_ACCEPTANCE", context, acceptance());
+    expect(findings).toHaveLength(1);
+    expectFindingShape(findings[0], "date-order", subject);
+    expect(findings[0].message).toContain("sec1");
+  });
+
+  it("emits one no-retraction finding per offending retraction, each naming that retraction", () => {
+    const context = contextWith({
+      equityCompensation: [issuanceRecord("sec1")] as any,
+      transactions: [
+        issuanceRecord("sec1"),
+        { id: "ret-a", object_type: "TX_EQUITY_COMPENSATION_RETRACTION", security_id: "sec1", date: "2021-06-01" },
+        { id: "ret-b", object_type: "TX_EQUITY_COMPENSATION_RETRACTION", security_id: "sec1", date: "2021-07-01" },
+      ],
+    });
+    const findings = runValidator("TX_EQUITY_COMPENSATION_ACCEPTANCE", context, acceptance());
+    expect(findings).toHaveLength(2);
+    for (const finding of findings) expectFindingShape(finding, "no-retraction", subject);
+    expect(findings.map((f) => f.message).join("\n")).toContain("ret-a");
+    expect(findings.map((f) => f.message).join("\n")).toContain("ret-b");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Retraction: issuance-exists, date-order, no-acceptance
+// ---------------------------------------------------------------------------
+
+describe("equity compensation retraction validity", () => {
+  const retraction = (overrides: Record<string, unknown> = {}) => ({
+    id: "ret1",
+    object_type: "TX_EQUITY_COMPENSATION_RETRACTION",
+    security_id: "sec1",
+    date: "2021-01-01",
+    ...overrides,
+  });
+  const subject = { object_type: "TX_EQUITY_COMPENSATION_RETRACTION", id: "ret1" };
+
+  it("returns no findings when the issuance exists, dates order, and no acceptance references it", () => {
+    const context = contextWith({
+      equityCompensation: [issuanceRecord("sec1")] as any,
+      transactions: [issuanceRecord("sec1")],
+    });
+    expect(runValidator("TX_EQUITY_COMPENSATION_RETRACTION", context, retraction())).toEqual([]);
+  });
+
+  it("removes the referenced security from equityCompensation on the valid branch", () => {
+    const seeded = contextWith({
+      equityCompensation: [issuanceRecord("sec1"), issuanceRecord("sec2")] as any,
+      transactions: [issuanceRecord("sec1"), issuanceRecord("sec2")],
+    });
+    const actor = startSeeded(seeded);
+    actor.send(ev("TX_EQUITY_COMPENSATION_RETRACTION", retraction()));
+
+    const snapshot = actor.getSnapshot();
+    expect(snapshot.value).toBe("capTable");
+    expect(snapshot.context.equityCompensation.some((e: any) => e.security_id === "sec1")).toBe(false);
+    expect(snapshot.context.equityCompensation.some((e: any) => e.security_id === "sec2")).toBe(true);
+    expect(snapshot.context.findings).toEqual([]);
+  });
+
+  it("flags a missing issuance with an error naming the security_id", () => {
+    const context = contextWith({ transactions: [issuanceRecord("sec1")] });
+    const findings = runValidator("TX_EQUITY_COMPENSATION_RETRACTION", context, retraction());
+    expect(findings).toHaveLength(1);
+    expectFindingShape(findings[0], "issuance-exists", subject);
+    expect(findings[0].message).toContain("sec1");
+  });
+
+  it("flags an out-of-order date with an error naming the security_id", () => {
+    const context = contextWith({
+      equityCompensation: [issuanceRecord("sec1", "2022-01-01")] as any,
+      transactions: [issuanceRecord("sec1", "2022-01-01")],
+    });
+    const findings = runValidator("TX_EQUITY_COMPENSATION_RETRACTION", context, retraction());
+    expect(findings).toHaveLength(1);
+    expectFindingShape(findings[0], "date-order", subject);
+    expect(findings[0].message).toContain("sec1");
+  });
+
+  it("emits one no-acceptance finding per offending acceptance, each naming that acceptance", () => {
+    const context = contextWith({
+      equityCompensation: [issuanceRecord("sec1")] as any,
+      transactions: [
+        issuanceRecord("sec1"),
+        { id: "acc-a", object_type: "TX_EQUITY_COMPENSATION_ACCEPTANCE", security_id: "sec1", date: "2021-06-01" },
+        { id: "acc-b", object_type: "TX_EQUITY_COMPENSATION_ACCEPTANCE", security_id: "sec1", date: "2021-07-01" },
+      ],
+    });
+    const findings = runValidator("TX_EQUITY_COMPENSATION_RETRACTION", context, retraction());
+    expect(findings).toHaveLength(2);
+    for (const finding of findings) expectFindingShape(finding, "no-acceptance", subject);
+    expect(findings.map((f) => f.message).join("\n")).toContain("acc-a");
+    expect(findings.map((f) => f.message).join("\n")).toContain("acc-b");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cancellation: issuance-exists, date-order, no-other-transactions
+// ---------------------------------------------------------------------------
+
+describe("equity compensation cancellation validity", () => {
+  const cancellation = (overrides: Record<string, unknown> = {}) => ({
+    id: "can1",
+    object_type: "TX_EQUITY_COMPENSATION_CANCELLATION",
+    security_id: "sec1",
+    date: "2021-01-01",
+    ...overrides,
+  });
+  const cancellationRecord = { id: "can1", object_type: "TX_EQUITY_COMPENSATION_CANCELLATION", security_id: "sec1", date: "2021-01-01" };
+  const acceptanceRecord = { id: "acc-x", object_type: "TX_EQUITY_COMPENSATION_ACCEPTANCE", security_id: "sec1", date: "2021-02-01" };
+  const subject = { object_type: "TX_EQUITY_COMPENSATION_CANCELLATION", id: "can1" };
+
+  it("returns no findings when only an issuance, an acceptance, and the cancellation itself reference the security", () => {
+    const context = contextWith({
+      equityCompensation: [issuanceRecord("sec1")] as any,
+      transactions: [issuanceRecord("sec1"), acceptanceRecord, cancellationRecord],
+    });
+    expect(runValidator("TX_EQUITY_COMPENSATION_CANCELLATION", context, cancellation())).toEqual([]);
+  });
+
+  it("treats any live equity compensation record matched by security_id as the issuance, regardless of object_type", () => {
+    // The existence check matches on security_id alone; a non-issuance object_type
+    // in the live collection still satisfies it.
+    const context = contextWith({
+      equityCompensation: [{ id: "x", object_type: "SOMETHING_ELSE", security_id: "sec1", date: "2020-01-01" }] as any,
+      transactions: [issuanceRecord("sec1")],
+    });
+    expect(runValidator("TX_EQUITY_COMPENSATION_CANCELLATION", context, cancellation())).toEqual([]);
+  });
+
+  it("removes the referenced security from equityCompensation on the valid branch", () => {
+    const seeded = contextWith({
+      equityCompensation: [issuanceRecord("sec1"), issuanceRecord("sec2")] as any,
+      transactions: [issuanceRecord("sec1"), issuanceRecord("sec2")],
+    });
+    const actor = startSeeded(seeded);
+    actor.send(ev("TX_EQUITY_COMPENSATION_CANCELLATION", cancellation()));
+
+    const snapshot = actor.getSnapshot();
+    expect(snapshot.value).toBe("capTable");
+    expect(snapshot.context.equityCompensation.some((e: any) => e.security_id === "sec1")).toBe(false);
+    expect(snapshot.context.equityCompensation.some((e: any) => e.security_id === "sec2")).toBe(true);
+  });
+
+  it("flags a missing issuance with an error naming the security_id", () => {
+    const context = contextWith({ transactions: [issuanceRecord("sec1")] });
+    const findings = runValidator("TX_EQUITY_COMPENSATION_CANCELLATION", context, cancellation());
+    expect(findings).toHaveLength(1);
+    expectFindingShape(findings[0], "issuance-exists", subject);
+    expect(findings[0].message).toContain("sec1");
+  });
+
+  it("flags an out-of-order date with an error naming the security_id", () => {
+    const context = contextWith({
+      equityCompensation: [issuanceRecord("sec1", "2022-01-01")] as any,
+      transactions: [issuanceRecord("sec1", "2022-01-01")],
+    });
+    const findings = runValidator("TX_EQUITY_COMPENSATION_CANCELLATION", context, cancellation());
+    expect(findings).toHaveLength(1);
+    expectFindingShape(findings[0], "date-order", subject);
+    expect(findings[0].message).toContain("sec1");
+  });
+
+  it("emits one no-other-transactions finding per offender, exempting acceptances and itself", () => {
+    const context = contextWith({
+      equityCompensation: [issuanceRecord("sec1")] as any,
+      transactions: [
+        issuanceRecord("sec1"),
+        acceptanceRecord,
+        cancellationRecord,
+        { id: "xfer-a", object_type: "TX_EQUITY_COMPENSATION_TRANSFER", security_id: "sec1", date: "2021-06-01" },
+        { id: "xfer-b", object_type: "TX_EQUITY_COMPENSATION_TRANSFER", security_id: "sec1", date: "2021-07-01" },
+      ],
+    });
+    const findings = runValidator("TX_EQUITY_COMPENSATION_CANCELLATION", context, cancellation());
+    expect(findings).toHaveLength(2);
+    for (const finding of findings) expectFindingShape(finding, "no-other-transactions", subject);
+    const messages = findings.map((f) => f.message).join("\n");
+    expect(messages).toContain("xfer-a");
+    expect(messages).toContain("xfer-b");
+    // The exempt acceptance is never named as an offender.
+    expect(messages).not.toContain("acc-x");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Transfer: issuance-exists, date-order (no-other-transactions is a declared gap)
+// ---------------------------------------------------------------------------
+
+describe("equity compensation transfer validity", () => {
+  const transfer = (overrides: Record<string, unknown> = {}) => ({
+    id: "xfer1",
+    object_type: "TX_EQUITY_COMPENSATION_TRANSFER",
+    security_id: "sec1",
+    date: "2021-01-01",
+    ...overrides,
+  });
+  const subject = { object_type: "TX_EQUITY_COMPENSATION_TRANSFER", id: "xfer1" };
+
+  it("returns no findings when the issuance exists and dates order", () => {
+    const context = contextWith({
+      equityCompensation: [issuanceRecord("sec1")] as any,
+      transactions: [issuanceRecord("sec1")],
+    });
+    expect(runValidator("TX_EQUITY_COMPENSATION_TRANSFER", context, transfer())).toEqual([]);
+  });
+
+  it("removes the referenced security from equityCompensation on the valid branch", () => {
+    const seeded = contextWith({
+      equityCompensation: [issuanceRecord("sec1"), issuanceRecord("sec2")] as any,
+      transactions: [issuanceRecord("sec1"), issuanceRecord("sec2")],
+    });
+    const actor = startSeeded(seeded);
+    actor.send(ev("TX_EQUITY_COMPENSATION_TRANSFER", transfer()));
+
+    const snapshot = actor.getSnapshot();
+    expect(snapshot.value).toBe("capTable");
+    expect(snapshot.context.equityCompensation.some((e: any) => e.security_id === "sec1")).toBe(false);
+    expect(snapshot.context.equityCompensation.some((e: any) => e.security_id === "sec2")).toBe(true);
+  });
+
+  it("flags a missing issuance with an error naming the security_id", () => {
+    const context = contextWith({ transactions: [issuanceRecord("sec1")] });
+    const findings = runValidator("TX_EQUITY_COMPENSATION_TRANSFER", context, transfer());
+    expect(findings).toHaveLength(1);
+    expectFindingShape(findings[0], "issuance-exists", subject);
+    expect(findings[0].message).toContain("sec1");
+  });
+
+  it("flags an out-of-order date with an error naming the security_id", () => {
+    const context = contextWith({
+      equityCompensation: [issuanceRecord("sec1", "2022-01-01")] as any,
+      transactions: [issuanceRecord("sec1", "2022-01-01")],
+    });
+    const findings = runValidator("TX_EQUITY_COMPENSATION_TRANSFER", context, transfer());
+    expect(findings).toHaveLength(1);
+    expectFindingShape(findings[0], "date-order", subject);
+    expect(findings[0].message).toContain("sec1");
+  });
+
+  it("never emits no-other-transactions, even when other transactions reference the security", () => {
+    const context = contextWith({
+      equityCompensation: [issuanceRecord("sec1")] as any,
+      transactions: [
+        issuanceRecord("sec1"),
+        { id: "ret-x", object_type: "TX_EQUITY_COMPENSATION_RETRACTION", security_id: "sec1", date: "2021-06-01" },
+        { id: "can-x", object_type: "TX_EQUITY_COMPENSATION_CANCELLATION", security_id: "sec1", date: "2021-07-01" },
+      ],
+    });
+    const findings = runValidator("TX_EQUITY_COMPENSATION_TRANSFER", context, transfer());
+    // The declared gap is never checked, so the transaction stays valid here.
+    expect(findings).toEqual([]);
+    expect(findings.some((f) => f.check === "no-other-transactions")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Exercise: issuance-exists, date-order (five resulting-security checks are gaps)
+// ---------------------------------------------------------------------------
+
+describe("equity compensation exercise validity", () => {
+  const exercise = (overrides: Record<string, unknown> = {}) => ({
+    id: "ex1",
+    object_type: "TX_EQUITY_COMPENSATION_EXERCISE",
+    security_id: "sec1",
+    date: "2021-01-01",
+    resulting_security_ids: ["res1"],
+    ...overrides,
+  });
+  const subject = { object_type: "TX_EQUITY_COMPENSATION_EXERCISE", id: "ex1" };
+
+  it("returns no findings when the issuance exists and dates order", () => {
+    const context = contextWith({
+      equityCompensation: [issuanceRecord("sec1")] as any,
+      transactions: [issuanceRecord("sec1")],
+    });
+    expect(runValidator("TX_EQUITY_COMPENSATION_EXERCISE", context, exercise())).toEqual([]);
+  });
+
+  it("leaves the machine in capTable without mutating collections on the valid branch", () => {
+    const seeded = contextWith({
+      equityCompensation: [issuanceRecord("sec1")] as any,
+      transactions: [issuanceRecord("sec1")],
+    });
+    const before = structuredClone(seeded.equityCompensation);
+
+    const actor = startSeeded(seeded);
+    actor.send(ev("TX_EQUITY_COMPENSATION_EXERCISE", exercise()));
+
+    const snapshot = actor.getSnapshot();
+    expect(snapshot.value).toBe("capTable");
+    // Exercise mutates no collection — the asymmetry with the warrant exercise,
+    // which removes, is preserved.
+    expect(snapshot.context.equityCompensation).toEqual(before);
+    expect(snapshot.context.findings).toEqual([]);
+  });
+
+  it("flags a missing issuance with an error naming the security_id", () => {
+    const context = contextWith({ transactions: [issuanceRecord("sec1")] });
+    const findings = runValidator("TX_EQUITY_COMPENSATION_EXERCISE", context, exercise());
+    expect(findings).toHaveLength(1);
+    expectFindingShape(findings[0], "issuance-exists", subject);
+    expect(findings[0].message).toContain("sec1");
+  });
+
+  it("flags an out-of-order date with an error naming the security_id", () => {
+    const context = contextWith({
+      equityCompensation: [issuanceRecord("sec1", "2022-01-01")] as any,
+      transactions: [issuanceRecord("sec1", "2022-01-01")],
+    });
+    const findings = runValidator("TX_EQUITY_COMPENSATION_EXERCISE", context, exercise());
+    expect(findings).toHaveLength(1);
+    expectFindingShape(findings[0], "date-order", subject);
+    expect(findings[0].message).toContain("sec1");
+  });
+
+  it("never emits its resulting-security gap checks, even when those conditions are unmet", () => {
+    // resulting_security_ids names a security with no matching resulting issuance,
+    // and another transaction references the exercised security — conditions the
+    // gap checks would flag if written. None is, so the transaction stays valid.
+    const context = contextWith({
+      equityCompensation: [issuanceRecord("sec1")] as any,
+      transactions: [
+        issuanceRecord("sec1"),
+        { id: "ret-x", object_type: "TX_EQUITY_COMPENSATION_RETRACTION", security_id: "sec1", date: "2021-06-01" },
+      ],
+    });
+    const findings = runValidator("TX_EQUITY_COMPENSATION_EXERCISE", context, exercise());
+    expect(findings).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Release: issuance-exists, date-order
+// ---------------------------------------------------------------------------
+
+describe("equity compensation release validity", () => {
+  const release = (overrides: Record<string, unknown> = {}) => ({
+    id: "rel1",
+    object_type: "TX_EQUITY_COMPENSATION_RELEASE",
+    security_id: "sec1",
+    date: "2021-01-01",
+    ...overrides,
+  });
+  const subject = { object_type: "TX_EQUITY_COMPENSATION_RELEASE", id: "rel1" };
+
+  it("returns no findings when the issuance exists and dates order", () => {
+    const context = contextWith({
+      equityCompensation: [issuanceRecord("sec1")] as any,
+      transactions: [issuanceRecord("sec1")],
+    });
+    expect(runValidator("TX_EQUITY_COMPENSATION_RELEASE", context, release())).toEqual([]);
+  });
+
+  it("leaves the machine in capTable without mutating collections on the valid branch", () => {
+    const seeded = contextWith({
+      equityCompensation: [issuanceRecord("sec1")] as any,
+      transactions: [issuanceRecord("sec1")],
+    });
+    const before = structuredClone(seeded.equityCompensation);
+
+    const actor = startSeeded(seeded);
+    actor.send(ev("TX_EQUITY_COMPENSATION_RELEASE", release()));
+
+    const snapshot = actor.getSnapshot();
+    expect(snapshot.value).toBe("capTable");
+    expect(snapshot.context.equityCompensation).toEqual(before);
+    expect(snapshot.context.findings).toEqual([]);
+  });
+
+  it("flags a missing issuance with an error naming the security_id", () => {
+    // In the package history (date-order passes) but not the live collection.
+    const context = contextWith({ transactions: [issuanceRecord("sec1")] });
+    const findings = runValidator("TX_EQUITY_COMPENSATION_RELEASE", context, release());
+    expect(findings).toHaveLength(1);
+    expectFindingShape(findings[0], "issuance-exists", subject);
+    expect(findings[0].message).toContain("sec1");
+  });
+
+  it("flags an out-of-order date with an error naming the security_id", () => {
+    // Issuance is live (issuance-exists passes) but dated after the release.
+    const context = contextWith({
+      equityCompensation: [issuanceRecord("sec1", "2022-01-01")] as any,
+      transactions: [issuanceRecord("sec1", "2022-01-01")],
+    });
+    const findings = runValidator("TX_EQUITY_COMPENSATION_RELEASE", context, release());
+    expect(findings).toHaveLength(1);
+    expectFindingShape(findings[0], "date-order", subject);
+    expect(findings[0].message).toContain("sec1");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Declared-vs-emitted consistency across the family
+// ---------------------------------------------------------------------------
+
+// A transaction record on `security_id` of the given kind; the offender/exempt
+// building block for the failing scenarios below.
+const txRecord = (object_type: string, id: string, security_id = "sec1", date = "2021-06-01") => ({
+  id,
+  object_type,
+  security_id,
+  date,
+});
+
+// For each migrated type, scenarios that each fail one implemented check. The
+// implemented ids a module declares should be exactly the ids these scenarios
+// emit; a module's declared gaps (transfer's and exercise's resulting-security
+// checks) have no failing scenario because no code path emits them.
+const failingScenarios: Record<MigratedKey, { context: OcfMachineContext; data: Record<string, unknown> }[]> = {
+  TX_EQUITY_COMPENSATION_ISSUANCE: [
+    {
+      context: baseContext(),
+      data: { id: "i1", object_type: "TX_EQUITY_COMPENSATION_ISSUANCE", security_id: "sec1", stakeholder_id: "nobody", date: "2021-01-01" },
+    },
+  ],
+  TX_EQUITY_COMPENSATION_ACCEPTANCE: [
+    { context: contextWith({ transactions: [issuanceRecord("sec1")] }), data: txRecord("TX_EQUITY_COMPENSATION_ACCEPTANCE", "a1", "sec1", "2021-01-01") },
+    { context: contextWith({ equityCompensation: [issuanceRecord("sec1", "2022-01-01")] as any, transactions: [issuanceRecord("sec1", "2022-01-01")] }), data: txRecord("TX_EQUITY_COMPENSATION_ACCEPTANCE", "a1", "sec1", "2021-01-01") },
+    { context: contextWith({ equityCompensation: [issuanceRecord("sec1")] as any, transactions: [issuanceRecord("sec1"), txRecord("TX_EQUITY_COMPENSATION_RETRACTION", "r1")] }), data: txRecord("TX_EQUITY_COMPENSATION_ACCEPTANCE", "a1", "sec1", "2021-01-01") },
+  ],
+  TX_EQUITY_COMPENSATION_EXERCISE: [
+    { context: contextWith({ transactions: [issuanceRecord("sec1")] }), data: txRecord("TX_EQUITY_COMPENSATION_EXERCISE", "e1", "sec1", "2021-01-01") },
+    { context: contextWith({ equityCompensation: [issuanceRecord("sec1", "2022-01-01")] as any, transactions: [issuanceRecord("sec1", "2022-01-01")] }), data: txRecord("TX_EQUITY_COMPENSATION_EXERCISE", "e1", "sec1", "2021-01-01") },
+  ],
+  TX_EQUITY_COMPENSATION_RELEASE: [
+    { context: contextWith({ transactions: [issuanceRecord("sec1")] }), data: txRecord("TX_EQUITY_COMPENSATION_RELEASE", "rel1", "sec1", "2021-01-01") },
+    { context: contextWith({ equityCompensation: [issuanceRecord("sec1", "2022-01-01")] as any, transactions: [issuanceRecord("sec1", "2022-01-01")] }), data: txRecord("TX_EQUITY_COMPENSATION_RELEASE", "rel1", "sec1", "2021-01-01") },
+  ],
+  TX_EQUITY_COMPENSATION_RETRACTION: [
+    { context: contextWith({ transactions: [issuanceRecord("sec1")] }), data: txRecord("TX_EQUITY_COMPENSATION_RETRACTION", "r1", "sec1", "2021-01-01") },
+    { context: contextWith({ equityCompensation: [issuanceRecord("sec1", "2022-01-01")] as any, transactions: [issuanceRecord("sec1", "2022-01-01")] }), data: txRecord("TX_EQUITY_COMPENSATION_RETRACTION", "r1", "sec1", "2021-01-01") },
+    { context: contextWith({ equityCompensation: [issuanceRecord("sec1")] as any, transactions: [issuanceRecord("sec1"), txRecord("TX_EQUITY_COMPENSATION_ACCEPTANCE", "a1")] }), data: txRecord("TX_EQUITY_COMPENSATION_RETRACTION", "r1", "sec1", "2021-01-01") },
+  ],
+  TX_EQUITY_COMPENSATION_CANCELLATION: [
+    { context: contextWith({ transactions: [issuanceRecord("sec1")] }), data: txRecord("TX_EQUITY_COMPENSATION_CANCELLATION", "c1", "sec1", "2021-01-01") },
+    { context: contextWith({ equityCompensation: [issuanceRecord("sec1", "2022-01-01")] as any, transactions: [issuanceRecord("sec1", "2022-01-01")] }), data: txRecord("TX_EQUITY_COMPENSATION_CANCELLATION", "c1", "sec1", "2021-01-01") },
+    { context: contextWith({ equityCompensation: [issuanceRecord("sec1")] as any, transactions: [issuanceRecord("sec1"), txRecord("TX_EQUITY_COMPENSATION_TRANSFER", "x1")] }), data: txRecord("TX_EQUITY_COMPENSATION_CANCELLATION", "c1", "sec1", "2021-01-01") },
+  ],
+  TX_EQUITY_COMPENSATION_TRANSFER: [
+    { context: contextWith({ transactions: [issuanceRecord("sec1")] }), data: txRecord("TX_EQUITY_COMPENSATION_TRANSFER", "x1", "sec1", "2021-01-01") },
+    { context: contextWith({ equityCompensation: [issuanceRecord("sec1", "2022-01-01")] as any, transactions: [issuanceRecord("sec1", "2022-01-01")] }), data: txRecord("TX_EQUITY_COMPENSATION_TRANSFER", "x1", "sec1", "2021-01-01") },
+  ],
+};
+
+/** Every check id emitted across a module's failing scenarios. */
+const emittedCheckIds = (key: MigratedKey): Set<string> => {
+  const emitted = new Set<string>();
+  for (const { context, data } of failingScenarios[key]) {
+    for (const finding of runValidator(key, context, data)) emitted.add(finding.check);
+  }
+  return emitted;
+};
+
+describe("declared and emitted checks stay consistent across the family", () => {
+  // Exact set equality in both directions: no finding is emitted for a check the
+  // descriptor does not declare implemented, and every declared implemented check
+  // is emitted by at least one failing scenario.
+  it.each(MIGRATED_KEYS)("%s emits exactly the check ids its descriptor declares implemented", (key) => {
+    expect([...emittedCheckIds(key)].sort()).toEqual([...implementedCheckIds(key)].sort());
+  });
+
+  it("never emits transfer's declared-gap check", () => {
+    expect(emittedCheckIds("TX_EQUITY_COMPENSATION_TRANSFER").has("no-other-transactions")).toBe(false);
+    // The gap is declared on the descriptor with implemented: false.
+    const declared = (TX_DESCRIPTORS.TX_EQUITY_COMPENSATION_TRANSFER as { checks: readonly { id: string; implemented?: false }[] }).checks;
+    expect(declared.some((c) => c.id === "no-other-transactions" && c.implemented === false)).toBe(true);
+  });
+
+  it("declares exercise's five resulting-security checks as gaps and emits none of them", () => {
+    const declared = (TX_DESCRIPTORS.TX_EQUITY_COMPENSATION_EXERCISE as { checks: readonly { id: string; implemented?: false }[] }).checks;
+    const gapIds = declared.filter((c) => c.implemented === false).map((c) => c.id);
+    // The five resulting-security checks the exercise documents but never wrote.
+    expect(gapIds.sort()).toEqual(
+      [
+        "resulting-issuances-exist",
+        "no-other-transactions",
+        "resulting-dates-match",
+        "resulting-stakeholder-matches",
+        "quantity-consistent",
+      ].sort(),
+    );
+    const emitted = emittedCheckIds("TX_EQUITY_COMPENSATION_EXERCISE");
+    for (const id of gapIds) expect(emitted.has(id)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Channel migration: findings, not report, for the equity compensation family
+// ---------------------------------------------------------------------------
+
+describe("equity compensation family findings migrate to the findings channel", () => {
+  it("routes an invalid equity compensation transaction to findings, leaves report clear, and serializes the errors in the failure result", () => {
+    const actor = startSeeded(baseContext());
+    // No stakeholder matches, so the issuance is invalid.
+    actor.send(ev("TX_EQUITY_COMPENSATION_ISSUANCE", {
+      id: "eci1",
+      object_type: "TX_EQUITY_COMPENSATION_ISSUANCE",
+      security_id: "sec1",
+      stakeholder_id: "nobody",
+      date: "2021-01-01",
+    }));
+
+    const { context, value } = actor.getSnapshot();
+    expect(value).toBe("validationError");
+    // The errors landed on findings…
+    expect(context.findings.length).toBeGreaterThan(0);
+    expect(context.findings.every((f) => f.severity === "error")).toBe(true);
+    // …no report entry was written for a migrated equity compensation type…
+    const migrated = MIGRATED_KEYS as readonly string[];
+    expect(context.report.some((entry: any) => migrated.includes(entry?.transaction_type))).toBe(false);
+    // …and the failure result serialized the error findings.
+    expect(context.result).toContain(JSON.stringify(context.findings, null, 2));
+  });
+});

--- a/tests/ocfMachine.test.ts
+++ b/tests/ocfMachine.test.ts
@@ -366,19 +366,31 @@ describe("legacy validators through the machine", () => {
       ocfPackageContent: {
         ...baseContext().ocfPackageContent,
         stakeholders: [{ id: "sh1" }],
+        stockClasses: [{ id: "sc1" }],
       } as OcfMachineContext["ocfPackageContent"],
     });
 
+  // A stock issuance the legacy validator accepts: a known stakeholder, a known
+  // stock class, and no stock legends to resolve.
+  const stockIssuance = (overrides: Record<string, unknown> = {}) => ({
+    id: "si1",
+    security_id: "s-sec1",
+    stakeholder_id: "sh1",
+    stock_class_id: "sc1",
+    stock_legend_ids: [],
+    ...overrides,
+  });
+
   it("records a validated transaction's report entry and leaves findings empty", () => {
     const actor = startSeeded(seededWithStakeholder());
-    actor.send(ev("TX_EQUITY_COMPENSATION_ISSUANCE", { id: "ec1", security_id: "ec-sec1", stakeholder_id: "sh1" }));
+    actor.send(ev("TX_STOCK_ISSUANCE", stockIssuance()));
 
     const snapshot = actor.getSnapshot();
     expect(snapshot.value).toBe("capTable");
     expect(snapshot.context.report).toHaveLength(1);
     expect(snapshot.context.report[0]).toMatchObject({
-      transaction_type: "TX_EQUITY_COMPENSATION_ISSUANCE",
-      transaction_id: "ec1",
+      transaction_type: "TX_STOCK_ISSUANCE",
+      transaction_id: "si1",
       stakeholder_validity: true,
     });
     expect(snapshot.context.findings).toEqual([]);
@@ -386,14 +398,14 @@ describe("legacy validators through the machine", () => {
 
   it("fails an invalid transaction with the report entry serialized in the result and findings still empty", () => {
     const actor = startSeeded(seededWithStakeholder());
-    // No such stakeholder — the equity compensation issuance validator rejects it.
-    actor.send(ev("TX_EQUITY_COMPENSATION_ISSUANCE", { id: "ec1", security_id: "ec-sec1", stakeholder_id: "nobody" }));
+    // No such stakeholder — the stock issuance validator rejects it.
+    actor.send(ev("TX_STOCK_ISSUANCE", stockIssuance({ stakeholder_id: "nobody" })));
 
     const snapshot = actor.getSnapshot();
     expect(snapshot.value).toBe("validationError");
     expect(snapshot.context.report).toHaveLength(1);
     expect(snapshot.context.result).toBe(
-      `The validation of the OCF package for Test Co failed on ec1: ${JSON.stringify(snapshot.context.report[0], null, 2)}`,
+      `The validation of the OCF package for Test Co failed on si1: ${JSON.stringify(snapshot.context.report[0], null, 2)}`,
     );
     expect(snapshot.context.findings).toEqual([]);
   });


### PR DESCRIPTION
Part of #159. Independent of the convertible (#199) and warrant (#200) migrations, both merged; base is `main`.

## What this does

Third family migration of the #159 series: the seven active equity compensation validators (issuance, acceptance, retraction, cancellation, transfer, exercise, release) move to the graded convention, mirroring the convertible and warrant families module for module.

- Each validator becomes `(context, data) => Finding[]` with deep-readonly, typed inputs. The dual-mode `isGuard` flag and the untyped `event` are gone.
- Each module exports its own descriptor (`effect`, `collection`, `validate`, `checks`), and the central table imports them. The free-text `CURRENT CHECKS` / `MISSING CHECKS` comment blocks become structured `Check` metadata.
- Check ids reuse the shared vocabulary from #199/#200 (`stakeholder-exists`, `issuance-exists`, `date-order`, `no-retraction`, `no-acceptance`, `no-other-transactions`), with per-descriptor uniqueness guarded by the existing metadata test. Every implemented check blocks validity in the legacy code, so every one grades as `error`.
- **`release` is one of the "written but never connected" validators #159 calls out for wiring.** It had a validator module that the machine never referenced (its table entry was `passthrough`); this PR wires it. So `release` goes from silently ignored to validated — see Behavior changes.
- **Unlike the warrant family, `exercise` is included here.** Warrant held its exercise back because of the defects in #192/#193; equity compensation's exercise carries no such defect — its legacy body implements only `issuance-exists` and `date-order`, and its resulting-security checks were only ever documented, never coded. Those five become `implemented: false` gap declarations. Exercise keeps `effect: "none"` (it mutates no collection today; the asymmetry with warrant exercise, which removes, is preserved, not endorsed).
- A new suite (`tests/equityCompensationValidators.test.ts`) covers the family the way the warrant/convertible suites do: per-check validity scenarios, finding shape and message content, per-offender finding counts, machine-driven collection effects, and set-equality between declared and emitted check ids.
- The two machine tests that used an equity compensation issuance as their example of a legacy-convention validator now use a stock issuance instead (its legacy validator performs the same single stakeholder check). This continues the re-point chain from #200 and recurs until the legacy test block is deleted along with `legacyValidate`.

`TX_EQUITY_COMPENSATION_REPRICING` is the one equity transaction that stays `passthrough` — only because no validator has been written for it yet. It is a known gap to be authored later, not a designed end-state.

## Behavior changes

- For these seven transaction types, findings replace `report` entries: per-check outcomes land on `context.findings`, and failure messages serialize the error findings. `context.report` no longer receives entries for them. This is the one change the characterization snapshot records — the fixture's single passing equity issuance no longer writes a report entry.
- **`release` moves from `passthrough` to active.** The machine previously ignored `TX_EQUITY_COMPENSATION_RELEASE` entirely; it is now validated (`issuance-exists` + `date-order`). The test fixture contains no release transaction, so the characterization snapshot is unchanged by this.
- Offender scans (`no-retraction`, `no-acceptance`, `no-other-transactions`) now emit one finding per offender instead of collapsing to a single boolean. Validity is unchanged; only the finding granularity is finer.
- **Fix — the phantom-field existence check in acceptance, retraction, and release.** All three legacy validators read their `issuance-exists` check from `context.equity_compensationIssuances`, a field that does not exist on the machine context (the real collection is `equityCompensation`). Any package containing one of these transactions would therefore throw at runtime; it was latent because the test fixture contains none (and release was never even wired). The typed graded context makes the phantom field a compile error, so the port cannot preserve it. All three now read `context.equityCompensation`, matching the sibling validators — turning a guaranteed crash into a working existence check. New tests cover the passing and missing-issuance paths this makes reachable. This is the sole deliberate deviation from a faithful port; every other legacy scan quirk is preserved.

## Port fidelity

The fixture contains only an equity issuance (no acceptance, retraction, cancellation, transfer, exercise, or release), and this PR deletes the legacy validator bodies, so the suite cannot itself prove the port faithful: the new tests encode the intended semantics. The preserved quirks match the convertible/warrant families exactly — existence checks read the live `equityCompensation` collection, while date-order and offender scans read the full package transaction list, including transactions dated after the one under validation. Two normalizations are applied uniformly and preserve validity in every module: the date-order scan leads with the `object_type` discriminant (identical matching set), and offender scans emit one finding per offending row.

<details>
<summary>Per-module predicate map</summary>

### tx_equity_compensation_issuance (append to `equityCompensation`)

| Legacy predicate | Source | Match condition | Graded check |
| --- | --- | --- | --- |
| `stakeholder_validity` | `stakeholders` file | `ele.id === stakeholder_id` | `stakeholder-exists` (error); names the `stakeholder_id` |

### tx_equity_compensation_acceptance (no collection effect)

| Legacy predicate | Source | Match condition | Graded check |
| --- | --- | --- | --- |
| incoming issuance exists | live `equityCompensation` | `security_id` match and `object_type === 'TX_EQUITY_COMPENSATION_ISSUANCE'` | `issuance-exists` (error) — **source fixed from the nonexistent `equity_compensationIssuances`** |
| incoming date | full `transactions` | `security_id` match, `object_type === '…ISSUANCE'`, then `date <=` | `date-order` (error) |
| no retraction | full `transactions` | offender: `security_id` match, `object_type === 'TX_EQUITY_COMPENSATION_RETRACTION'` | `no-retraction` (error); one finding per offender |

### tx_equity_compensation_retraction (remove from `equityCompensation`)

| Legacy predicate | Source | Match condition | Graded check |
| --- | --- | --- | --- |
| incoming issuance exists | live `equityCompensation` | `security_id` match and `object_type === '…ISSUANCE'` | `issuance-exists` (error) — **source fixed as above** |
| incoming date | full `transactions` | `security_id` match, `object_type === '…ISSUANCE'`, then `date <=` | `date-order` (error) |
| no acceptance | full `transactions` | offender: `security_id` match, `object_type === 'TX_EQUITY_COMPENSATION_ACCEPTANCE'` | `no-acceptance` (error); one finding per offender |

### tx_equity_compensation_cancellation (remove from `equityCompensation`)

| Legacy predicate | Source | Match condition | Graded check |
| --- | --- | --- | --- |
| incoming issuance exists | live `equityCompensation` | `security_id` match **alone**, no `object_type` filter (unlike its siblings) | `issuance-exists` (error) |
| incoming date | full `transactions` | `security_id` match, `object_type === '…ISSUANCE'`, then `date <=` | `date-order` (error) |
| only-transaction | full `transactions` | offender: `security_id` match, excluding equity issuances, equity acceptances, and the cancellation itself (matched by `id`) | `no-other-transactions` (error); one finding per offender |

The three-way exemption and the object_type-agnostic existence match are ported verbatim; this is the only module whose existence check omits the `object_type` filter.

### tx_equity_compensation_transfer (remove from `equityCompensation`)

| Legacy predicate | Source | Match condition | Graded check |
| --- | --- | --- | --- |
| incoming issuance exists | live `equityCompensation` | `security_id` match and `object_type === '…ISSUANCE'` | `issuance-exists` (error) |
| incoming date | full `transactions` | `security_id` match, `object_type === '…ISSUANCE'`, then `date <=` | `date-order` (error) |
| (documented, not coded) | (none) | (none) | `no-other-transactions` declared `implemented: false`; never emitted |

### tx_equity_compensation_release (no collection effect; newly wired from passthrough)

| Legacy predicate | Source | Match condition | Graded check |
| --- | --- | --- | --- |
| incoming issuance exists | live `equityCompensation` | `security_id` match and `object_type === '…ISSUANCE'` | `issuance-exists` (error) — **source fixed as above** |
| incoming date | full `transactions` | `security_id` match, `object_type === '…ISSUANCE'`, then `date <=` | `date-order` (error) |

Release's legacy validator has only these two checks — no offender scan.

### tx_equity_compensation_exercise (no collection effect)

| Legacy predicate | Source | Match condition | Graded check |
| --- | --- | --- | --- |
| incoming issuance exists | live `equityCompensation` | `security_id` match and `object_type === '…ISSUANCE'` | `issuance-exists` (error) |
| incoming date | full `transactions` | `security_id` match, `object_type === '…ISSUANCE'`, then `date <=` | `date-order` (error) |
| (documented, not coded) | (none) | (none) | five gaps, all `implemented: false`: `resulting-issuances-exist`, `no-other-transactions`, `resulting-dates-match`, `resulting-stakeholder-matches`, `quantity-consistent` |

Exercise's legacy `console.log` debug lines are dropped. It keeps `effect: "none"` — the legacy machine mutates no collection for it.

</details>

## Verification

`npm run build` (tsc) and `npm run test:ci` (vitest) are green — 6 files, 177 tests. The characterization snapshot changes by exactly one entry: the fixture's passing equity issuance no longer writes a `report` entry (`report: []`); `findings` stays `[]` and the appended `equityCompensation` collection is unchanged.
