### PR TITLE
Migrate equity compensation validators to the declarative check form

### DIFF
--- a/ocf_validator/ocfMachine.ts
+++ b/ocf_validator/ocfMachine.ts
@@ -23,6 +23,13 @@ import { TX_WARRANT_RETRACTION } from "./validators/warrant/tx_warrant_retractio
 import { TX_WARRANT_CANCELLATION } from "./validators/warrant/tx_warrant_cancellation";
 import { TX_WARRANT_TRANSFER } from "./validators/warrant/tx_warrant_transfer";
 import { TX_WARRANT_EXERCISE } from "./validators/warrant/tx_warrant_exercise";
+import { TX_EQUITY_COMPENSATION_ISSUANCE } from "./validators/equity_compensation/tx_equity_compensation_issuance";
+import { TX_EQUITY_COMPENSATION_ACCEPTANCE } from "./validators/equity_compensation/tx_equity_compensation_acceptance";
+import { TX_EQUITY_COMPENSATION_EXERCISE } from "./validators/equity_compensation/tx_equity_compensation_exercise";
+import { TX_EQUITY_COMPENSATION_RELEASE } from "./validators/equity_compensation/tx_equity_compensation_release";
+import { TX_EQUITY_COMPENSATION_RETRACTION } from "./validators/equity_compensation/tx_equity_compensation_retraction";
+import { TX_EQUITY_COMPENSATION_CANCELLATION } from "./validators/equity_compensation/tx_equity_compensation_cancellation";
+import { TX_EQUITY_COMPENSATION_TRANSFER } from "./validators/equity_compensation/tx_equity_compensation_transfer";
 import run_EOD from "./eod";
 
 // The validator contract types are defined in types/validator.ts; re-exported
@@ -176,17 +183,18 @@ export const TX_DESCRIPTORS = {
   TX_STOCK_ISSUANCE: { effect: "append", collection: "stockIssuances", legacyValidate: validators.valid_tx_stock_issuance },
   TX_CONVERTIBLE_ISSUANCE,
   TX_WARRANT_ISSUANCE,
-  TX_EQUITY_COMPENSATION_ISSUANCE: { effect: "append", collection: "equityCompensation", legacyValidate: validators.valid_tx_equity_compensation_issuance },
+  TX_EQUITY_COMPENSATION_ISSUANCE,
 
   // --- none: validate + report, no collection mutation --------------------
   TX_STOCK_ACCEPTANCE: { effect: "none", legacyValidate: validators.valid_tx_stock_acceptance },
   TX_CONVERTIBLE_ACCEPTANCE,
   TX_WARRANT_ACCEPTANCE,
-  TX_EQUITY_COMPENSATION_ACCEPTANCE: { effect: "none", legacyValidate: validators.valid_tx_equity_compensation_acceptance },
-  // TX_EQUITY_COMPENSATION_EXERCISE removes nothing today (its collection filter
-  // is commented out in the legacy machine), asymmetric with TX_WARRANT_EXERCISE
-  // which removes. That asymmetry is PRESERVED pending investigation, not endorsed.
-  TX_EQUITY_COMPENSATION_EXERCISE: { effect: "none", legacyValidate: validators.valid_tx_equity_compensation_exercise },
+  TX_EQUITY_COMPENSATION_ACCEPTANCE,
+  // TX_EQUITY_COMPENSATION_EXERCISE removes nothing today, asymmetric with
+  // TX_WARRANT_EXERCISE which removes. That asymmetry is PRESERVED pending
+  // investigation, not endorsed.
+  TX_EQUITY_COMPENSATION_EXERCISE,
+  TX_EQUITY_COMPENSATION_RELEASE,
 
   // --- remove: filter the family collection by security_id ---------------
   TX_STOCK_RETRACTION: { effect: "remove", collection: "stockIssuances", legacyValidate: validators.valid_tx_stock_retraction },
@@ -203,9 +211,9 @@ export const TX_DESCRIPTORS = {
   TX_WARRANT_CANCELLATION,
   TX_WARRANT_TRANSFER,
   TX_WARRANT_EXERCISE,
-  TX_EQUITY_COMPENSATION_RETRACTION: { effect: "remove", collection: "equityCompensation", legacyValidate: validators.valid_tx_equity_compensation_retraction },
-  TX_EQUITY_COMPENSATION_CANCELLATION: { effect: "remove", collection: "equityCompensation", legacyValidate: validators.valid_tx_equity_compensation_cancellation },
-  TX_EQUITY_COMPENSATION_TRANSFER: { effect: "remove", collection: "equityCompensation", legacyValidate: validators.valid_tx_equity_compensation_transfer },
+  TX_EQUITY_COMPENSATION_RETRACTION,
+  TX_EQUITY_COMPENSATION_CANCELLATION,
+  TX_EQUITY_COMPENSATION_TRANSFER,
 
   // --- passthrough: received and silently ignored today ------------------
   //   No validator, no report entry, no collection mutation. They stay in
@@ -213,7 +221,6 @@ export const TX_DESCRIPTORS = {
   //   contains TX_VESTING_START) is byte-identical. `satisfies Record<TxKey, …>`
   //   below forces any future OCF transaction type to be classified here — a
   //   compile error until it is.
-  TX_EQUITY_COMPENSATION_RELEASE: { effect: "passthrough" },
   TX_EQUITY_COMPENSATION_REPRICING: { effect: "passthrough" },
   TX_ISSUER_AUTHORIZED_SHARES_ADJUSTMENT: { effect: "passthrough" },
   TX_PLAN_SECURITY_ACCEPTANCE: { effect: "passthrough" },

--- a/ocf_validator/validators/equity_compensation/checks.ts
+++ b/ocf_validator/validators/equity_compensation/checks.ts
@@ -1,0 +1,96 @@
+import type { CheckObject } from "../checkKit";
+
+/**
+ * The equity compensation issuance referenced by the transaction's security_id
+ * is outstanding as of the transaction's date. Passes on a bare security_id
+ * match against the live equity compensation collection, which holds only
+ * issuances. When the live match fails, the message consults the full package
+ * transaction history and states one of three causes by elimination: the
+ * security was never issued, it is issued only later, or it was issued on or
+ * before this date but is no longer outstanding. The cause and any date it
+ * displays come from a single history record — a match dated on or before the
+ * transaction is preferred over a later-dated one.
+ */
+export const issuanceExists = {
+  id: "issuance-exists",
+  severity: "error",
+  description:
+    "The equity compensation issuance referenced by the transaction's security_id is outstanding as of the transaction's date.",
+  run: (context, data: { security_id: string; date: string }) => {
+    const messages: string[] = [];
+
+    let issuanceExists = false;
+    context.equityCompensation.forEach((ele) => {
+      if (ele.security_id === data.security_id) {
+        issuanceExists = true;
+      }
+    });
+    if (issuanceExists) return messages;
+
+    const { transactions } = context.ocfPackageContent;
+    let firstIssuanceDate: string | undefined;
+    let onOrBeforeDate: string | undefined;
+    transactions.forEach((ele) => {
+      if (
+        ele.object_type === "TX_EQUITY_COMPENSATION_ISSUANCE" &&
+        ele.security_id === data.security_id
+      ) {
+        if (firstIssuanceDate === undefined) firstIssuanceDate = ele.date;
+        if (onOrBeforeDate === undefined && ele.date <= data.date) {
+          onOrBeforeDate = ele.date;
+        }
+      }
+    });
+
+    if (firstIssuanceDate === undefined) {
+      messages.push(
+        `No equity compensation issuance with security_id ${data.security_id} appears in the package.`,
+      );
+    } else if (onOrBeforeDate === undefined) {
+      messages.push(
+        `The equity compensation issuance referenced by security_id ${data.security_id} is dated ${firstIssuanceDate}, after this transaction (${data.date}).`,
+      );
+    } else {
+      messages.push(
+        `The equity compensation issuance referenced by security_id ${data.security_id} (dated ${onOrBeforeDate}) is not outstanding as of this transaction's date.`,
+      );
+    }
+
+    return messages;
+  },
+} satisfies CheckObject;
+
+/**
+ * No other transaction dated on or before this transaction references its
+ * security_id, other than an equity compensation acceptance. One finding per
+ * offending transaction. The scan keeps every transaction type in play, so it
+ * narrows by property presence rather than by discriminant: a transaction
+ * carrying no security_id can never reference this one. The transaction under
+ * validation appears in its own history, so it is exempted by id.
+ */
+export const noOtherTransactions = {
+  id: "no-other-transactions",
+  severity: "error",
+  description:
+    "No other transaction dated on or before this transaction references its security_id, other than an equity compensation acceptance.",
+  run: (context, data: { id: string; security_id: string; date: string }) => {
+    const messages: string[] = [];
+
+    context.ocfPackageContent.transactions.forEach((ele) => {
+      if (
+        "security_id" in ele &&
+        ele.security_id === data.security_id &&
+        ele.date <= data.date &&
+        ele.object_type !== "TX_EQUITY_COMPENSATION_ISSUANCE" &&
+        ele.object_type !== "TX_EQUITY_COMPENSATION_ACCEPTANCE" &&
+        ele.id !== data.id
+      ) {
+        messages.push(
+          `Another transaction (${ele.id}) references the transaction's security_id.`,
+        );
+      }
+    });
+
+    return messages;
+  },
+} satisfies CheckObject;

--- a/ocf_validator/validators/equity_compensation/tx_equity_compensation_acceptance.ts
+++ b/ocf_validator/validators/equity_compensation/tx_equity_compensation_acceptance.ts
@@ -1,72 +1,36 @@
-const valid_tx_equity_compensation_acceptance = (context: any, event: any, isGuard: Boolean) => {
-  const {transactions} = context.ocfPackageContent;
+import { defineValidator, type CheckObject } from "../checkKit";
+import { issuanceExists } from "./checks";
 
-  let validity = false;
-  let report: any = {transaction_type: "TX_EQUITY_COMPENSATION_ACCEPTANCE", transaction_id: event.data.id, transaction_date: event.data.date};
+const noRetraction = {
+  id: "no-retraction",
+  severity: "error",
+  description:
+    "No equity compensation retraction dated on or before this transaction references its security_id.",
+  run: (context, data: { security_id: string; date: string }) => {
+    const messages: string[] = [];
+    const { transactions } = context.ocfPackageContent;
 
-  // Check that equity_compensation issuance in incoming security_id referenced by transaction exists in current state.
-  let incoming_equity_compensationIssuance_validity = false;
-  context.equity_compensationIssuances.forEach((ele: any) => {
-    if (
-      ele.security_id === event.data.security_id &&
-      ele.object_type === 'TX_EQUITY_COMPENSATION_ISSUANCE'
-    ) {
-      incoming_equity_compensationIssuance_validity = true;
-      report.incoming_equity_compensationIssuance_validity = true;
-    }
-  });
-  if (!incoming_equity_compensationIssuance_validity) {
-    report.incoming_equity_compensationIssuance_validity = false;
-  }
-
-  // Check to ensure that the date of transaction is the same day or after the date of the incoming equity_compensation issuance.
-  let incoming_date_validity = false;
-  transactions.forEach((ele: any) => {
-    if (
-      ele.security_id === event.data.security_id &&
-      ele.object_type === 'TX_EQUITY_COMPENSATION_ISSUANCE'
-    ) {
-      if (ele.date <= event.data.date) {
-        incoming_date_validity = true;
-        report.incoming_date_validity = true;
+    // no-retraction emits one finding per equity compensation retraction on this
+    // security_id dated on or before this transaction; a later retraction cannot
+    // invalidate it.
+    transactions.forEach((ele) => {
+      if (
+        ele.object_type === "TX_EQUITY_COMPENSATION_RETRACTION" &&
+        ele.security_id === data.security_id &&
+        ele.date <= data.date
+      ) {
+        messages.push(
+          `An equity compensation retraction (${ele.id}) references the transaction's security_id.`,
+        );
       }
-    }
-  });
-  if (!incoming_date_validity) {
-    report.incoming_date_validity = false;
-  }
+    });
 
-  // Check that equity_compensation issuance in incoming security_id does not have a equity_compensation retraction transaction associated with it.
-  let no_equity_compensation_retraction_validity = false;
-  let equity_compensation_retraction_exists = false;
-  transactions.forEach((ele: any) => {
-    if (
-      ele.security_id === event.data.security_id &&
-      ele.object_type === 'TX_EQUITY_COMPENSATION_RETRACTION'
-    ) {
-      equity_compensation_retraction_exists = true;
-    }
-  });
+    return messages;
+  },
+} satisfies CheckObject;
 
-  if (!equity_compensation_retraction_exists) {
-    no_equity_compensation_retraction_validity = true;
-    report.no_equity_compensation_retraction_validity = true;
-  }
-  if (!no_equity_compensation_retraction_validity) {
-    report.no_equity_compensation_retraction_validity = false;
-  }
-
-  if (
-    incoming_equity_compensationIssuance_validity &&
-    incoming_date_validity &&
-    no_equity_compensation_retraction_validity
-  ) {
-    validity = true;
-  }
-
-  const result = isGuard ? validity : report;
-  
-  return result;
-};
-
-export default valid_tx_equity_compensation_acceptance;
+export const TX_EQUITY_COMPENSATION_ACCEPTANCE = defineValidator({
+  transaction: "TX_EQUITY_COMPENSATION_ACCEPTANCE",
+  effect: "none",
+  checks: [issuanceExists, noRetraction],
+});

--- a/ocf_validator/validators/equity_compensation/tx_equity_compensation_cancellation.ts
+++ b/ocf_validator/validators/equity_compensation/tx_equity_compensation_cancellation.ts
@@ -1,79 +1,9 @@
-// Reference for tx_equity_compensation_cancellation: https://open-cap-table-coalition.github.io/Open-Cap-Format-OCF/schema_markdown/schema/objects/transactions/cancellation/StockCancellation/
-/*
-  CURRENT CHECKS:
-    1. Check that equity_compensation issuance in incoming security_id reference by transaction exists in current state.
-    2. Check to ensure that the date of transaction is the same day or after the date of the incoming equity_compensation issuance.
-    3. The security_id of the equity_compensation issuance referred to in the security_id variable must not be the security_id related to any other transactions with the exception of a equity_compensation acceptance transaction.
-*/
+import { defineValidator } from "../checkKit";
+import { issuanceExists, noOtherTransactions } from "./checks";
 
-import {OcfMachineContext} from '../../ocfMachine';
-
-const valid_tx_equity_compensation_cancellation = (
-  context: OcfMachineContext,
-  event: any,
-  isGuard: Boolean = false
-) => {
-  let validity = false;
-  let report: any = {transaction_type: "TX_EQUITY_COMPENSATION_CANCELLATION", transaction_id: event.data.id, transaction_date: event.data.date};
-
-  const {transactions} = context.ocfPackageContent;
-  // 1. Check that equity_compensation issuance in incoming security_id reference by transaction exists in current state.
-  let incoming_equity_compensationIssuance_validity = false;
-  context.equityCompensation.forEach((ele: any) => {
-    if (ele.security_id === event.data.security_id) {
-      incoming_equity_compensationIssuance_validity = true;
-      report.incoming_equity_compensationIssuance_validity = true;
-    }
-  });
-
-  if (!incoming_equity_compensationIssuance_validity) {
-    report.incoming_equity_compensationIssuance_validity = false;
-  }
-
-  // 2. Check to ensure that the date of transaction is the same day or after the date of the incoming equity_compensation issuance.
-  let incoming_date_validity = false;
-  transactions.forEach((ele: any) => {
-    if (
-      ele.security_id === event.data.security_id &&
-      ele.object_type === 'TX_EQUITY_COMPENSATION_ISSUANCE'
-    ) {
-      if (ele.date <= event.data.date) {
-        incoming_date_validity = true;
-        report.incoming_date_validity = true;
-      }
-    }
-  });
-  if (!incoming_date_validity) {
-    report.incoming_date_validity = false;
-  }
-
-  let only_transaction_validity = true;
-  transactions.map((ele: any) => {
-    if (
-      ele.security_id === event.data.security_id &&
-      ele.object_type !== 'TX_EQUITY_COMPENSATION_ISSUANCE' &&
-      ele.object_type !== 'TX_EQUITY_COMPENSATION_ACCEPTANCE' &&
-      !(ele.object_type === 'TX_EQUITY_COMPENSATION_CANCELLATION' && ele.id === event.data.id)
-    ) {
-      only_transaction_validity = false;
-      report.only_transaction_validity = false;
-    }
-  });
-  if (only_transaction_validity) {
-    report.only_transaction_validity = true;
-  }
-
-  if (
-    incoming_equity_compensationIssuance_validity &&
-    incoming_date_validity &&
-    only_transaction_validity
-  ) {
-    validity = true;
-  }
-
-  const result = isGuard ? validity : report;
-  
-  return result;
-};
-
-export default valid_tx_equity_compensation_cancellation;
+export const TX_EQUITY_COMPENSATION_CANCELLATION = defineValidator({
+  transaction: "TX_EQUITY_COMPENSATION_CANCELLATION",
+  effect: "remove",
+  collection: "equityCompensation",
+  checks: [issuanceExists, noOtherTransactions],
+});

--- a/ocf_validator/validators/equity_compensation/tx_equity_compensation_exercise.ts
+++ b/ocf_validator/validators/equity_compensation/tx_equity_compensation_exercise.ts
@@ -1,64 +1,56 @@
-import { OcfMachineContext } from "../../ocfMachine";
+import { defineValidator, type CheckObject } from "../checkKit";
+import { issuanceExists } from "./checks";
 
-/*
-CURRENT CHECKS:
-Check that equity_compensation issuance in incoming security_id referenced by transaction exists in current state.
-The date of the equity_compensation issuance referred to in the security_id must have a date equal to or earlier than the date of the equity_compensation exercise
-Any stock issuances with corresponding security IDs referred to in the resulting_security_ids array must exist
-The security_id of the equity_compensation issuance referred to in the security_id variable must not be the security_id related to any other transactions with the exception of a equity_compensation acceptance transaction.
-The dates of any equity_compensation issuances referred to in the resulting_security_ids variables must have a date equal to the date of the equity_compensation exercise
-The stakeholder_id of the equity_compensation issuance referred to in the security_id variable must equal the stakeholder_id of any stock issuances referred to in the resulting_security_ids variable
+// The exercise documents these resulting-security checks but implements none of
+// them: each is metadata with no run, so it reports as a gap and contributes no
+// findings. Unlike warrant exercise — which removes the exercised security and
+// implements the resulting-security checks — equity compensation exercise
+// mutates no collection and leaves these unwritten.
 
-NOT IMPLEMENTED:
-The quantity_converted variable must equal the sum of any equity_compensation issuances referred to in the resulting_security_ids variable
-*/
+const resultingStockExists = {
+  id: "resulting-stock-exists",
+  severity: "error",
+  description:
+    "Each resulting security is a stock issuance present in the package.",
+} satisfies CheckObject;
 
-const valid_tx_equity_compensation_exercise = (context: OcfMachineContext, event: any, isGuard: Boolean) => {
-  let validity = false;
-  const { transactions } = context.ocfPackageContent;
-  let report: any = { transaction_type: "TX_EQUITY_COMPENSATION_EXERCISE", transaction_id: event.data.id, transaction_date: event.data.date };
+const noOtherTransactions = {
+  id: "no-other-transactions",
+  severity: "error",
+  description:
+    "No other transaction dated on or before this transaction references its security_id, other than an equity compensation acceptance.",
+} satisfies CheckObject;
 
-  // Check that equity_compensation issuance in incoming security_id referenced by transaction exists in current state.
-  let incoming_equity_compensationIssuance_validity = false;
-  
-  context.equityCompensation.forEach((ele: any) => {
-    console.log('ele.security_id', ele.security_id);
-    console.log('event.data.security_id', event.data.security_id);
-    console.log('ele.object_type', ele.object_type);
-    if (ele.security_id === event.data.security_id && ele.object_type === "TX_EQUITY_COMPENSATION_ISSUANCE") {
-      incoming_equity_compensationIssuance_validity = true;
-      report.incoming_equity_compensationIssuance_validity = true;
-    }
-  });
-  if (!incoming_equity_compensationIssuance_validity) {
-    report.incoming_equity_compensationIssuance_validity = false;
-  }
+const resultingStockDated = {
+  id: "resulting-stock-dated",
+  severity: "error",
+  description:
+    "Each resulting stock issuance is dated the same day as the exercise.",
+} satisfies CheckObject;
 
-  // The date of the equity_compensation issuance referred to in the security_id must have a date equal to or earlier than the date of the equity_compensation exercise
-  let incoming_date_validity = false;
-  transactions.forEach((ele: any) => {
-    if (ele.security_id === event.data.security_id && ele.object_type === "TX_EQUITY_COMPENSATION_ISSUANCE") {
-      if (ele.date <= event.data.date) {
-        incoming_date_validity = true;
-        report.incoming_date_validity = true;
-      }
-    }
-  });
-  if (!incoming_date_validity) {
-    report.incoming_date_validity = false;
-  }
+const resultingStockStakeholder = {
+  id: "resulting-stock-stakeholder",
+  severity: "error",
+  description:
+    "Each resulting stock issuance names the stakeholder of the exercised equity compensation issuance.",
+} satisfies CheckObject;
 
+const resultingQuantitySum = {
+  id: "resulting-quantity-sum",
+  severity: "error",
+  description:
+    "The exercised quantity_converted equals the sum of the resulting stock issuances' quantities.",
+} satisfies CheckObject;
 
-  if (
-    incoming_equity_compensationIssuance_validity &&
-    incoming_date_validity
-  ) {
-    validity = true;
-  }
-
-  const result = isGuard ? validity : report;
-
-  return result;
-};
-
-export default valid_tx_equity_compensation_exercise;
+export const TX_EQUITY_COMPENSATION_EXERCISE = defineValidator({
+  transaction: "TX_EQUITY_COMPENSATION_EXERCISE",
+  effect: "none",
+  checks: [
+    issuanceExists,
+    resultingStockExists,
+    noOtherTransactions,
+    resultingStockDated,
+    resultingStockStakeholder,
+    resultingQuantitySum,
+  ],
+});

--- a/ocf_validator/validators/equity_compensation/tx_equity_compensation_issuance.ts
+++ b/ocf_validator/validators/equity_compensation/tx_equity_compensation_issuance.ts
@@ -1,27 +1,31 @@
-const valid_tx_equity_compensation_issuance = (context: any, event: any, isGuard: any) => {
-  let validity = false;
-  const { stakeholders } = context.ocfPackageContent;
-  let report: any = {transaction_type: "TX_EQUITY_COMPENSATION_ISSUANCE", transaction_id: event.data.id, transaction_date: event.data.date};
-  
-  // Check if the stakeholder referenced by the transaction exists in the stakeholder file.
-  let stakeholder_validity = false;
-  stakeholders.forEach((ele: any) => {
-    if (ele.id === event.data.stakeholder_id) {
-      stakeholder_validity = true;
-      report.stakeholder_validity = true
+import { defineValidator, type CheckObject } from "../checkKit";
+
+const stakeholderExists = {
+  id: "stakeholder-exists",
+  severity: "error",
+  description:
+    "The stakeholder referenced by the transaction exists in the stakeholder file.",
+  run: (context, data: { stakeholder_id: string }) => {
+    const messages: string[] = [];
+    const { stakeholders } = context.ocfPackageContent;
+
+    let stakeholderExists = false;
+    stakeholders.forEach((ele: any) => {
+      if (ele.id === data.stakeholder_id) stakeholderExists = true;
+    });
+    if (!stakeholderExists) {
+      messages.push(
+        `The stakeholder ${data.stakeholder_id} referenced by the transaction was not found in the stakeholder file.`,
+      );
     }
-  });
-  if (!stakeholder_validity) {
-    report.stakeholder_validity = false
-  }
 
-  if (stakeholder_validity) {
-    validity = true;
-  }
+    return messages;
+  },
+} satisfies CheckObject;
 
-  const result = isGuard ? validity : report;
-  
-  return result;
-};
-
-export default valid_tx_equity_compensation_issuance;
+export const TX_EQUITY_COMPENSATION_ISSUANCE = defineValidator({
+  transaction: "TX_EQUITY_COMPENSATION_ISSUANCE",
+  effect: "append",
+  collection: "equityCompensation",
+  checks: [stakeholderExists],
+});

--- a/ocf_validator/validators/equity_compensation/tx_equity_compensation_release.ts
+++ b/ocf_validator/validators/equity_compensation/tx_equity_compensation_release.ts
@@ -1,53 +1,8 @@
-const valid_tx_equity_compensation_release = (context: any, event: any, isGuard: Boolean) => {
-  const {transactions} = context.ocfPackageContent;
+import { defineValidator } from "../checkKit";
+import { issuanceExists } from "./checks";
 
-  let validity = false;
-  let report: any = {transaction_type: "TX_EQUITY_COMPENSATION_RELEASE", transaction_id: event.data.id, transaction_date: event.data.date};
-
-  // Check that equity_compensation issuance in incoming security_id referenced by transaction exists in current state.
-  let incoming_equity_compensationIssuance_validity = false;
-  context.equity_compensationIssuances.forEach((ele: any) => {
-    if (
-      ele.security_id === event.data.security_id &&
-      ele.object_type === 'TX_EQUITY_COMPENSATION_ISSUANCE'
-    ) {
-      incoming_equity_compensationIssuance_validity = true;
-      report.incoming_equity_compensationIssuance_validity = true;
-    }
-  });
-  if (!incoming_equity_compensationIssuance_validity) {
-    report.incoming_equity_compensationIssuance_validity = false;
-  }
-
-  // Check to ensure that the date of transaction is the same day or after the date of the incoming equity_compensation issuance.
-  let incoming_date_validity = false;
-  transactions.forEach((ele: any) => {
-    if (
-      ele.security_id === event.data.security_id &&
-      ele.object_type === 'TX_EQUITY_COMPENSATION_ISSUANCE'
-    ) {
-      if (ele.date <= event.data.date) {
-        incoming_date_validity = true;
-        report.incoming_date_validity = true;
-      }
-    }
-  });
-  if (!incoming_date_validity) {
-    report.incoming_date_validity = false;
-  }
-
- 
-
-  if (
-    incoming_equity_compensationIssuance_validity &&
-    incoming_date_validity
-  ) {
-    validity = true;
-  }
-
-  const result = isGuard ? validity : report;
-  
-  return result;
-};
-
-export default valid_tx_equity_compensation_release;
+export const TX_EQUITY_COMPENSATION_RELEASE = defineValidator({
+  transaction: "TX_EQUITY_COMPENSATION_RELEASE",
+  effect: "none",
+  checks: [issuanceExists],
+});

--- a/ocf_validator/validators/equity_compensation/tx_equity_compensation_retraction.ts
+++ b/ocf_validator/validators/equity_compensation/tx_equity_compensation_retraction.ts
@@ -1,75 +1,37 @@
-const valid_tx_equity_compensation_retraction = (context: any, event: any, isGuard: Boolean = false) => {
-  let validity = false;
+import { defineValidator, type CheckObject } from "../checkKit";
+import { issuanceExists } from "./checks";
 
-  let report: any = {transaction_type: "TX_EQUITY_COMPENSATION_RETRACTION", transaction_id: event.data.id, transaction_date: event.data.date};
+const noAcceptance = {
+  id: "no-acceptance",
+  severity: "error",
+  description:
+    "No equity compensation acceptance dated on or before this transaction references its security_id.",
+  run: (context, data: { security_id: string; date: string }) => {
+    const messages: string[] = [];
+    const { transactions } = context.ocfPackageContent;
 
-  // TBC: validation of tx_equity_compensation_retraction
-  const {transactions} = context.ocfPackageContent;
-  // Check that equity_compensation issuance in incoming security_id referenced by transaction exists in current state.
-  let incoming_equity_compensationIssuance_validity = false;
-  context.equity_compensationIssuances.forEach((ele: any) => {
-    if (
-      ele.security_id === event.data.security_id &&
-      ele.object_type === 'TX_EQUITY_COMPENSATION_ISSUANCE'
-    ) {
-      incoming_equity_compensationIssuance_validity = true;
-      report.incoming_equity_compensationIssuance_validity = true
-    }
-  });
-  if (!incoming_equity_compensationIssuance_validity) {
-    report.incoming_equity_compensationIssuance_validity = false
-
-  }
-
-  // Check to ensure that the date of transaction is the same day or after the date of the incoming equity_compensation issuance.
-  let incoming_date_validity = false;
-  transactions.forEach((ele: any) => {
-    if (
-      ele.security_id === event.data.security_id &&
-      ele.object_type === 'TX_EQUITY_COMPENSATION_ISSUANCE'
-    ) {
-      if (ele.date <= event.data.date) {
-        incoming_date_validity = true;
-        report.incoming_date_validity = true;
+    // no-acceptance emits one finding per equity compensation acceptance on this
+    // security_id dated on or before this transaction; a later acceptance cannot
+    // invalidate it.
+    transactions.forEach((ele) => {
+      if (
+        ele.object_type === "TX_EQUITY_COMPENSATION_ACCEPTANCE" &&
+        ele.security_id === data.security_id &&
+        ele.date <= data.date
+      ) {
+        messages.push(
+          `An equity compensation acceptance (${ele.id}) references the transaction's security_id.`,
+        );
       }
-    }
-  });
-  if (!incoming_date_validity) {
-    report.incoming_date_validity = false;
+    });
 
-  }
+    return messages;
+  },
+} satisfies CheckObject;
 
-  // Check that equity_compensation issuance in incoming security_id does not have a equity_compensation acceptance transaction associated with it.
-  let no_equity_compensation_acceptance_validity = false;
-  let equity_compensation_acceptance_exists = false;
-  transactions.forEach((ele: any) => {
-    if (
-      ele.security_id === event.data.security_id &&
-      ele.object_type === 'TX_EQUITY_COMPENSATION_ACCEPTANCE'
-    ) {
-      equity_compensation_acceptance_exists = true;
-    }
-  });
-
-  if (!equity_compensation_acceptance_exists) {
-    no_equity_compensation_acceptance_validity = true;
-    report.no_equity_compensation_acceptance_validity = true;
-  }
-  if (!no_equity_compensation_acceptance_validity) {
-    report.no_equity_compensation_acceptance_validity = false;
-  }
-
-  if (
-    incoming_equity_compensationIssuance_validity &&
-    incoming_date_validity &&
-    no_equity_compensation_acceptance_validity
-  ) {
-    validity = true;
-  }
-
-  const result = isGuard ? validity : report;
-  
-  return result;
-};
-
-export default valid_tx_equity_compensation_retraction;
+export const TX_EQUITY_COMPENSATION_RETRACTION = defineValidator({
+  transaction: "TX_EQUITY_COMPENSATION_RETRACTION",
+  effect: "remove",
+  collection: "equityCompensation",
+  checks: [issuanceExists, noAcceptance],
+});

--- a/ocf_validator/validators/equity_compensation/tx_equity_compensation_transfer.ts
+++ b/ocf_validator/validators/equity_compensation/tx_equity_compensation_transfer.ts
@@ -1,63 +1,18 @@
-import {OcfMachineContext} from '../../ocfMachine';
-// Reference for tx_equity_compensation_transfer transaction: https://open-cap-table-coalition.github.io/Open-Cap-Format-OCF/schema_markdown/schema/objects/transactions/transfer/StockTransfer/
+import { defineValidator, type CheckObject } from "../checkKit";
+import { issuanceExists } from "./checks";
 
-/*
-  CURRENT CHECKS:
-    1. Does the incoming security_id referenced by transaction exist in current cap table state?
-    2. Is the date of transaction the same day or after the date of the incoming issuance?
- MISSING CHECKS:
-    1. The security_id of the equity_compensation issuance referred to in the security_id variable must not be the security_id related to any other transactions with the exception of a equity_compensation acceptance transaction.
-*/
+// The transfer module declares this check but does not implement it: the same
+// metadata with no run, so it reports as a gap and contributes no findings.
+const noOtherTransactions = {
+  id: "no-other-transactions",
+  severity: "error",
+  description:
+    "No other transaction dated on or before this transaction references its security_id, other than an equity compensation acceptance.",
+} satisfies CheckObject;
 
-const valid_tx_equity_compensation_transfer = (context: OcfMachineContext, event: any, isGuard: Boolean) => {
-  let validity = false;
-  const {transactions} = context.ocfPackageContent;
-  let report: any = {transaction_type: "TX_EQUITY_COMPENSATION_TRANSFER", transaction_id: event.data.id, transaction_date: event.data.date};
-
-  // Check that equity_compensation issuance in incoming security_id referenced by transaction exists in current state.
-  let incoming_equity_compensationIssuance_validity = false;
-  context.equityCompensation.map((ele: any) => {
-    if (
-      ele.security_id === event.data.security_id &&
-      ele.object_type === 'TX_EQUITY_COMPENSATION_ISSUANCE'
-    ) {
-      incoming_equity_compensationIssuance_validity = true;
-      report.incoming_equity_compensationIssuance_validity = true;
-    }
-  });
-  if (!incoming_equity_compensationIssuance_validity) {
-    report.incoming_equity_compensationIssuance_validity = false;
-  }
-
-  // Check to ensure that the date of transaction is the same day or after the date of the incoming equity_compensation issuance.
-  let incoming_date_validity = false;
-  transactions.map((ele: any) => {
-    if (
-      ele.security_id === event.data.security_id &&
-      ele.object_type === 'TX_EQUITY_COMPENSATION_ISSUANCE'
-    ) {
-      if (ele.date <= event.data.date) {
-        incoming_date_validity = true;
-        report.incoming_date_validity = true;
-      }
-    }
-  });
-  if (!incoming_date_validity) {
-    report.incoming_date_validity = false;
-  }
-
- 
-
-  if (
-    incoming_equity_compensationIssuance_validity &&
-    incoming_date_validity
-  ) {
-    validity = true;
-  }
-
-  const result = isGuard ? validity : report;
-  
-  return result;
-};
-
-export default valid_tx_equity_compensation_transfer;
+export const TX_EQUITY_COMPENSATION_TRANSFER = defineValidator({
+  transaction: "TX_EQUITY_COMPENSATION_TRANSFER",
+  effect: "remove",
+  collection: "equityCompensation",
+  checks: [issuanceExists, noOtherTransactions],
+});

--- a/ocf_validator/validators/index.ts
+++ b/ocf_validator/validators/index.ts
@@ -6,13 +6,6 @@ import valid_tx_stock_conversion from './stock/tx_stock_conversion';
 import valid_tx_stock_reissuance from './stock/tx_stock_reissuance';
 import valid_tx_stock_repurchase from './stock/tx_stock_repurchase';
 import valid_tx_stock_transfer from './stock/tx_stock_transfer';
-import valid_tx_equity_compensation_issuance from './equity_compensation/tx_equity_compensation_issuance';
-import valid_tx_equity_compensation_retraction from './equity_compensation/tx_equity_compensation_retraction';
-import valid_tx_equity_compensation_acceptance from './equity_compensation/tx_equity_compensation_acceptance';
-import valid_tx_equity_compensation_cancellation from './equity_compensation/tx_equity_compensation_cancellation';
-import valid_tx_equity_compensation_release from './equity_compensation/tx_equity_compensation_release';
-import valid_tx_equity_compensation_transfer from './equity_compensation/tx_equity_compensation_transfer';
-import valid_tx_equity_compensation_exercise from './equity_compensation/tx_equity_compensation_exercise';
 import valid_tx_plan_security_issuance from './plan_security/tx_plan_security_issuance';
 import valid_tx_plan_security_retraction from './plan_security/tx_plan_security_retraction';
 import valid_tx_plan_security_acceptance from './plan_security/tx_plan_security_acceptance';
@@ -38,13 +31,6 @@ const validators = {
   valid_tx_stock_reissuance,
   valid_tx_stock_repurchase,
   valid_tx_stock_transfer,
-  valid_tx_equity_compensation_issuance,
-  valid_tx_equity_compensation_retraction,
-  valid_tx_equity_compensation_acceptance,
-  valid_tx_equity_compensation_cancellation,
-  valid_tx_equity_compensation_release,
-  valid_tx_equity_compensation_transfer,
-  valid_tx_equity_compensation_exercise,
   valid_tx_plan_security_issuance,
   valid_tx_plan_security_retraction,
   valid_tx_plan_security_acceptance,

--- a/tests/__snapshots__/characterization.test.ts.snap
+++ b/tests/__snapshots__/characterization.test.ts.snap
@@ -36,14 +36,7 @@ exports[`ocfValidator over testPackage > produces a stable validation result and
   ],
   "findings": [],
   "lastErrorFindings": [],
-  "report": [
-    {
-      "stakeholder_validity": true,
-      "transaction_date": "2019-06-01",
-      "transaction_id": "eci_01",
-      "transaction_type": "TX_EQUITY_COMPENSATION_ISSUANCE",
-    },
-  ],
+  "report": [],
   "result": "The validation of the OCF package for Acme Holdings Limited is complete and the package appears valid.",
   "snapshots": [
     {

--- a/tests/equityCompensationValidators.test.ts
+++ b/tests/equityCompensationValidators.test.ts
@@ -1,0 +1,755 @@
+import { describe, it, expect } from "vitest";
+import { TX_DESCRIPTORS } from "../ocf_validator/ocfMachine";
+import validators from "../ocf_validator/validators";
+import type { OcfMachineContext } from "../types/validator";
+import {
+  baseContext,
+  startSeeded,
+  ev,
+  contextWith,
+  runValidator,
+  implementedCheckIds,
+  expectFindingShape,
+} from "./helpers";
+
+const MIGRATED_KEYS = [
+  "TX_EQUITY_COMPENSATION_ISSUANCE",
+  "TX_EQUITY_COMPENSATION_ACCEPTANCE",
+  "TX_EQUITY_COMPENSATION_RETRACTION",
+  "TX_EQUITY_COMPENSATION_CANCELLATION",
+  "TX_EQUITY_COMPENSATION_TRANSFER",
+  "TX_EQUITY_COMPENSATION_EXERCISE",
+  "TX_EQUITY_COMPENSATION_RELEASE",
+] as const;
+type MigratedKey = (typeof MIGRATED_KEYS)[number];
+
+// A single equity compensation issuance, in the shape both the live collection
+// and the package transaction history hold it. `date` lets a scenario place the
+// issuance before or after the transaction under validation to exercise the
+// existence check's layered diagnostics.
+const issuanceRecord = (security_id: string, date = "2020-01-01") => ({
+  id: `eci-${security_id}`,
+  object_type: "TX_EQUITY_COMPENSATION_ISSUANCE",
+  security_id,
+  date,
+});
+
+// ---------------------------------------------------------------------------
+// Issuance: stakeholder-exists
+// ---------------------------------------------------------------------------
+
+describe("equity compensation issuance validity", () => {
+  const withStakeholder = (id: string) =>
+    baseContext({
+      ocfPackageContent: {
+        ...baseContext().ocfPackageContent,
+        stakeholders: [{ id }],
+      } as OcfMachineContext["ocfPackageContent"],
+    });
+
+  const issuance = (overrides: Record<string, unknown> = {}) => ({
+    id: "eci1",
+    object_type: "TX_EQUITY_COMPENSATION_ISSUANCE",
+    security_id: "sec1",
+    stakeholder_id: "sh1",
+    date: "2021-01-01",
+    ...overrides,
+  });
+
+  it("returns no findings when the referenced stakeholder exists", () => {
+    const findings = runValidator("TX_EQUITY_COMPENSATION_ISSUANCE", withStakeholder("sh1"), issuance());
+    expect(findings).toEqual([]);
+  });
+
+  it("flags a missing stakeholder with an error naming the stakeholder_id", () => {
+    const findings = runValidator("TX_EQUITY_COMPENSATION_ISSUANCE", withStakeholder("someone-else"), issuance());
+    expect(findings).toHaveLength(1);
+    expectFindingShape(findings[0], "stakeholder-exists", {
+      object_type: "TX_EQUITY_COMPENSATION_ISSUANCE",
+      id: "eci1",
+    });
+    expect(findings[0].message).toContain("sh1");
+  });
+
+  it("appends a valid issuance to equityCompensation and stays in capTable", () => {
+    const actor = startSeeded(withStakeholder("sh1"));
+    actor.send(ev("TX_EQUITY_COMPENSATION_ISSUANCE", issuance()));
+
+    const snapshot = actor.getSnapshot();
+    expect(snapshot.value).toBe("capTable");
+    expect(snapshot.context.equityCompensation).toHaveLength(1);
+    expect(snapshot.context.equityCompensation[0]).toMatchObject({ id: "eci1", security_id: "sec1" });
+    expect(snapshot.context.findings).toEqual([]);
+  });
+
+  it("halts an invalid issuance in validationError with the error finding recorded", () => {
+    const actor = startSeeded(withStakeholder("someone-else"));
+    actor.send(ev("TX_EQUITY_COMPENSATION_ISSUANCE", issuance()));
+
+    const snapshot = actor.getSnapshot();
+    expect(snapshot.value).toBe("validationError");
+    expect(snapshot.context.findings).toHaveLength(1);
+    expect(snapshot.context.findings[0].check).toBe("stakeholder-exists");
+    expect(snapshot.context.equityCompensation).toEqual([]);
+    expect(snapshot.context.result).toContain("stakeholder-exists");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Acceptance: issuance-exists, no-retraction
+// ---------------------------------------------------------------------------
+
+describe("equity compensation acceptance validity", () => {
+  const acceptance = (overrides: Record<string, unknown> = {}) => ({
+    id: "acc1",
+    object_type: "TX_EQUITY_COMPENSATION_ACCEPTANCE",
+    security_id: "sec1",
+    date: "2021-01-01",
+    ...overrides,
+  });
+  const subject = { object_type: "TX_EQUITY_COMPENSATION_ACCEPTANCE", id: "acc1" };
+
+  it("returns no findings when the issuance is outstanding and no retraction references it", () => {
+    const context = contextWith({
+      equityCompensation: [issuanceRecord("sec1")] as any,
+      transactions: [issuanceRecord("sec1")],
+    });
+    expect(runValidator("TX_EQUITY_COMPENSATION_ACCEPTANCE", context, acceptance())).toEqual([]);
+  });
+
+  it("leaves the machine in capTable without mutating collections on the valid branch", () => {
+    const seeded = contextWith({
+      equityCompensation: [issuanceRecord("sec1")] as any,
+      transactions: [issuanceRecord("sec1")],
+    });
+    const before = structuredClone(seeded.equityCompensation);
+
+    const actor = startSeeded(seeded);
+    actor.send(ev("TX_EQUITY_COMPENSATION_ACCEPTANCE", acceptance()));
+
+    const snapshot = actor.getSnapshot();
+    expect(snapshot.value).toBe("capTable");
+    expect(snapshot.context.equityCompensation).toEqual(before);
+    expect(snapshot.context.findings).toEqual([]);
+  });
+
+  it("flags a not-outstanding issuance with an error naming the security_id", () => {
+    // In the package history but not the live collection.
+    const context = contextWith({ transactions: [issuanceRecord("sec1")] });
+    const findings = runValidator("TX_EQUITY_COMPENSATION_ACCEPTANCE", context, acceptance());
+    expect(findings).toHaveLength(1);
+    expectFindingShape(findings[0], "issuance-exists", subject);
+    expect(findings[0].message).toContain("sec1");
+  });
+
+  it("emits one no-retraction finding per past offending retraction, each naming that retraction", () => {
+    const context = contextWith({
+      equityCompensation: [issuanceRecord("sec1")] as any,
+      transactions: [
+        issuanceRecord("sec1"),
+        { id: "ret-a", object_type: "TX_EQUITY_COMPENSATION_RETRACTION", security_id: "sec1", date: "2020-06-01" },
+        { id: "ret-b", object_type: "TX_EQUITY_COMPENSATION_RETRACTION", security_id: "sec1", date: "2020-07-01" },
+      ],
+    });
+    const findings = runValidator("TX_EQUITY_COMPENSATION_ACCEPTANCE", context, acceptance());
+    expect(findings).toHaveLength(2);
+    for (const finding of findings) expectFindingShape(finding, "no-retraction", subject);
+    expect(findings.map((f) => f.message).join("\n")).toContain("ret-a");
+    expect(findings.map((f) => f.message).join("\n")).toContain("ret-b");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Retraction: issuance-exists, no-acceptance
+// ---------------------------------------------------------------------------
+
+describe("equity compensation retraction validity", () => {
+  const retraction = (overrides: Record<string, unknown> = {}) => ({
+    id: "ret1",
+    object_type: "TX_EQUITY_COMPENSATION_RETRACTION",
+    security_id: "sec1",
+    date: "2021-01-01",
+    ...overrides,
+  });
+  const subject = { object_type: "TX_EQUITY_COMPENSATION_RETRACTION", id: "ret1" };
+
+  it("returns no findings when the issuance is outstanding and no acceptance references it", () => {
+    const context = contextWith({
+      equityCompensation: [issuanceRecord("sec1")] as any,
+      transactions: [issuanceRecord("sec1")],
+    });
+    expect(runValidator("TX_EQUITY_COMPENSATION_RETRACTION", context, retraction())).toEqual([]);
+  });
+
+  it("removes the referenced security from equityCompensation on the valid branch", () => {
+    const seeded = contextWith({
+      equityCompensation: [issuanceRecord("sec1"), issuanceRecord("sec2")] as any,
+      transactions: [issuanceRecord("sec1"), issuanceRecord("sec2")],
+    });
+    const actor = startSeeded(seeded);
+    actor.send(ev("TX_EQUITY_COMPENSATION_RETRACTION", retraction()));
+
+    const snapshot = actor.getSnapshot();
+    expect(snapshot.value).toBe("capTable");
+    expect(snapshot.context.equityCompensation.some((e: any) => e.security_id === "sec1")).toBe(false);
+    expect(snapshot.context.equityCompensation.some((e: any) => e.security_id === "sec2")).toBe(true);
+    expect(snapshot.context.findings).toEqual([]);
+  });
+
+  it("flags a not-outstanding issuance with an error naming the security_id", () => {
+    const context = contextWith({ transactions: [issuanceRecord("sec1")] });
+    const findings = runValidator("TX_EQUITY_COMPENSATION_RETRACTION", context, retraction());
+    expect(findings).toHaveLength(1);
+    expectFindingShape(findings[0], "issuance-exists", subject);
+    expect(findings[0].message).toContain("sec1");
+  });
+
+  it("emits one no-acceptance finding per past offending acceptance, each naming that acceptance", () => {
+    const context = contextWith({
+      equityCompensation: [issuanceRecord("sec1")] as any,
+      transactions: [
+        issuanceRecord("sec1"),
+        { id: "acc-a", object_type: "TX_EQUITY_COMPENSATION_ACCEPTANCE", security_id: "sec1", date: "2020-06-01" },
+        { id: "acc-b", object_type: "TX_EQUITY_COMPENSATION_ACCEPTANCE", security_id: "sec1", date: "2020-07-01" },
+      ],
+    });
+    const findings = runValidator("TX_EQUITY_COMPENSATION_RETRACTION", context, retraction());
+    expect(findings).toHaveLength(2);
+    for (const finding of findings) expectFindingShape(finding, "no-acceptance", subject);
+    expect(findings.map((f) => f.message).join("\n")).toContain("acc-a");
+    expect(findings.map((f) => f.message).join("\n")).toContain("acc-b");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cancellation: issuance-exists, no-other-transactions
+// ---------------------------------------------------------------------------
+
+describe("equity compensation cancellation validity", () => {
+  const cancellation = (overrides: Record<string, unknown> = {}) => ({
+    id: "can1",
+    object_type: "TX_EQUITY_COMPENSATION_CANCELLATION",
+    security_id: "sec1",
+    date: "2021-01-01",
+    ...overrides,
+  });
+  const cancellationRecord = { id: "can1", object_type: "TX_EQUITY_COMPENSATION_CANCELLATION", security_id: "sec1", date: "2021-01-01" };
+  const acceptanceRecord = { id: "acc-x", object_type: "TX_EQUITY_COMPENSATION_ACCEPTANCE", security_id: "sec1", date: "2020-02-01" };
+  const subject = { object_type: "TX_EQUITY_COMPENSATION_CANCELLATION", id: "can1" };
+
+  it("returns no findings when only an issuance, an acceptance, and the cancellation itself reference the security", () => {
+    const context = contextWith({
+      equityCompensation: [issuanceRecord("sec1")] as any,
+      transactions: [issuanceRecord("sec1"), acceptanceRecord, cancellationRecord],
+    });
+    expect(runValidator("TX_EQUITY_COMPENSATION_CANCELLATION", context, cancellation())).toEqual([]);
+  });
+
+  it("treats any live equity compensation record matched by security_id as the issuance, regardless of object_type", () => {
+    // The existence check matches on security_id alone; a non-issuance object_type
+    // in the live collection still satisfies it.
+    const context = contextWith({
+      equityCompensation: [{ id: "x", object_type: "SOMETHING_ELSE", security_id: "sec1", date: "2020-01-01" }] as any,
+      transactions: [issuanceRecord("sec1")],
+    });
+    expect(runValidator("TX_EQUITY_COMPENSATION_CANCELLATION", context, cancellation())).toEqual([]);
+  });
+
+  it("removes the referenced security from equityCompensation on the valid branch", () => {
+    const seeded = contextWith({
+      equityCompensation: [issuanceRecord("sec1"), issuanceRecord("sec2")] as any,
+      transactions: [issuanceRecord("sec1"), issuanceRecord("sec2")],
+    });
+    const actor = startSeeded(seeded);
+    actor.send(ev("TX_EQUITY_COMPENSATION_CANCELLATION", cancellation()));
+
+    const snapshot = actor.getSnapshot();
+    expect(snapshot.value).toBe("capTable");
+    expect(snapshot.context.equityCompensation.some((e: any) => e.security_id === "sec1")).toBe(false);
+    expect(snapshot.context.equityCompensation.some((e: any) => e.security_id === "sec2")).toBe(true);
+  });
+
+  it("emits one no-other-transactions finding per past offender, exempting acceptances and itself", () => {
+    const context = contextWith({
+      equityCompensation: [issuanceRecord("sec1")] as any,
+      transactions: [
+        issuanceRecord("sec1"),
+        acceptanceRecord,
+        cancellationRecord,
+        { id: "xfer-a", object_type: "TX_EQUITY_COMPENSATION_TRANSFER", security_id: "sec1", date: "2020-06-01" },
+        { id: "xfer-b", object_type: "TX_EQUITY_COMPENSATION_TRANSFER", security_id: "sec1", date: "2020-07-01" },
+      ],
+    });
+    const findings = runValidator("TX_EQUITY_COMPENSATION_CANCELLATION", context, cancellation());
+    expect(findings).toHaveLength(2);
+    for (const finding of findings) expectFindingShape(finding, "no-other-transactions", subject);
+    const messages = findings.map((f) => f.message).join("\n");
+    expect(messages).toContain("xfer-a");
+    expect(messages).toContain("xfer-b");
+    // The exempt acceptance is never named as an offender.
+    expect(messages).not.toContain("acc-x");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Transfer: issuance-exists (no-other-transactions is a declared gap)
+// ---------------------------------------------------------------------------
+
+describe("equity compensation transfer validity", () => {
+  const transfer = (overrides: Record<string, unknown> = {}) => ({
+    id: "xfer1",
+    object_type: "TX_EQUITY_COMPENSATION_TRANSFER",
+    security_id: "sec1",
+    date: "2021-01-01",
+    ...overrides,
+  });
+  const subject = { object_type: "TX_EQUITY_COMPENSATION_TRANSFER", id: "xfer1" };
+
+  it("returns no findings when the issuance is outstanding", () => {
+    const context = contextWith({
+      equityCompensation: [issuanceRecord("sec1")] as any,
+      transactions: [issuanceRecord("sec1")],
+    });
+    expect(runValidator("TX_EQUITY_COMPENSATION_TRANSFER", context, transfer())).toEqual([]);
+  });
+
+  it("removes the referenced security from equityCompensation on the valid branch", () => {
+    const seeded = contextWith({
+      equityCompensation: [issuanceRecord("sec1"), issuanceRecord("sec2")] as any,
+      transactions: [issuanceRecord("sec1"), issuanceRecord("sec2")],
+    });
+    const actor = startSeeded(seeded);
+    actor.send(ev("TX_EQUITY_COMPENSATION_TRANSFER", transfer()));
+
+    const snapshot = actor.getSnapshot();
+    expect(snapshot.value).toBe("capTable");
+    expect(snapshot.context.equityCompensation.some((e: any) => e.security_id === "sec1")).toBe(false);
+    expect(snapshot.context.equityCompensation.some((e: any) => e.security_id === "sec2")).toBe(true);
+  });
+
+  it("flags a not-outstanding issuance with an error naming the security_id", () => {
+    const context = contextWith({ transactions: [issuanceRecord("sec1")] });
+    const findings = runValidator("TX_EQUITY_COMPENSATION_TRANSFER", context, transfer());
+    expect(findings).toHaveLength(1);
+    expectFindingShape(findings[0], "issuance-exists", subject);
+    expect(findings[0].message).toContain("sec1");
+  });
+
+  it("never emits no-other-transactions, even when a past transaction references the security", () => {
+    const context = contextWith({
+      equityCompensation: [issuanceRecord("sec1")] as any,
+      transactions: [
+        issuanceRecord("sec1"),
+        { id: "ret-x", object_type: "TX_EQUITY_COMPENSATION_RETRACTION", security_id: "sec1", date: "2020-06-01" },
+        { id: "can-x", object_type: "TX_EQUITY_COMPENSATION_CANCELLATION", security_id: "sec1", date: "2020-07-01" },
+      ],
+    });
+    const findings = runValidator("TX_EQUITY_COMPENSATION_TRANSFER", context, transfer());
+    // The declared gap is never checked, so the transaction stays valid here.
+    expect(findings).toEqual([]);
+    expect(findings.some((f) => f.check === "no-other-transactions")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Release: issuance-exists (wired from passthrough into the active none section)
+// ---------------------------------------------------------------------------
+
+describe("equity compensation release validity", () => {
+  const release = (overrides: Record<string, unknown> = {}) => ({
+    id: "rel1",
+    object_type: "TX_EQUITY_COMPENSATION_RELEASE",
+    security_id: "sec1",
+    date: "2021-01-01",
+    ...overrides,
+  });
+  const subject = { object_type: "TX_EQUITY_COMPENSATION_RELEASE", id: "rel1" };
+
+  it("returns no findings when the issuance is outstanding", () => {
+    const context = contextWith({
+      equityCompensation: [issuanceRecord("sec1")] as any,
+      transactions: [issuanceRecord("sec1")],
+    });
+    expect(runValidator("TX_EQUITY_COMPENSATION_RELEASE", context, release())).toEqual([]);
+  });
+
+  it("leaves the machine in capTable without mutating collections on the valid branch", () => {
+    const seeded = contextWith({
+      equityCompensation: [issuanceRecord("sec1")] as any,
+      transactions: [issuanceRecord("sec1")],
+    });
+    const before = structuredClone(seeded.equityCompensation);
+
+    const actor = startSeeded(seeded);
+    actor.send(ev("TX_EQUITY_COMPENSATION_RELEASE", release()));
+
+    const snapshot = actor.getSnapshot();
+    expect(snapshot.value).toBe("capTable");
+    expect(snapshot.context.equityCompensation).toEqual(before);
+    expect(snapshot.context.findings).toEqual([]);
+  });
+
+  it("flags a not-outstanding issuance with an error naming the security_id", () => {
+    const context = contextWith({ transactions: [issuanceRecord("sec1")] });
+    const findings = runValidator("TX_EQUITY_COMPENSATION_RELEASE", context, release());
+    expect(findings).toHaveLength(1);
+    expectFindingShape(findings[0], "issuance-exists", subject);
+    expect(findings[0].message).toContain("sec1");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Exercise: issuance-exists live, resulting-security checks are declared gaps
+// ---------------------------------------------------------------------------
+
+// The exercise diverges from warrant exercise: its effect is `none`, so it
+// removes nothing, and every resulting-security check is a declared gap rather
+// than an implemented check.
+const EXERCISE_GAP_IDS = [
+  "resulting-stock-exists",
+  "no-other-transactions",
+  "resulting-stock-dated",
+  "resulting-stock-stakeholder",
+  "resulting-quantity-sum",
+];
+
+describe("equity compensation exercise validity", () => {
+  const exercise = (overrides: Record<string, unknown> = {}) => ({
+    id: "ex1",
+    object_type: "TX_EQUITY_COMPENSATION_EXERCISE",
+    security_id: "sec1",
+    resulting_security_ids: ["res1"],
+    date: "2021-01-01",
+    ...overrides,
+  });
+  const subject = { object_type: "TX_EQUITY_COMPENSATION_EXERCISE", id: "ex1" };
+
+  it("returns no findings when the issuance is outstanding", () => {
+    const context = contextWith({
+      equityCompensation: [issuanceRecord("sec1")] as any,
+      transactions: [issuanceRecord("sec1")],
+    });
+    expect(runValidator("TX_EQUITY_COMPENSATION_EXERCISE", context, exercise())).toEqual([]);
+  });
+
+  it("keeps the exercised issuance in equityCompensation on the valid branch, mutating no collection", () => {
+    const seeded = contextWith({
+      equityCompensation: [issuanceRecord("sec1")] as any,
+      transactions: [issuanceRecord("sec1")],
+    });
+    const before = structuredClone(seeded.equityCompensation);
+
+    const actor = startSeeded(seeded);
+    actor.send(ev("TX_EQUITY_COMPENSATION_EXERCISE", exercise()));
+
+    const snapshot = actor.getSnapshot();
+    expect(snapshot.value).toBe("capTable");
+    // Unlike warrant exercise, which removes the exercised security, equity
+    // compensation exercise removes nothing — the issuance survives.
+    expect(snapshot.context.equityCompensation).toEqual(before);
+    expect(snapshot.context.findings).toEqual([]);
+  });
+
+  it("flags a not-outstanding issuance, its only implemented failing path", () => {
+    const context = contextWith({ transactions: [issuanceRecord("sec1")] });
+    const findings = runValidator("TX_EQUITY_COMPENSATION_EXERCISE", context, exercise());
+    expect(findings).toHaveLength(1);
+    expectFindingShape(findings[0], "issuance-exists", subject);
+    expect(findings[0].message).toContain("sec1");
+  });
+
+  it("declares its five resulting-security checks as gaps and emits none, even when their conditions are unmet", () => {
+    // resulting_security_ids names a security with no backing stock issuance and
+    // another transaction references the exercised security — conditions the gap
+    // checks would flag if written. None is, so the transaction stays valid.
+    const context = contextWith({
+      equityCompensation: [issuanceRecord("sec1")] as any,
+      transactions: [
+        issuanceRecord("sec1"),
+        { id: "ret-x", object_type: "TX_EQUITY_COMPENSATION_RETRACTION", security_id: "sec1", date: "2020-06-01" },
+      ],
+    });
+    const findings = runValidator(
+      "TX_EQUITY_COMPENSATION_EXERCISE",
+      context,
+      exercise({ resulting_security_ids: ["absent"] }),
+    );
+    expect(findings).toEqual([]);
+
+    const declared = (TX_DESCRIPTORS.TX_EQUITY_COMPENSATION_EXERCISE as { checks: readonly { id: string; implemented?: false }[] }).checks;
+    const gapIds = declared.filter((c) => c.implemented === false).map((c) => c.id);
+    expect(gapIds.sort()).toEqual([...EXERCISE_GAP_IDS].sort());
+    // Every gap declares error severity and none is implemented.
+    for (const id of EXERCISE_GAP_IDS) {
+      const gap = declared.find((c) => c.id === id) as { severity: string; implemented?: false };
+      expect(gap.severity).toBe("error");
+      expect(gap.implemented).toBe(false);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Existence check: layered failure diagnostics
+// ---------------------------------------------------------------------------
+
+describe("issuance-exists reports why the referenced issuance is unavailable", () => {
+  const acceptance = { id: "acc1", object_type: "TX_EQUITY_COMPENSATION_ACCEPTANCE", security_id: "sec1", date: "2021-01-01" };
+  const subject = { object_type: "TX_EQUITY_COMPENSATION_ACCEPTANCE", id: "acc1" };
+
+  // Every scenario keeps the live collection empty so the existence check fails and
+  // takes the history-scanning path; the message names one of the three causes.
+  const expectSoleCause = (context: OcfMachineContext, message: string) => {
+    const findings = runValidator("TX_EQUITY_COMPENSATION_ACCEPTANCE", context, acceptance);
+    expect(findings).toHaveLength(1);
+    expectFindingShape(findings[0], "issuance-exists", subject);
+    expect(findings[0].message).toBe(message);
+    // No separate date-order check exists in this family.
+    expect(findings.some((f) => f.check === "date-order")).toBe(false);
+  };
+
+  it("names a security that was never issued in the package", () => {
+    expectSoleCause(
+      contextWith({ transactions: [] }),
+      "No equity compensation issuance with security_id sec1 appears in the package.",
+    );
+  });
+
+  it("names an issuance dated after the transaction", () => {
+    expectSoleCause(
+      contextWith({ transactions: [issuanceRecord("sec1", "2022-01-01")] }),
+      "The equity compensation issuance referenced by security_id sec1 is dated 2022-01-01, after this transaction (2021-01-01).",
+    );
+  });
+
+  it("reports an issuance issued on or before the transaction but no longer outstanding", () => {
+    expectSoleCause(
+      contextWith({ transactions: [issuanceRecord("sec1", "2020-01-01")] }),
+      "The equity compensation issuance referenced by security_id sec1 (dated 2020-01-01) is not outstanding as of this transaction's date.",
+    );
+  });
+
+  it("displays the on-or-before issuance's date when the history holds both an earlier and a later match", () => {
+    expectSoleCause(
+      contextWith({ transactions: [issuanceRecord("sec1", "2020-01-01"), issuanceRecord("sec1", "2022-01-01")] }),
+      "The equity compensation issuance referenced by security_id sec1 (dated 2020-01-01) is not outstanding as of this transaction's date.",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Offender scans: past-only
+// ---------------------------------------------------------------------------
+
+describe("offender scans consider only offenders dated on or before the transaction", () => {
+  // Each implemented scan judged at the date boundary: the transaction under
+  // validation is dated 2021-06-01, with the referenced issuance already live so
+  // the existence check passes and only the scan under test can emit.
+  const TX_DATE = "2021-06-01";
+  const scans = [
+    { scan: "no-retraction", txType: "TX_EQUITY_COMPENSATION_ACCEPTANCE", txId: "acc1", offenderType: "TX_EQUITY_COMPENSATION_RETRACTION", offenderId: "ret1" },
+    { scan: "no-acceptance", txType: "TX_EQUITY_COMPENSATION_RETRACTION", txId: "ret1", offenderType: "TX_EQUITY_COMPENSATION_ACCEPTANCE", offenderId: "acc1" },
+    { scan: "no-other-transactions", txType: "TX_EQUITY_COMPENSATION_CANCELLATION", txId: "can1", offenderType: "TX_EQUITY_COMPENSATION_TRANSFER", offenderId: "xfer1" },
+  ] as const;
+
+  it.each(scans)("$scan flags a same-day or earlier offender but ignores a later one", ({ scan, txType, txId, offenderType, offenderId }) => {
+    const tx = { id: txId, object_type: txType, security_id: "sec1", date: TX_DATE };
+    const emitsAt = (offenderDate: string) => {
+      const context = contextWith({
+        equityCompensation: [issuanceRecord("sec1")] as any,
+        transactions: [
+          issuanceRecord("sec1"),
+          { id: offenderId, object_type: offenderType, security_id: "sec1", date: offenderDate },
+        ],
+      });
+      return runValidator(txType, context, tx).some((f) => f.check === scan);
+    };
+
+    expect(emitsAt("2021-12-01")).toBe(false);
+    expect(emitsAt(TX_DATE)).toBe(true);
+    expect(emitsAt("2021-01-01")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Conflicting transactions: the later one carries the error
+// ---------------------------------------------------------------------------
+
+describe("a conflicting transaction pair flags the later transaction, not the earlier", () => {
+  const issuance = { id: "eci1", object_type: "TX_EQUITY_COMPENSATION_ISSUANCE", security_id: "sec1", date: "2020-01-01" };
+
+  it("clears an acceptance and flags a later retraction by its backward scan", () => {
+    const acceptance = { id: "acc1", object_type: "TX_EQUITY_COMPENSATION_ACCEPTANCE", security_id: "sec1", date: "2020-02-01" };
+    const retraction = { id: "ret1", object_type: "TX_EQUITY_COMPENSATION_RETRACTION", security_id: "sec1", date: "2020-03-01" };
+
+    const actor = startSeeded(
+      contextWith({
+        equityCompensation: [issuance] as any,
+        transactions: [issuance, acceptance, retraction],
+      }),
+    );
+
+    actor.send(ev("TX_EQUITY_COMPENSATION_ACCEPTANCE", acceptance));
+    expect(actor.getSnapshot().value).toBe("capTable");
+    expect(actor.getSnapshot().context.findings).toEqual([]);
+
+    actor.send(ev("TX_EQUITY_COMPENSATION_RETRACTION", retraction));
+    const { context, value } = actor.getSnapshot();
+    expect(value).toBe("validationError");
+
+    const errors = context.findings.filter((f) => f.severity === "error");
+    expect(errors).toHaveLength(1);
+    expect(errors[0].check).toBe("no-acceptance");
+    for (const finding of context.findings) {
+      expect(finding.subject).toEqual({ object_type: "TX_EQUITY_COMPENSATION_RETRACTION", id: "ret1" });
+    }
+    expect(context.findings.some((f) => f.subject.id === "acc1")).toBe(false);
+  });
+
+  it("clears a retraction that removes the issuance and then flags the later acceptance by both checks", () => {
+    const retraction = { id: "ret1", object_type: "TX_EQUITY_COMPENSATION_RETRACTION", security_id: "sec1", date: "2020-02-01" };
+    const acceptance = { id: "acc1", object_type: "TX_EQUITY_COMPENSATION_ACCEPTANCE", security_id: "sec1", date: "2020-03-01" };
+
+    const actor = startSeeded(
+      contextWith({
+        equityCompensation: [issuance] as any,
+        transactions: [issuance, retraction, acceptance],
+      }),
+    );
+
+    actor.send(ev("TX_EQUITY_COMPENSATION_RETRACTION", retraction));
+    const afterRetraction = actor.getSnapshot();
+    expect(afterRetraction.value).toBe("capTable");
+    expect(afterRetraction.context.findings).toEqual([]);
+    // The retraction removed the issuance from the live collection.
+    expect(afterRetraction.context.equityCompensation.some((e: any) => e.security_id === "sec1")).toBe(false);
+
+    actor.send(ev("TX_EQUITY_COMPENSATION_ACCEPTANCE", acceptance));
+    const { context, value } = actor.getSnapshot();
+    expect(value).toBe("validationError");
+
+    const errors = context.findings.filter((f) => f.severity === "error");
+    expect(errors.map((f) => f.check).sort()).toEqual(["issuance-exists", "no-retraction"]);
+    const existence = errors.find((f) => f.check === "issuance-exists");
+    expect(existence?.message).toBe(
+      "The equity compensation issuance referenced by security_id sec1 (dated 2020-01-01) is not outstanding as of this transaction's date.",
+    );
+    for (const finding of context.findings) {
+      expect(finding.subject).toEqual({ object_type: "TX_EQUITY_COMPENSATION_ACCEPTANCE", id: "acc1" });
+    }
+    expect(context.findings.some((f) => f.subject.id === "ret1")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Declared-vs-emitted consistency across the family
+// ---------------------------------------------------------------------------
+
+// A transaction record on `security_id` of the given kind; the offender/exempt
+// building block for the failing scenarios below.
+const txRecord = (object_type: string, id: string, security_id = "sec1", date = "2020-06-01") => ({
+  id,
+  object_type,
+  security_id,
+  date,
+});
+
+// For each migrated type, scenarios that each fail one implemented check. The
+// implemented ids a module declares should be exactly the ids these scenarios
+// emit; a module's declared gaps (transfer's and exercise's resulting-security
+// checks) have no failing scenario because no code path emits them.
+const failingScenarios: Record<MigratedKey, { context: OcfMachineContext; data: Record<string, unknown> }[]> = {
+  TX_EQUITY_COMPENSATION_ISSUANCE: [
+    {
+      context: baseContext(),
+      data: { id: "i1", object_type: "TX_EQUITY_COMPENSATION_ISSUANCE", security_id: "sec1", stakeholder_id: "nobody", date: "2021-01-01" },
+    },
+  ],
+  TX_EQUITY_COMPENSATION_ACCEPTANCE: [
+    { context: contextWith({ transactions: [issuanceRecord("sec1")] }), data: txRecord("TX_EQUITY_COMPENSATION_ACCEPTANCE", "a1", "sec1", "2021-01-01") },
+    { context: contextWith({ equityCompensation: [issuanceRecord("sec1")] as any, transactions: [issuanceRecord("sec1"), txRecord("TX_EQUITY_COMPENSATION_RETRACTION", "r1")] }), data: txRecord("TX_EQUITY_COMPENSATION_ACCEPTANCE", "a1", "sec1", "2021-01-01") },
+  ],
+  TX_EQUITY_COMPENSATION_RETRACTION: [
+    { context: contextWith({ transactions: [issuanceRecord("sec1")] }), data: txRecord("TX_EQUITY_COMPENSATION_RETRACTION", "r1", "sec1", "2021-01-01") },
+    { context: contextWith({ equityCompensation: [issuanceRecord("sec1")] as any, transactions: [issuanceRecord("sec1"), txRecord("TX_EQUITY_COMPENSATION_ACCEPTANCE", "a1")] }), data: txRecord("TX_EQUITY_COMPENSATION_RETRACTION", "r1", "sec1", "2021-01-01") },
+  ],
+  TX_EQUITY_COMPENSATION_CANCELLATION: [
+    { context: contextWith({ transactions: [issuanceRecord("sec1")] }), data: txRecord("TX_EQUITY_COMPENSATION_CANCELLATION", "c1", "sec1", "2021-01-01") },
+    { context: contextWith({ equityCompensation: [issuanceRecord("sec1")] as any, transactions: [issuanceRecord("sec1"), txRecord("TX_EQUITY_COMPENSATION_TRANSFER", "x1")] }), data: txRecord("TX_EQUITY_COMPENSATION_CANCELLATION", "c1", "sec1", "2021-01-01") },
+  ],
+  TX_EQUITY_COMPENSATION_TRANSFER: [
+    { context: contextWith({ transactions: [issuanceRecord("sec1")] }), data: txRecord("TX_EQUITY_COMPENSATION_TRANSFER", "x1", "sec1", "2021-01-01") },
+  ],
+  TX_EQUITY_COMPENSATION_EXERCISE: [
+    { context: contextWith({ transactions: [issuanceRecord("sec1")] }), data: { id: "ex1", object_type: "TX_EQUITY_COMPENSATION_EXERCISE", security_id: "sec1", resulting_security_ids: [], date: "2021-01-01" } },
+  ],
+  TX_EQUITY_COMPENSATION_RELEASE: [
+    { context: contextWith({ transactions: [issuanceRecord("sec1")] }), data: txRecord("TX_EQUITY_COMPENSATION_RELEASE", "rel1", "sec1", "2021-01-01") },
+  ],
+};
+
+/** Every check id emitted across a module's failing scenarios. */
+const emittedCheckIds = (key: MigratedKey): Set<string> => {
+  const emitted = new Set<string>();
+  for (const { context, data } of failingScenarios[key]) {
+    for (const finding of runValidator(key, context, data)) emitted.add(finding.check);
+  }
+  return emitted;
+};
+
+describe("declared and emitted checks stay consistent across the family", () => {
+  // Exact set equality in both directions: no finding is emitted for a check the
+  // descriptor does not declare implemented, and every declared implemented check
+  // is emitted by at least one failing scenario.
+  it.each(MIGRATED_KEYS)("%s emits exactly the check ids its descriptor declares implemented", (key) => {
+    expect([...emittedCheckIds(key)].sort()).toEqual([...implementedCheckIds(key)].sort());
+  });
+
+  it("never emits transfer's declared-gap check", () => {
+    expect(emittedCheckIds("TX_EQUITY_COMPENSATION_TRANSFER").has("no-other-transactions")).toBe(false);
+    // The gap is declared on the descriptor with implemented: false.
+    const declared = (TX_DESCRIPTORS.TX_EQUITY_COMPENSATION_TRANSFER as { checks: readonly { id: string; implemented?: false }[] }).checks;
+    expect(declared.some((c) => c.id === "no-other-transactions" && c.implemented === false)).toBe(true);
+  });
+
+  it("never emits any of exercise's declared-gap checks", () => {
+    const emitted = emittedCheckIds("TX_EQUITY_COMPENSATION_EXERCISE");
+    for (const id of EXERCISE_GAP_IDS) expect(emitted.has(id)).toBe(false);
+  });
+
+  it("carries release on the graded convention with no legacy validator", () => {
+    expect("validate" in TX_DESCRIPTORS.TX_EQUITY_COMPENSATION_RELEASE).toBe(true);
+    expect("legacyValidate" in TX_DESCRIPTORS.TX_EQUITY_COMPENSATION_RELEASE).toBe(false);
+    // A stray default export would still register a legacy key here, so assert its
+    // absence directly rather than trusting the descriptor swap alone.
+    expect("valid_tx_equity_compensation_release" in validators).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Channel migration: findings, not report, for the equity compensation family
+// ---------------------------------------------------------------------------
+
+describe("equity compensation family findings migrate to the findings channel", () => {
+  it("routes an invalid equity compensation transaction to findings, leaves report clear, and serializes the errors in the failure result", () => {
+    const actor = startSeeded(baseContext());
+    // No stakeholder matches, so the issuance is invalid.
+    actor.send(ev("TX_EQUITY_COMPENSATION_ISSUANCE", {
+      id: "eci1",
+      object_type: "TX_EQUITY_COMPENSATION_ISSUANCE",
+      security_id: "sec1",
+      stakeholder_id: "nobody",
+      date: "2021-01-01",
+    }));
+
+    const { context, value } = actor.getSnapshot();
+    expect(value).toBe("validationError");
+    // The errors landed on findings…
+    expect(context.findings.length).toBeGreaterThan(0);
+    expect(context.findings.every((f) => f.severity === "error")).toBe(true);
+    // …no report entry was written for a migrated equity compensation type…
+    const migrated = MIGRATED_KEYS as readonly string[];
+    expect(context.report.some((entry: any) => migrated.includes(entry?.transaction_type))).toBe(false);
+    // …and the failure result serialized the error findings.
+    expect(context.result).toContain(JSON.stringify(context.findings, null, 2));
+  });
+});

--- a/tests/ocfMachine.test.ts
+++ b/tests/ocfMachine.test.ts
@@ -366,19 +366,31 @@ describe("legacy validators through the machine", () => {
       ocfPackageContent: {
         ...baseContext().ocfPackageContent,
         stakeholders: [{ id: "sh1" }],
+        stockClasses: [{ id: "sc1" }],
       } as OcfMachineContext["ocfPackageContent"],
     });
 
+  // A stock issuance the legacy validator accepts: a known stakeholder, a known
+  // stock class, and no stock legends to resolve.
+  const stockIssuance = (overrides: Record<string, unknown> = {}) => ({
+    id: "si1",
+    security_id: "s-sec1",
+    stakeholder_id: "sh1",
+    stock_class_id: "sc1",
+    stock_legend_ids: [],
+    ...overrides,
+  });
+
   it("records a validated transaction's report entry and leaves findings empty", () => {
     const actor = startSeeded(seededWithStakeholder());
-    actor.send(ev("TX_EQUITY_COMPENSATION_ISSUANCE", { id: "ec1", security_id: "ec-sec1", stakeholder_id: "sh1" }));
+    actor.send(ev("TX_STOCK_ISSUANCE", stockIssuance()));
 
     const snapshot = actor.getSnapshot();
     expect(snapshot.value).toBe("capTable");
     expect(snapshot.context.report).toHaveLength(1);
     expect(snapshot.context.report[0]).toMatchObject({
-      transaction_type: "TX_EQUITY_COMPENSATION_ISSUANCE",
-      transaction_id: "ec1",
+      transaction_type: "TX_STOCK_ISSUANCE",
+      transaction_id: "si1",
       stakeholder_validity: true,
     });
     expect(snapshot.context.findings).toEqual([]);
@@ -386,14 +398,14 @@ describe("legacy validators through the machine", () => {
 
   it("fails an invalid transaction with the report entry serialized in the result and findings still empty", () => {
     const actor = startSeeded(seededWithStakeholder());
-    // No such stakeholder — the equity compensation issuance validator rejects it.
-    actor.send(ev("TX_EQUITY_COMPENSATION_ISSUANCE", { id: "ec1", security_id: "ec-sec1", stakeholder_id: "nobody" }));
+    // No such stakeholder — the stock issuance validator rejects it.
+    actor.send(ev("TX_STOCK_ISSUANCE", stockIssuance({ stakeholder_id: "nobody" })));
 
     const snapshot = actor.getSnapshot();
     expect(snapshot.value).toBe("validationError");
     expect(snapshot.context.report).toHaveLength(1);
     expect(snapshot.context.result).toBe(
-      `The validation of the OCF package for Test Co failed on ec1: ${JSON.stringify(snapshot.context.report[0], null, 2)}`,
+      `The validation of the OCF package for Test Co failed on si1: ${JSON.stringify(snapshot.context.report[0], null, 2)}`,
     );
     expect(snapshot.context.findings).toEqual([]);
   });


### PR DESCRIPTION
Part of #159. Closes #194. Stacked on #204 (`issue-193-warrant-exercise`); the base retargets as the stack merges.

## What this does

Third family migration of the #159 series, in the declarative check form the #198/#193 stack
established: the seven equity compensation validators (issuance, acceptance, retraction,
cancellation, transfer, exercise, release) become `defineValidator` descriptors composing
`CheckObject`s from a new `equity_compensation/checks.ts`, mirroring the warrant and convertible
families module-for-module.

- Each module is a `defineValidator({ transaction, effect, collection?, checks })`; the dual-mode
  `isGuard` flag, the untyped `event`, and hand-written `validate` bodies are gone.
- `equity_compensation/checks.ts` holds the shared `issuanceExists` and `noOtherTransactions`
  checks, mirroring `warrant/checks.ts`. `issuance-exists` matches the live `equityCompensation`
  collection ("outstanding as of the transaction's date") and, on failure, derives a three-cause
  diagnostic from history; it **subsumes the old `date-order` check**, so the family has no separate
  date-order. Offender scans are date-bounded, per the stack's semantics.
- **`release` is one of the "written but never connected" validators #159 calls out.** Its module
  existed but the machine never referenced it (table entry `passthrough`); this PR wires it into the
  active `none` section, so it goes from silently ignored to validated (`issuance-exists`).
- **`exercise` keeps its resulting-security checks as `implemented: false` gaps** — the one
  deliberate divergence from #204, which *implements* them for warrant exercise. The legacy equity
  exercise only ever implemented the incoming-issuance check and documented the rest without coding
  them; the migration rule is to declare a check a gap when the migrated file does not implement it.
  Exercise keeps `effect: "none"` (the asymmetry with warrant exercise, which removes, is preserved).
- A new suite (`tests/equityCompensationValidators.test.ts`) covers the family the way the warrant
  suite does, reusing the shared `tests/helpers.ts`. The legacy-convention exemplar in
  `tests/ocfMachine.test.ts` re-points from the equity issuance to a stock issuance (still legacy),
  continuing the chain from #200.

`TX_EQUITY_COMPENSATION_REPRICING` is the one equity transaction still `passthrough` — no validator
module has been written for it yet. A known gap to author later, not a designed end-state.

## Behavior changes

- For these seven transaction types, findings replace `report` entries. `context.report` no longer
  receives entries for them — the one change the characterization snapshot records (the fixture's
  passing equity issuance no longer writes a report entry).
- **`release` moves from `passthrough` to active** — the machine previously ignored
  `TX_EQUITY_COMPENSATION_RELEASE` entirely; it is now validated. The fixture has no release
  transaction, so the snapshot is unaffected.
- **Fix — the phantom-field existence check in acceptance, retraction, and release.** All three
  legacy modules read their existence check from `context.equity_compensationIssuances`, a field
  that does not exist (the real collection is `equityCompensation`), so any package containing one of
  those transactions would throw at runtime — latent because no fixture exercises them (and release
  was never wired). The shared `issuanceExists` reads `equityCompensation`, so the phantom field is
  gone. New tests cover the paths this makes reachable.
- The scan semantics match the stack, not the legacy code: `issuance-exists` reflects the live
  collection, and offender scans only consider transactions dated on or before the one under
  validation (a future-dated transaction cannot invalidate an earlier one).

## Port fidelity

`equity_compensation/checks.ts` is a module-for-module mirror of `warrant/checks.ts` with the
collection and transaction types swapped; each equity module mirrors its warrant counterpart. The
fixture contains only a passing equity issuance, so the suite — not the fixture — encodes the
intended semantics.

<details>
<summary>Per-module check composition</summary>

| Module | effect / collection | checks |
| --- | --- | --- |
| issuance | `append` / `equityCompensation` | `stakeholder-exists` |
| acceptance | `none` | `issuance-exists`, `no-retraction` |
| retraction | `remove` / `equityCompensation` | `issuance-exists`, `no-acceptance` |
| cancellation | `remove` / `equityCompensation` | `issuance-exists`, `no-other-transactions` |
| transfer | `remove` / `equityCompensation` | `issuance-exists`, `no-other-transactions` *(gap)* |
| release | `none` | `issuance-exists` |
| exercise | `none` | `issuance-exists`, + 5 gaps: `resulting-stock-exists`, `no-other-transactions`, `resulting-stock-dated`, `resulting-stock-stakeholder`, `resulting-quantity-sum` |

Gaps are declared (`implemented: false`) but not run — they contribute no findings and report as
coverage gaps. Every implemented check grades as `error`.

</details>

## Verification

`npm run build` (tsc) and `npm run test:ci` (vitest) are green — 6 files, 212 tests. The
characterization snapshot changes by exactly one entry: the fixture's passing equity issuance no
longer writes a `report` entry (`report: []`); `findings` stays `[]` and nothing else changes.

